### PR TITLE
Better type selection and other cleanup

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -42,6 +42,10 @@ newlines {
   sometimesBeforeColonInMethodReturnType = false
 }
 
+# Chops down ALL method signatures with more than one argument.
+# https://scalameta.org/scalafmt/docs/configuration.html#forcing-config-style
+optIn.configStyleArguments = true
+
 verticalMultiline {
 
   # Chops down ALL method signatures when the line length exceeds `maxColumn` or `arityThreshold`. The default is 100
@@ -71,6 +75,37 @@ rewrite {
     "override", "private", "protected", "implicit", "final", "sealed", "abstract", "lazy"
   ]
 
+  neverInfix.excludeFilters = [
+    # default exclusions
+    until
+    to
+    by
+    eq
+    ne
+    "should.*"
+    "contain.*"
+    "must.*"
+    in
+    ignore
+    be
+    taggedAs
+    thrownBy
+    synchronized
+    have
+    when
+    size
+    only
+    noneOf
+    oneElementOf
+    noElementsOf
+    atLeastOneElementOf
+    atMostOneElementOf
+    allElementsOf
+    inOrderElementsOf
+    theSameElementsAs
+    # non-default exclusions
+    like
+  ]
 }
 
 # Now that Scala 2.13 is the standard for all projects except Spark, let's allow trailing commas.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        # TODO: Use better coverage configs after adding better unit test coverage
+        target: auto
+        threshold: 5%

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExpAlg.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExpAlg.scala
@@ -6,8 +6,10 @@ import com.rallyhealth.vapors.core.data.{NamedLens, Window}
 // TODO: Use CursorAlg style for ADT naming
 sealed trait ExpAlg[T, A]
 
-// TODO: Replace this with more granular algebra OR give a printable name and grammar information to every operation
-final case class ExpFunctor[T, A](apply: T => A) extends ExpAlg[T, A]
+final case class ExpPure[T, A](
+  label: String,
+  always: T => A,
+) extends ExpAlg[T, A]
 
 final case class ExpSelectField[T, U, A](
   selector: NamedLens[T, U],

--- a/core/src/main/scala/com/rallyhealth/vapors/core/data/Bounded.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/data/Bounded.scala
@@ -1,6 +1,6 @@
 package com.rallyhealth.vapors.core.data
 
-import cats.{Functor, Show}
+import cats.Functor
 
 sealed trait Bounded[A]
 

--- a/core/src/main/scala/com/rallyhealth/vapors/core/data/DataPath.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/data/DataPath.scala
@@ -17,6 +17,8 @@ final case class DataPath(nodes: List[DataPath.Node]) extends AnyVal {
     endIdx: Int,
   ): DataPath = slice(startIdx, endIdx)
 
+  def isEmpty: Boolean = nodes.isEmpty
+
   def indexes(at: NonEmptySet[Int]): DataPath = DataPath(nodes ::: IdxSet(BitSet.fromSpecific(at.toSortedSet)) :: Nil)
 
   def slice(
@@ -91,7 +93,7 @@ object DataPath {
       var remaining: List[DataPath.Node] = tail
       head match {
         case MapKey(key) =>
-          buffer.append('[').append(key).append(']')
+          buffer.append("['").append(key).append("']")
         case Field(name) =>
           buffer.append('.').append(name)
         case Head =>

--- a/core/src/main/scala/com/rallyhealth/vapors/core/data/Intersect.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/data/Intersect.scala
@@ -1,0 +1,18 @@
+package com.rallyhealth.vapors.core.data
+
+trait Intersect[A] {
+
+  def intersect(results: Seq[A]): A
+}
+
+object Intersect {
+
+  def apply[A](implicit A: Intersect[A]): Intersect[A] = A
+
+  implicit object boolean extends Intersect[Boolean] {
+    override def intersect(results: Seq[Boolean]): Boolean = results.forall(identity)
+  }
+
+  implicit def set[A]: Intersect[Set[A]] = _.reduce(_ & _)
+
+}

--- a/core/src/main/scala/com/rallyhealth/vapors/core/data/NamedLens.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/data/NamedLens.scala
@@ -53,7 +53,8 @@ case class NamedLens[A, B](
 object NamedLens {
 
   type Id[A] = NamedLens[A, A]
-  def id[A]: NamedLens[A, A] = NamedLens(DataPath(Nil), identity[A])
+  val Id: NamedLens[Any, Any] = NamedLens(DataPath(Nil), identity[Any])
+  def id[A]: NamedLens[A, A] = Id.asInstanceOf[Id[A]]
 
   implicit class Selector[A, B](val lens: NamedLens[A, B]) extends AnyVal {
     def select[C](getter: B => C): NamedLens[A, C] = macro NamedLensMacros.selectImpl[A, B, C]

--- a/core/src/main/scala/com/rallyhealth/vapors/core/data/ResultSet.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/data/ResultSet.scala
@@ -35,22 +35,18 @@ object ResultSet {
     ): ResultSet[A] = x ++ y
   }
 
-  implicit object UnionResults extends Union[ResultSet[Any]] {
-    override def union(results: Seq[ResultSet[Any]]): ResultSet[Any] = {
-      results.reduceLeft[ResultSet[Any]] {
-        case (NoFactsMatch(), b) => b // try the next expression if the first failed
-        case (a, NoFactsMatch()) => a // use the previous expression if the next fails
-        case (a, b) => a ++ b // union all the possible facts (for better quality calculations)
-      }
+  implicit def unionAny[T]: Union[ResultSet[T]] = {
+    _.reduceLeft[ResultSet[T]] {
+      case (NoFactsMatch(), b) => b // try the next expression if the first failed
+      case (a, NoFactsMatch()) => a // use the previous expression if the next fails
+      case (a, b) => a ++ b // union all the possible facts (for better quality calculations)
     }
   }
 
-  implicit object IntersectResults extends Intersect[ResultSet[Any]] {
-    override def intersect(results: Seq[ResultSet[Any]]): ResultSet[Any] = {
-      results.reduceLeft[ResultSet[Any]] {
-        case (NoFactsMatch(), _) | (_, NoFactsMatch()) => NoFactsMatch() // skip the all expressions if the first failed
-        case (acc, nextResult) => acc ++ nextResult // union all the required facts
-      }
+  implicit def intersectAny[T]: Intersect[ResultSet[T]] = {
+    _.reduceLeft[ResultSet[T]] {
+      case (NoFactsMatch(), _) | (_, NoFactsMatch()) => NoFactsMatch() // skip the all expressions if the first failed
+      case (acc, nextResult) => acc ++ nextResult // union all the required facts
     }
   }
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/data/Union.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/data/Union.scala
@@ -1,0 +1,17 @@
+package com.rallyhealth.vapors.core.data
+
+trait Union[A] {
+
+  def union(results: Seq[A]): A
+}
+
+object Union {
+
+  def apply[A](implicit A: Union[A]): Union[A] = A
+
+  implicit object boolean extends Union[Boolean] {
+    override def union(results: Seq[Boolean]): Boolean = results.exists(identity)
+  }
+
+  implicit def set[A]: Intersect[Set[A]] = _.reduce(_ | _)
+}

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl.scala
@@ -16,8 +16,6 @@ object dsl {
     */
   final val __ = this
 
-  // TODO: Make these things more generic to things that are not Facts using typeclasses
-
   /**
     * The root of all expression types.
     *
@@ -54,6 +52,8 @@ object dsl {
     */
   type Facts[T] = NonEmptyList[Fact[T]]
 
+  type TerminalExp[T, V] = AnyExp[V, ResultSet[T]]
+
   /**
     * An expression that operates on a non-empty list of facts.
     *
@@ -66,16 +66,16 @@ object dsl {
     * An expression that returns a [[ResultSet]] so that it can be evaluated by
     * the [[evaluator.evalQuery]] method.
     */
-  type TerminalFactExp[T] = FactsExp[T, ResultSet[T]]
+  type TerminalFactsExp[T] = FactsExp[T, ResultSet[T]]
 
-  /** @see [[TerminalFactExp]] */
-  private def liftTerminal[T](value: ExpAlg[Facts[T], ResultSet[T]]): TerminalFactExp[T] = FreeApplicative.lift(value)
+  /** @see [[TerminalFactsExp]] */
+  private def liftTermExp[T](value: ExpAlg[Facts[T], ResultSet[T]]): TerminalFactsExp[T] = FreeApplicative.lift(value)
 
   /** @see [[FactsExp]] */
   private def liftFactsExp[T, A](value: ExpAlg[Facts[T], A]): FactsExp[T, A] = FreeApplicative.lift(value)
 
   /** @see [[CondExp]] */
-  private def liftPredExp[X](value: ExpAlg[X, Boolean]): CondExp[X] = FreeApplicative.lift(value)
+  private def liftCondExp[X](value: ExpAlg[X, Boolean]): CondExp[X] = FreeApplicative.lift(value)
 
   /** @see [[AnyExp]] */
   private def liftAnyExp[X, A](value: ExpAlg[X, A]): AnyExp[X, A] = FreeApplicative.lift(value)
@@ -91,15 +91,15 @@ object dsl {
   // TODO: Move Query stuff to another file
 
   /**
-    * New type wrapper for a [[TerminalFactExp]] for a given type.
+    * New type wrapper for a [[TerminalFactsExp]] for a given type.
     *
     * @note you should call [[query]], [[queryAny]], or [[queryOf]] to get one.
     */
   // TODO: Should this even be parameterized? Operating over List[Fact[Any]] might be worth committing to
-  final case class Query[T](expression: TerminalFactExp[T])
+  final case class Query[T](expression: TerminalFactsExp[T])
 
   // TODO: This should probably become the new norm and just implement a better filter / compiler error messages
-  def queryAny(exp: TerminalFactExp[Any]): Query[Any] = queryOf(exp)
+  def queryAny(exp: TerminalFactsExp[Any]): Query[Any] = queryOf(exp)
 
   /**
     * Builds a query that can handle any type of input by filtering the facts down the type expected by
@@ -119,10 +119,10 @@ object dsl {
     "0.0.1",
   )
   // TODO: This is too useful to remove without having the unified condition builder
-  def query[U : ClassTag : TypeTag](exp: TerminalFactExp[U]): Query[Any] = {
+  def query[U : ClassTag : TypeTag](exp: TerminalFactsExp[U]): Query[Any] = {
     val uType = typeOf[U]
     if (uType =:= typeOf[Any]) {
-      Query(exp.asInstanceOf[TerminalFactExp[Any]])
+      Query(exp.asInstanceOf[TerminalFactsExp[Any]])
     } else {
       Query(
         liftFactsExp(
@@ -143,69 +143,41 @@ object dsl {
     }
   }
 
-  def queryOf[U](exp: TerminalFactExp[U]): Query[U] = Query(exp)
+  def queryOf[U](exp: TerminalFactsExp[U]): Query[U] = Query(exp)
 
-  def hasValue[T](expected: T): TerminalFactExp[T] = liftFactsExp {
+  @deprecated("Select the fact type first before comparing equality.", "0.0.1")
+  def hasValue[T](expected: T): TerminalFactsExp[T] = liftFactsExp {
     ExpFunctor[Facts[T], ResultSet[T]](facts => ResultSet.fromList(facts.filter(_.value == expected)))
   }
 
   @deprecated("Convert this into serializable expressions over facts.", "0.0.1")
-  def filter[T](predicate: Fact[T] => Boolean): TerminalFactExp[T] = liftFactsExp {
+  def filter[T](predicate: Fact[T] => Boolean): TerminalFactsExp[T] = liftFactsExp {
     ExpFunctor[Facts[T], ResultSet[T]](facts => ResultSet.fromList(facts.filter(predicate)))
   }
 
-  def whereAnyFactHas[T](exp: AnyExp[Fact[T], Boolean]): TerminalFactExp[T] = liftTerminal {
-    ExpExists[Facts[T], Fact[T], ResultSet[T]](_.toList, exp, Matched, Empty)
-  }
-
-  def whereAllFactsHave[T](exp: AnyExp[Fact[T], Boolean]): TerminalFactExp[T] = liftTerminal {
-    ExpForAll[Facts[T], Fact[T], ResultSet[T]](_.toList, exp, Matched, Empty)
-  }
-
-  def factTypeOf[T >: U, U : ClassTag : TypeTag](factType: FactType[U]): CondExpBuilder[T, U] = {
-    factTypeIn[T, U](FactTypeSet.of(factType))
-  }
-
-  def factTypeIn[T >: U, U : ClassTag : TypeTag](factTypeSet: FactTypeSet[U]): CondExpBuilder[T, U] = {
-    new CondExpBuilder[T, U]({ exp: CondExp[Fact[U]] =>
-      liftAnyExp {
-        ExpCollect[Fact[T], Fact[U], Boolean](
-          typeOf[U].toString,
-          fact => factTypeSet.matchAs(fact),
-          exp,
-          _ => false,
-        )
-      }
-    })
-  }
-
-  def factValue[T](exp: CondExp[T]): CondExp[Fact[T]] = liftAnyExp {
-    ExpSelectField[Fact[T], T, Boolean](Fact.value, exp)
-  }
-
   // TODO: Use some cats typeclass instead of iterable?
-  def all[F[x] <: IterableOnce[x], T, A](cond: CondExp[T]): CondExp[F[T]] = liftPredExp {
+  def all[F[x] <: IterableOnce[x], T, A](cond: CondExp[T]): CondExp[F[T]] = liftCondExp {
     ExpForAll[F[T], T, Boolean](identity[F[T]], cond, True, False)
   }
 
   // TODO: Use some cats typeclass instead of iterable?
-  def exists[F[x] <: IterableOnce[x], T, A](cond: CondExp[T]): CondExp[F[T]] = liftPredExp {
+  def exists[F[x] <: IterableOnce[x], T, A](cond: CondExp[T]): CondExp[F[T]] = liftCondExp {
     ExpExists[F[T], T, Boolean](identity[F[T]], cond, True, False)
   }
 
-  def lessThan[T : Ordering](upperBound: T): CondExp[T] = liftPredExp {
+  def lessThan[T : Ordering](upperBound: T): CondExp[T] = liftCondExp {
     ExpWithin[T, Boolean](Window.lessThan(upperBound), True, False)
   }
 
-  def lessThanOrEqual[T : Ordering](upperBound: T): CondExp[T] = liftPredExp {
+  def lessThanOrEqual[T : Ordering](upperBound: T): CondExp[T] = liftCondExp {
     ExpWithin[T, Boolean](Window.lessThanOrEqual(upperBound), True, False)
   }
 
-  def greaterThan[T : Ordering](lowerBound: T): CondExp[T] = liftPredExp {
+  def greaterThan[T : Ordering](lowerBound: T): CondExp[T] = liftCondExp {
     ExpWithin[T, Boolean](Window.greaterThan(lowerBound), True, False)
   }
 
-  def greaterThanOrEqual[T : Ordering](lowerBound: T): CondExp[T] = liftPredExp {
+  def greaterThanOrEqual[T : Ordering](lowerBound: T): CondExp[T] = liftCondExp {
     ExpWithin[T, Boolean](Window.greaterThanOrEqual(lowerBound), True, False)
   }
 
@@ -220,90 +192,104 @@ object dsl {
     ExpCond[T, A](exp, thenExp, elseExp)
   }
 
-  def withFactsOfType[T >: U, U : ClassTag : TypeTag](
-    factType: FactType[U],
-  )(
-    exp: FactsExp[U, ResultSet[T]],
-  ): TerminalFactExp[Any] = {
-    withFactsOfTypeIn[T, U](FactTypeSet.of(factType))(exp)
+  def withFactsOfType[U : ClassTag : TypeTag](factType: FactType[U]): TypedFactExpBuilder[Any, U] = {
+    withFactsOfTypeIn[Any, U](FactTypeSet.of(factType))
   }
 
-  def withFactsOfTypeIn[T >: U, U : ClassTag : TypeTag](
+  def withFactsOfTypeIn[T >: U, U : ClassTag : TypeTag](factTypeSet: FactTypeSet[U]): TypedFactExpBuilder[T, U] = {
+    new TypedFactExpBuilder[T, U](factTypeSet)
+  }
+
+  def and[T, A : Intersect](
+    one: AnyExp[T, A],
+    two: AnyExp[T, A],
+    others: AnyExp[T, A]*,
+  ): AnyExp[T, A] = liftAnyExp {
+    ExpAnd[T, A](
+      Intersect[A].intersect,
+      one :: two :: others.toList,
+    )
+  }
+
+  def or[T, A : Union](
+    one: AnyExp[T, A],
+    two: AnyExp[T, A],
+    others: AnyExp[T, A]*,
+  ): AnyExp[T, A] = liftAnyExp {
+    ExpOr[T, A](
+      Union[A].union,
+      one :: two :: others.toList,
+    )
+  }
+
+  def typeNameOf[T : TypeTag]: String = typeOf[T].toString.split('.').dropWhile(_.charAt(0).isLower).mkString(".")
+
+  final class FactValuesExpBuilder[T >: U, U : ClassTag : TypeTag, V] private[dsl] (
     factTypeSet: FactTypeSet[U],
-  )(
-    exp: FactsExp[U, ResultSet[T]],
-  ): TerminalFactExp[Any] = liftFactsExp {
-    // TODO: Figure out if there any disadvantages to using Any here
-    //       If there are, we need to figure out why we get compiler errors when using type T
-    ExpCollect[Facts[Any], Facts[U], ResultSet[Any]](
-      typeOf[U].toString,
-      facts => NonEmptyList.fromList(facts.collect(factTypeSet.matchAsPartial[U])),
-      exp.map(identity),
-      _ => NoFactsMatch(),
-    )
-  }
+    factLens: NamedLens[Fact[U], V],
+  ) {
 
-  // TODO: Figure out how to expand this to non-terminal expressions
-  def and[T](
-    one: TerminalFactExp[T],
-    two: TerminalFactExp[T],
-    others: TerminalFactExp[T]*,
-  ): TerminalFactExp[T] = liftFactsExp {
-    ExpAnd[Facts[T], ResultSet[T]](
-      _.reduceLeft[ResultSet[T]]({
-        case (NoFactsMatch(), _) | (_, NoFactsMatch()) => NoFactsMatch() // skip the all expressions if the first failed
-        case (acc: FactsMatch[T], nextResult: FactsMatch[T]) => acc ++ nextResult // combine all the required facts
-      }),
-      one :: two :: others.toList,
-    )
-  }
+    private def selectFactValuesWhere(exp: ExpAlg[Facts[U], ResultSet[T]]): TerminalFactsExp[T] = {
+      liftTermExp {
+        ExpCollect[Facts[T], Facts[U], ResultSet[T]](
+          s"Fact[${typeNameOf[U]}]",
+          facts => NonEmptyList.fromList(facts.collect(factTypeSet.matchAsPartial[U])),
+          liftFactsExp(exp),
+          Empty,
+        )
+      }
+    }
 
-  // TODO: Figure out how to expand this to non-terminal expressions
-  def or[T](
-    one: TerminalFactExp[T],
-    two: TerminalFactExp[T],
-    others: TerminalFactExp[T]*,
-  ): TerminalFactExp[T] = liftFactsExp {
-    ExpOr[Facts[T], ResultSet[T]](
-      s =>
-        s.reduceLeft[ResultSet[T]]({
-          case (NoFactsMatch(), b) => b // try the next expression if the first failed
-          case (a @ FactsMatch(_), _) => a // take the first required set of facts
-        }),
-      one :: two :: others.toList,
-    )
-  }
+    def whereAllValues(condExp: CondExp[V]): TerminalFactsExp[T] = {
+      selectFactValuesWhere {
+        ExpForAll[Facts[U], Fact[U], ResultSet[T]](
+          _.toList,
+          liftCondExp {
+            ExpSelectField[Fact[U], V, Boolean](factLens, condExp)
+          },
+          Matched,
+          Empty,
+        )
+      }
+    }
 
-  /**
-    * A conditional expression builder that captures the type parameters of the expected input and output,
-    * but allows freedom in sub-selecting fields without messing up type inference.
-    */
-  // TODO: Unify the notion of a conditional expression on a single fact with the condition-like syntax
-  //       of operating over lists of facts using filters.
-  final class CondExpBuilder[T, U] private[dsl] (condBuilder: CondExp[Fact[U]] => CondExp[Fact[T]]) {
-
-    /**
-      * Create a conditional expression for a fact from a field on the [[Fact]] itself.
-      *
-      * @note if you plan to create a lens into the value (or compare the value directly), you might want to use
-      *        the [[whereValueAt]] (or [[whereValue]]) method instead.
-      */
-    def where(exp: CondExp[Fact[U]]): CondExp[Fact[T]] = condBuilder(exp)
-
-    /**
-      * Create a conditional expression for a fact based on the given conditional expression over the [[Fact.value]].
-      */
-    def whereValue(exp: CondExp[U]): CondExp[Fact[T]] = whereValueAt(identity[NamedLens.Id[U]])(exp)
-
-    /**
-      * Create a conditional expression for a fact based on the given conditional expression over any [[NamedLens]]
-      * that starts from the [[Fact.value]].
-      */
-    def whereValueAt[V](lens: NamedLens.Id[U] => NamedLens[U, V])(exp: CondExp[V]): CondExp[Fact[T]] = {
-      val namedLens = lens(NamedLens.id[U])
-      condBuilder(liftAnyExp {
-        ExpSelectField[Fact[U], V, Boolean](Fact.value[U].andThen(namedLens), exp)
-      })
+    def whereAnyValue(condExp: CondExp[V]): TerminalFactsExp[T] = {
+      selectFactValuesWhere {
+        ExpExists[Facts[U], Fact[U], ResultSet[T]](
+          _.toList,
+          liftCondExp {
+            ExpSelectField[Fact[U], V, Boolean](factLens, condExp)
+          },
+          Matched,
+          Empty,
+        )
+      }
     }
   }
+
+  final class TypedFactExpBuilder[T >: U, U : ClassTag : TypeTag] private[dsl] (factTypeSet: FactTypeSet[U]) {
+
+    // TODO: These terminal expression methods can be optimized to avoid an unnecessary select expression
+
+    def whereAnyFact(condExp: CondExp[Fact[U]]): TerminalFactsExp[T] = {
+      new FactValuesExpBuilder[T, U, Fact[U]](factTypeSet, NamedLens.id[Fact[U]]).whereAnyValue(condExp)
+    }
+
+    def whereAnyValue(condExp: CondExp[U]): TerminalFactsExp[T] = {
+      new FactValuesExpBuilder[T, U, U](factTypeSet, Fact.value[U]).whereAnyValue(condExp)
+    }
+
+    def whereAllFacts(condExp: CondExp[Fact[U]]): TerminalFactsExp[T] = {
+      new FactValuesExpBuilder[T, U, Fact[U]](factTypeSet, NamedLens.id[Fact[U]]).whereAllValues(condExp)
+    }
+
+    def whereAllValues(condExp: CondExp[U]): TerminalFactsExp[T] = {
+      new FactValuesExpBuilder[T, U, U](factTypeSet, Fact.value[U]).whereAllValues(condExp)
+    }
+
+    def withValuesAt[V](lens: NamedLens.Id[U] => NamedLens[U, V]): FactValuesExpBuilder[T, U, V] = {
+      new FactValuesExpBuilder(factTypeSet, Fact.value[U].andThen(lens(NamedLens.id[U])))
+    }
+  }
+
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/evaluator/EvalLoop.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/evaluator/EvalLoop.scala
@@ -17,8 +17,8 @@ private[evaluator] final class EvalLoop[T] extends (ExpAlg[T, *] ~> (T => *)) {
     exp: ExpAlg[T, B],
     data: T,
   ): B = exp match {
-    case ExpFunctor(map) =>
-      map(data)
+    case ExpPure(_, value) =>
+      value(data)
     case ExpSelectField(selector, expression) =>
       evalLoop(expression)(selector.get(data))
     case ExpExists(toIterable, condition, whenTrue, whenFalse) =>

--- a/core/src/main/scala/com/rallyhealth/vapors/core/evaluator/package.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/evaluator/package.scala
@@ -1,19 +1,11 @@
 package com.rallyhealth.vapors.core
 
-import cats.data.NonEmptyList
-import com.rallyhealth.vapors.core.data.{Fact, ResultSet}
-
 package object evaluator {
   import cats.instances.function._
   import dsl._
 
-  def eval[T, A](facts: Seq[Fact[T]])(exp: FactsExp[T, A]): Option[A] = {
-    NonEmptyList.fromList(facts.toList).map { matchingFacts =>
-      exp.foldMap(new EvalLoop[NonEmptyList[Fact[T]]]).apply(matchingFacts)
-    }
+  def eval[T, A](input: T)(exp: AnyExp[T, A]): A = {
+    exp.foldMap(new EvalLoop[T]).apply(input)
   }
 
-  def evalQuery[R](facts: Seq[Fact[R]])(query: Query[R]): Option[ResultSet[R]] = {
-    eval(facts)(query.expression)
-  }
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/fql/Printer.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/fql/Printer.scala
@@ -29,7 +29,7 @@ object Printer {
       import cats.syntax.show._
       implicit val showAnyFromToString: Show[Any] = Show.fromToString
       fa match {
-        case ExpFunctor(_) => "<functor>" :: Nil
+        case ExpPure(label, _) => "<" :: label :: ">" :: Nil
         case ExpSelectField(selector, sub) => selector.path.show :: " " :: sub.foldMap(this)
         case ExpForAll(_, sub, _, _) => ".forall(_" :: sub.foldMap(this) ::: ")" :: Nil
         case ExpExists(_, sub, _, _) => ".exists(_" :: sub.foldMap(this) ::: ")" :: Nil

--- a/core/src/main/scala/com/rallyhealth/vapors/core/fql/Printer.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/fql/Printer.scala
@@ -10,7 +10,7 @@ class Printer {
 
   def serialize[T, A](exp: AnyExp[T, A]): String = {
     val parts = exp.foldMap(ImmutablePrinter())(ApplicablePrinterF)
-    parts.mkString
+    ("_" :: parts).mkString
   }
 }
 
@@ -30,22 +30,24 @@ object Printer {
       implicit val showAnyFromToString: Show[Any] = Show.fromToString
       fa match {
         case ExpFunctor(_) => "<functor>" :: Nil
-        case ExpSelectField(selector, sub) => "_" :: selector.path.show :: " " :: sub.foldMap(this)
-        case ExpForAll(_, sub, _, _) => "forall (" :: sub.foldMap(this) ::: ")" :: Nil
-        case ExpExists(_, sub, _, _) => "exists (" :: sub.foldMap(this) ::: ")" :: Nil
-        case ExpWithin(window: BoundedWindow[Any], _, _) => "where " :: window.show :: ")" :: Nil
-        case ExpWithin(window, _, _) => "within (" :: window.toString :: ")" :: Nil
+        case ExpSelectField(selector, sub) => selector.path.show :: " " :: sub.foldMap(this)
+        case ExpForAll(_, sub, _, _) => ".forall(_" :: sub.foldMap(this) ::: ")" :: Nil
+        case ExpExists(_, sub, _, _) => ".exists(_" :: sub.foldMap(this) ::: ")" :: Nil
+        case ExpWithin(window: BoundedWindow[Any], _, _) => "where " :: window.show :: Nil
+        case ExpWithin(window, _, _) => "within(" :: window.toString :: ")" :: Nil
         case ExpCollect(subtypeName, _, sub, _) =>
-          "match { case " :: subtypeName :: " => " :: sub.foldMap(this) ::: " }" :: Nil
+          ".collect { case f: " :: subtypeName :: " => f" :: sub.foldMap(this) ::: " }" :: Nil
         case ExpCond(condExp, thenExp, elseExp) =>
           "if " :: condExp.foldMap(this) ::: " then " :: thenExp.foldMap(this) ::: " else " :: elseExp.foldMap(this)
         case ExpAnd(_, subs) =>
           subs.map(_.foldMap(this)).foldLeft[List[String]](Nil) {
-            case (acc, next) => "(" :: acc ::: ") and (" :: next ::: ")" :: Nil
+            case (Nil, next) => next
+            case (acc, next) => acc ::: " and " :: next
           }
         case ExpOr(_, subs) =>
           subs.map(_.foldMap(this)).foldLeft[List[String]](Nil) {
-            case (acc, next) => "(" :: acc ::: ") or (" :: next ::: ")" :: Nil
+            case (Nil, next) => next
+            case (acc, next) => acc ::: " or " :: next
           }
       }
     }

--- a/core/src/test/scala/com/rallyhealth/vapors/core/fql/PrinterSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/fql/PrinterSpec.scala
@@ -12,35 +12,37 @@ class PrinterSpec extends AnyWordSpec {
   "Printer.serialize" should {
 
     "print an expression that selects a specific fact type using whereValue(_ > 30)" in {
-      val q = queryAny {
+      val q = {
         __.withFactsOfType(FactTypes.age)
           .whereAnyValue(__ > 30)
       }
-      val results = evalQuery(JoeSchmoe.facts.toList)(q)
-      assertResult(Some(FactsMatch(NonEmptyList.of(JoeSchmoe.age))))(results)
+      assertResult(FactsMatch(NonEmptyList.of(JoeSchmoe.age))) {
+        eval(JoeSchmoe.facts)(q)
+      }
       assertResult(
         "_.collect { case f: Fact[Int] => f.exists(_.value where x > 30) }",
       ) {
-        printer.serialize(q.expression)
+        printer.serialize(q)
       }
     }
 
     "print an expression that selects a fact type using where(factValue(_ > 200))" in {
-      val q = queryAny {
+      val q = {
         __.withFactsOfType(FactTypes.weight)
           .whereAnyValue(__ > 200)
       }
-      val results = evalQuery(JoeSchmoe.facts.toList)(q)
-      assertResult(Some(FactsMatch(NonEmptyList.of(JoeSchmoe.weight))))(results)
+      assertResult(FactsMatch(NonEmptyList.of(JoeSchmoe.weight))) {
+        eval(JoeSchmoe.facts)(q)
+      }
       assertResult(
         "_.collect { case f: Fact[Int] => f.exists(_.value where x > 200) }",
       ) {
-        printer.serialize(q.expression)
+        printer.serialize(q)
       }
     }
 
     "print an expression that selects a value using the NamedLens select" in {
-      val q = queryAny {
+      val q = {
         __.withFactsOfType(FactTypes.probs)
           .withValuesAt(_.select(_.scores).atKey("weightloss"))
           .whereAnyValue(
@@ -50,8 +52,9 @@ class PrinterSpec extends AnyWordSpec {
             ),
           )
       }
-      val results = evalQuery(JoeSchmoe.facts.toList)(q)
-      assertResult(Some(FactsMatch(NonEmptyList.of(JoeSchmoe.probs))))(results)
+      assertResult(FactsMatch(NonEmptyList.of(JoeSchmoe.probs))) {
+        eval(JoeSchmoe.facts)(q)
+      }
       assertResult(
         // TODO: This query looks wrong...
         //       there is a mismatch between how value selection works within .exists() and conditional expressions
@@ -59,7 +62,7 @@ class PrinterSpec extends AnyWordSpec {
           " case f: Fact[Example.Probs] =>" +
           " f.exists(_.value.scores['weightloss'] .exists(_where x > 0.5) or .exists(_where x < 0.3)) }",
       ) {
-        printer.serialize(q.expression)
+        printer.serialize(q)
       }
     }
   }

--- a/core/src/test/scala/com/rallyhealth/vapors/core/fql/PrinterSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/fql/PrinterSpec.scala
@@ -13,17 +13,13 @@ class PrinterSpec extends AnyWordSpec {
 
     "print an expression that selects a specific fact type using whereValue(_ > 30)" in {
       val q = queryAny {
-        __.withFactsOfType(FactTypes.age) {
-          __.whereAnyFactHas {
-            __.factTypeOf(FactTypes.age).whereValue(__ > 30)
-          }
-        }
+        __.withFactsOfType(FactTypes.age)
+          .whereAnyValue(__ > 30)
       }
       val results = evalQuery(JoeSchmoe.facts.toList)(q)
       assertResult(Some(FactsMatch(NonEmptyList.of(JoeSchmoe.age))))(results)
       assertResult(
-        // TODO: This query is overly redundant, we should not need to match on the type twice
-        "match { case Int => exists (match { case Int => _.value where x > 30) }) }",
+        "_.collect { case f: Fact[Int] => f.exists(_.value where x > 30) }",
       ) {
         printer.serialize(q.expression)
       }
@@ -31,17 +27,13 @@ class PrinterSpec extends AnyWordSpec {
 
     "print an expression that selects a fact type using where(factValue(_ > 200))" in {
       val q = queryAny {
-        __.withFactsOfType(FactTypes.weight) {
-          __.whereAnyFactHas {
-            __.factTypeOf(FactTypes.weight).where(__.factValue(__ > 200))
-          }
-        }
+        __.withFactsOfType(FactTypes.weight)
+          .whereAnyValue(__ > 200)
       }
       val results = evalQuery(JoeSchmoe.facts.toList)(q)
       assertResult(Some(FactsMatch(NonEmptyList.of(JoeSchmoe.weight))))(results)
       assertResult(
-        // TODO: This query is overly redundant, we should not need to match on the type twice
-        "match { case Int => exists (match { case Int => _.value where x > 200) }) }",
+        "_.collect { case f: Fact[Int] => f.exists(_.value where x > 200) }",
       ) {
         printer.serialize(q.expression)
       }
@@ -49,23 +41,23 @@ class PrinterSpec extends AnyWordSpec {
 
     "print an expression that selects a value using the NamedLens select" in {
       val q = queryAny {
-        __.withFactsOfType(FactTypes.probs) {
-          __.whereAnyFactHas {
-            __.factTypeOf(FactTypes.probs).whereValueAt(_.select(_.scores).atKey("weightloss")) {
-              __.exists(__ > 0.5)
-            }
-          }
-        }
+        __.withFactsOfType(FactTypes.probs)
+          .withValuesAt(_.select(_.scores).atKey("weightloss"))
+          .whereAnyValue(
+            __.or(
+              __.exists(__ > 0.5),
+              __.exists(__ < 0.3),
+            ),
+          )
       }
       val results = evalQuery(JoeSchmoe.facts.toList)(q)
       assertResult(Some(FactsMatch(NonEmptyList.of(JoeSchmoe.probs))))(results)
       assertResult(
-        // TODO: This query is overly redundant, we should not need to match on the type twice
-        "match {" +
-          " case com.rallyhealth.vapors.core.Example.Probs => exists (match {" +
-          " case com.rallyhealth.vapors.core.Example.Probs => _.value.scores[weightloss] exists (where x > 0.5))" +
-          " })" +
-          " }",
+        // TODO: This query looks wrong...
+        //       there is a mismatch between how value selection works within .exists() and conditional expressions
+        "_.collect {" +
+          " case f: Fact[Example.Probs] =>" +
+          " f.exists(_.value.scores['weightloss'] .exists(_where x > 0.5) or .exists(_where x < 0.3)) }",
       ) {
         printer.serialize(q.expression)
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,11 +22,6 @@ object Dependencies {
     }
   }
 
-  final object Resolvers {
-
-    val danslapman: Resolver = Resolver.bintrayRepo("danslapman", "maven")
-  }
-
   final object CoreProject {
 
     def all(scalaVersion: String): Seq[ModuleID] =


### PR DESCRIPTION
- Use type selection builder at the top-level to avoid deprecated query
- Add Intersect and Union typeclasses for better or() / and() interface
- Define proper union typeclass for ResultSet
- Remove Query class and related methods
- Remove hasValue and filter dsl methods
- Replace ExpFunctor with the labeled ExpPure
- Allow use of infix "like" method for scalatest