### PR TITLE
Move factfilter code out of core package

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/factfilter/package.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/factfilter/package.scala
@@ -1,3 +1,0 @@
-package com.rallyhealth.vapors.core.dsl
-
-package object factfilter extends Dsl

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/package.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/package.scala
@@ -1,3 +1,0 @@
-package com.rallyhealth.vapors.core
-
-package object dsl extends factfilter.Dsl

--- a/core/src/main/scala/com/rallyhealth/vapors/core/evaluator/EvalLoop.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/evaluator/EvalLoop.scala
@@ -3,7 +3,7 @@ package com.rallyhealth.vapors.core.evaluator
 import cats.instances.function._
 import cats.~>
 import com.rallyhealth.vapors.core.algebra._
-import com.rallyhealth.vapors.core.dsl.Exp
+import com.rallyhealth.vapors.factfilter.dsl.Exp
 
 private[evaluator] final class EvalLoop[T] extends (ExpAlg[T, *] ~> (T => *)) {
 

--- a/core/src/main/scala/com/rallyhealth/vapors/core/evaluator/package.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/evaluator/package.scala
@@ -1,10 +1,12 @@
 package com.rallyhealth.vapors.core
 
+import cats.free.FreeApplicative
+import com.rallyhealth.vapors.core.algebra.ExpAlg
+
 package object evaluator {
   import cats.instances.function._
-  import dsl._
 
-  def eval[T, A](input: T)(exp: Exp[T, A]): A = {
+  def eval[T, A](input: T)(exp: FreeApplicative[ExpAlg[T, *], A]): A = {
     exp.foldMap(new EvalLoop[T]).apply(input)
   }
 

--- a/core/src/main/scala/com/rallyhealth/vapors/core/fql/Printer.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/fql/Printer.scala
@@ -3,7 +3,7 @@ package com.rallyhealth.vapors.core.fql
 import cats.{~>, Applicative, Show}
 import com.rallyhealth.vapors.core.algebra._
 import com.rallyhealth.vapors.core.data.BoundedWindow
-import com.rallyhealth.vapors.core.dsl.Exp
+import com.rallyhealth.vapors.factfilter.dsl.Exp
 
 class Printer {
   import Printer._

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/Fact.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/Fact.scala
@@ -1,4 +1,6 @@
-package com.rallyhealth.vapors.core.data
+package com.rallyhealth.vapors.factfilter.data
+
+import com.rallyhealth.vapors.core.data.{DataPath, NamedLens}
 
 sealed abstract class Fact {
   type Value

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/FactType.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/FactType.scala
@@ -1,6 +1,7 @@
-package com.rallyhealth.vapors.core.data
+package com.rallyhealth.vapors.factfilter.data
 
 import cats.Order
+import com.rallyhealth.vapors.core.data.NamedLens
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/FactTypeSet.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/FactTypeSet.scala
@@ -1,4 +1,4 @@
-package com.rallyhealth.vapors.core.data
+package com.rallyhealth.vapors.factfilter.data
 
 import cats.data.{NonEmptyList, NonEmptyMap, NonEmptySet}
 

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/ResultSet.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/ResultSet.scala
@@ -1,7 +1,6 @@
-package com.rallyhealth.vapors.core.data
+package com.rallyhealth.vapors.factfilter.data
 
 import cats.data.NonEmptyList
-import com.rallyhealth.vapors.core.dsl.{Facts, FactsOfType}
 import com.rallyhealth.vapors.core.logic.{Intersect, Union}
 
 sealed abstract class ResultSet extends Equals {

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/package.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/package.scala
@@ -1,0 +1,29 @@
+package com.rallyhealth.vapors.factfilter
+
+import cats.data.NonEmptyList
+import com.rallyhealth.vapors.core.data.NamedLens
+
+package object data {
+
+  /**
+    * Alias for a collection of facts with no restriction on Scala type.
+    *
+    * @note This is the input for a top-level fact filter expression.
+    */
+  final type Facts = NonEmptyList[Fact]
+
+  /**
+    * A [[NamedLens]] defined over a [[TypedFact]] of a known type.
+    */
+  final type FactLens[T, V] = NamedLens[TypedFact[T], V]
+
+  /**
+    * A useful alias for building a [[NamedLens]] by passing the identity lens as a starting point to a function.
+    */
+  final type FactLensId[T] = NamedLens.Id[TypedFact[T]]
+
+  /**
+    * Alias for a collection of facts of a specific type.
+    */
+  final type FactsOfType[T] = NonEmptyList[TypedFact[T]]
+}

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/Dsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/Dsl.scala
@@ -1,16 +1,15 @@
-package com.rallyhealth.vapors.core.dsl.factfilter
+package com.rallyhealth.vapors.factfilter.dsl
 
 import cats.free.FreeApplicative
+import com.rallyhealth.vapors.core.algebra.ExpAlg
+import com.rallyhealth.vapors.core.data.Window
 import com.rallyhealth.vapors.core.logic.{Intersect, Union}
-import com.rallyhealth.vapors.core.{algebra, data}
+import com.rallyhealth.vapors.factfilter.data._
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
-private[dsl] class Dsl extends Evaluation with Types with Syntax {
-
-  import algebra._
-  import data._
+private[dsl] class Dsl {
 
   // TODO: Use some cats typeclass instead of iterable?
   def all[F[x] <: IterableOnce[x], T, A](cond: CondExp[T]): CondExp[F[T]] = liftCondExp {

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/Evaluation.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/Evaluation.scala
@@ -1,9 +1,9 @@
-package com.rallyhealth.vapors.core.dsl.factfilter
+package com.rallyhealth.vapors.factfilter.dsl
 
-import com.rallyhealth.vapors.core.data.{NoFactsMatch, ResultSet}
+import com.rallyhealth.vapors.factfilter.data.{Facts, ResultSet}
 import com.rallyhealth.vapors.core.evaluator
 
-private[dsl] trait Evaluation extends Types {
+private[dsl] trait Evaluation {
 
   /**
     * The core logic of this DSL operates on an [[TerminalFactsExp]] query to produce a function that
@@ -11,7 +11,7 @@ private[dsl] trait Evaluation extends Types {
     * the given expression, and wraps them up in an [[ResultSet]].
     *
     * @param facts the non-empty list of facts on which to operate
-    * @param query the FreeApplicative query that will be passed to the [[evaluator]]
+    * @param query the FreeApplicative query that will be passed to the [[com.rallyhealth.vapors.core.evaluator]]
     * @return an [[ResultSet]] that contains either the facts that satisfy the expression or [[NoFactsMatch]]
     */
   def evalWithFacts(facts: Facts)(query: TerminalFactsExp): ResultSet = {

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/Facts.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/Facts.scala
@@ -1,0 +1,12 @@
+package com.rallyhealth.vapors.factfilter.dsl
+
+import cats.data.NonEmptyList
+import com.rallyhealth.vapors.factfilter.data.{Fact, Facts}
+
+object Facts {
+
+  def apply(
+    head: Fact,
+    tail: Fact*,
+  ): Facts = NonEmptyList.of(head, tail: _*)
+}

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/LogicalOps.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/LogicalOps.scala
@@ -1,6 +1,5 @@
-package com.rallyhealth.vapors.core.dsl.factfilter
+package com.rallyhealth.vapors.factfilter.dsl
 
-import com.rallyhealth.vapors.core.dsl
 import com.rallyhealth.vapors.core.logic.{Intersect, Union}
 
 final class LogicalOps[T, A](private val exp: Exp[T, A]) extends AnyVal {
@@ -8,20 +7,20 @@ final class LogicalOps[T, A](private val exp: Exp[T, A]) extends AnyVal {
   /**
     * Builds an AND expression using infix notation.
     */
-  def and(o: Exp[T, A])(implicit A: Intersect[A]): Exp[T, A] = dsl.and(exp, o)
+  def and(o: Exp[T, A])(implicit A: Intersect[A]): Exp[T, A] = __.and(exp, o)
 
   /**
     * Same as [[and]] but with higher precedent.
     */
-  def &&(o: Exp[T, A])(implicit A: Intersect[A]): Exp[T, A] = dsl.and(exp, o)
+  def &&(o: Exp[T, A])(implicit A: Intersect[A]): Exp[T, A] = __.and(exp, o)
 
   /**
     * Builds an OR expression using infix notation.
     */
-  def or(o: Exp[T, A])(implicit A: Union[A]): Exp[T, A] = dsl.or(exp, o)
+  def or(o: Exp[T, A])(implicit A: Union[A]): Exp[T, A] = __.or(exp, o)
 
   /**
     * Same as [[or]] but with higher precedent.
     */
-  def ||(o: Exp[T, A])(implicit A: Union[A]): Exp[T, A] = dsl.or(exp, o)
+  def ||(o: Exp[T, A])(implicit A: Union[A]): Exp[T, A] = __.or(exp, o)
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/Syntax.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/Syntax.scala
@@ -1,21 +1,6 @@
-package com.rallyhealth.vapors.core.dsl.factfilter
-
-import com.rallyhealth.vapors.core.dsl
+package com.rallyhealth.vapors.factfilter.dsl
 
 private[dsl] trait Syntax {
-  self: Dsl =>
-
-  /**
-    * An alias to this [[dsl]] object, so you can use infix operators and more easily explore
-    * the list of supported expression builders.
-    *
-    * Example:
-    * {{{
-    *   __.withFactsOfType(FactTypes.Age)
-    *     .whereAnyValue(__ > 35)
-    * }}}
-    */
-  final val __ = this
 
   def >[T : Ordering](lowerBound: T): CondExp[T] = greaterThan(lowerBound)
   def >=[T : Ordering](lowerBound: T): CondExp[T] = greaterThanOrEqual(lowerBound)

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/WhereExpBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/WhereExpBuilder.scala
@@ -1,10 +1,11 @@
-package com.rallyhealth.vapors.core.dsl.factfilter
+package com.rallyhealth.vapors.factfilter.dsl
 
 import cats.data.NonEmptyList
 import cats.free.FreeApplicative
 import com.rallyhealth.vapors.core.algebra._
 import com.rallyhealth.vapors.core.data._
 import com.rallyhealth.vapors.core.util.ReflectUtils.typeNameOf
+import com.rallyhealth.vapors.factfilter.data._
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/package.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/package.scala
@@ -1,33 +1,22 @@
-package com.rallyhealth.vapors.core.dsl.factfilter
+package com.rallyhealth.vapors.factfilter
 
-import cats.data.NonEmptyList
 import cats.free.FreeApplicative
 import com.rallyhealth.vapors.core.algebra.ExpAlg
-import com.rallyhealth.vapors.core.data.{Fact, NamedLens, ResultSet, TypedFact, TypedResultSet}
+import com.rallyhealth.vapors.factfilter.data.{Facts, FactsOfType, ResultSet, TypedResultSet}
 
-private[dsl] trait Types {
+package object dsl extends Dsl with Evaluation with Syntax {
 
   /**
-    * Alias for a collection of facts with no restriction on Scala type.
+    * An alias to this [[dsl]] object, so you can use infix operators and more easily explore
+    * the list of supported expression builders.
     *
-    * @note This is the input for a top-level fact filter expression.
+    * Example:
+    * {{{
+    *   __.withFactsOfType(FactTypes.Age)
+    *     .whereAnyValue(__ > 35)
+    * }}}
     */
-  final type Facts = NonEmptyList[Fact]
-
-  /**
-    * Alias for a collection of facts of a specific type.
-    */
-  final type FactsOfType[T] = NonEmptyList[TypedFact[T]]
-
-  /**
-    * A [[NamedLens]] defined over a [[TypedFact]] of a known type.
-    */
-  final type FactLens[T, V] = NamedLens[TypedFact[T], V]
-
-  /**
-    * A useful alias for building a [[NamedLens]] by passing the identity lens as a starting point to a function.
-    */
-  final type FactLensId[T] = NamedLens.Id[TypedFact[T]]
+  final val __ = this
 
   /**
     * The root of all expression types.

--- a/core/src/test/scala/com/rallyhealth/vapors/core/evaluator/FreeApEvaluatorSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/evaluator/FreeApEvaluatorSpec.scala
@@ -1,13 +1,12 @@
 package com.rallyhealth.vapors.core.evaluator
 
 import cats.data.NonEmptyList
-import com.rallyhealth.vapors.core.Example._
-import com.rallyhealth.vapors.core.data.{FactTypeSet, FactsMatch}
-import com.rallyhealth.vapors.core.dsl
+import com.rallyhealth.vapors.factfilter.Example._
+import com.rallyhealth.vapors.factfilter.data.{FactTypeSet, FactsMatch}
+import com.rallyhealth.vapors.factfilter.dsl._
 import org.scalatest.wordspec.AnyWordSpec
 
 final class FreeApEvaluatorSpec extends AnyWordSpec {
-  import dsl._
 
   "evaluator" should {
 

--- a/core/src/test/scala/com/rallyhealth/vapors/core/evaluator/LogicalOperatorSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/evaluator/LogicalOperatorSpec.scala
@@ -1,12 +1,14 @@
 package com.rallyhealth.vapors.core.evaluator
 
-import com.rallyhealth.vapors.core.data._
-import com.rallyhealth.vapors.core.dsl.Exp
 import com.rallyhealth.vapors.core.logic.{Intersect, Union}
+import com.rallyhealth.vapors.factfilter.Example.JoeSchmoe
+import com.rallyhealth.vapors.factfilter.data.{Facts, FactsMatch, NoFactsMatch, ResultSet}
+import com.rallyhealth.vapors.factfilter.dsl._
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.language.existentials
 
+// TODO: Split out generic logical tests so that other types can be tested with these logical operations
 final class LogicalOperatorSpec extends AnyWordSpec {
 
   type LogicOpBuilder[T, A] = (Exp[T, A], Exp[T, A], Seq[Exp[T, A]]) => Exp[T, A]
@@ -153,8 +155,6 @@ final class LogicalOperatorSpec extends AnyWordSpec {
   }
 
   def validDslLogicalOperators(builder: DslLogicOpBuilder): Unit = {
-    import com.rallyhealth.vapors.core.Example.JoeSchmoe
-    import com.rallyhealth.vapors.core.dsl._
 
     "operating on boolean results" should {
 
@@ -187,7 +187,6 @@ final class LogicalOperatorSpec extends AnyWordSpec {
 
     behave like validDslLogicalOperators {
       new DslLogicOpBuilder {
-        import com.rallyhealth.vapors.core.dsl._
 
         override def andBuilder[T, A : Intersect]: LogicOpBuilder[T, A] = { (one, two, tail) =>
           and(one, two, tail: _*)
@@ -204,7 +203,6 @@ final class LogicalOperatorSpec extends AnyWordSpec {
 
     behave like validDslLogicalOperators {
       new DslLogicOpBuilder {
-        import com.rallyhealth.vapors.core.dsl._
 
         override def andBuilder[T, A : Intersect]: LogicOpBuilder[T, A] = { (one, two, tail) =>
           tail.foldLeft(one && two)(_ && _)

--- a/core/src/test/scala/com/rallyhealth/vapors/core/fql/PrinterSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/fql/PrinterSpec.scala
@@ -1,9 +1,9 @@
 package com.rallyhealth.vapors.core.fql
 
 import cats.data.NonEmptyList
-import com.rallyhealth.vapors.core.Example._
-import com.rallyhealth.vapors.core.data.FactsMatch
-import com.rallyhealth.vapors.core.dsl._
+import com.rallyhealth.vapors.factfilter.Example._
+import com.rallyhealth.vapors.factfilter.data.FactsMatch
+import com.rallyhealth.vapors.factfilter.dsl._
 import org.scalatest.wordspec.AnyWordSpec
 
 class PrinterSpec extends AnyWordSpec {

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/Example.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/Example.scala
@@ -1,11 +1,11 @@
-package com.rallyhealth.vapors.core
+package com.rallyhealth.vapors.factfilter
 
 import java.time.LocalDate
 
 import cats.data.NonEmptyList
-import com.rallyhealth.vapors.core.data.{FactType, FactTypeSet, TypedFact}
+import com.rallyhealth.vapors.factfilter.data.{FactType, FactTypeSet}
 
-private[core] object Example {
+object Example {
 
   final case class BloodPressure(
     diastolic: Double,


### PR DESCRIPTION
- Move `dsl.factfilter` code to `factfilter.dsl` and `factfilter.data`
- Split fact data types out of `core.data` package into `factfilter.data`
- Moved fact type and object aliases to the `factfilter.data` package