### PR TITLE
Fix use of __ outside of vapors library

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ComparisonOps.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ComparisonOps.scala
@@ -2,14 +2,11 @@ package com.rallyhealth.vapors.factfilter.dsl
 
 import cats.Eq
 
-private[dsl] trait Syntax {
+private[dsl] trait ComparisonOps {
 
   def >[T : Ordering](lowerBound: T): CondExp[T] = greaterThan(lowerBound)
   def >=[T : Ordering](lowerBound: T): CondExp[T] = greaterThanOrEqual(lowerBound)
   def <[T : Ordering](upperBound: T): CondExp[T] = lessThan(upperBound)
   def <=[T : Ordering](upperBound: T): CondExp[T] = lessThanOrEqual(upperBound)
   def ===[T : Eq](value: T): CondExp[T] = equalTo(value)
-
-  import scala.language.implicitConversions
-  implicit def logicalOps[T, A](exp: Exp[T, A]): LogicalOps[T, A] = new LogicalOps(exp)
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/Dsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/Dsl.scala
@@ -7,10 +7,7 @@ import com.rallyhealth.vapors.core.data.Window
 import com.rallyhealth.vapors.core.logic.{Intersect, Union}
 import com.rallyhealth.vapors.factfilter.data._
 
-import scala.reflect.ClassTag
-import scala.reflect.runtime.universe.TypeTag
-
-private[dsl] class Dsl {
+private[dsl] class Dsl extends TypedFactOps {
 
   // TODO: Use some cats typeclass instead of iterable?
   def all[F[x] <: IterableOnce[x], T, A](cond: CondExp[T]): CondExp[F[T]] = liftCondExp {
@@ -46,14 +43,6 @@ private[dsl] class Dsl {
 
   def when[T, A](exp: Exp[T, Boolean])(thenExp: Exp[T, A])(elseExp: Exp[T, A]): Exp[T, A] = liftExp {
     ExpAlg.Cond[T, A](exp, thenExp, elseExp)
-  }
-
-  def withFactsOfType[T >: U, U : ClassTag : TypeTag](factType: FactType[U]): WhereFactsExpBuilder[T, U] = {
-    new WhereFactsExpBuilder[T, U](FactTypeSet.of(factType))
-  }
-
-  def withFactsOfTypeIn[T >: U, U : ClassTag : TypeTag](factTypeSet: FactTypeSet[U]): WhereFactsExpBuilder[T, U] = {
-    new WhereFactsExpBuilder[T, U](factTypeSet)
   }
 
   def and[T, A : Intersect](

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/InfixOps.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/InfixOps.scala
@@ -1,0 +1,3 @@
+package com.rallyhealth.vapors.factfilter.dsl
+
+final class InfixOps private[dsl] extends ComparisonOps with TypedFactOps

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/LogicalOps.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/LogicalOps.scala
@@ -1,26 +1,27 @@
 package com.rallyhealth.vapors.factfilter.dsl
 
 import com.rallyhealth.vapors.core.logic.{Intersect, Union}
+import com.rallyhealth.vapors.factfilter.dsl
 
 final class LogicalOps[T, A](private val exp: Exp[T, A]) extends AnyVal {
 
   /**
     * Builds an AND expression using infix notation.
     */
-  def and(o: Exp[T, A])(implicit A: Intersect[A]): Exp[T, A] = __.and(exp, o)
+  def and(o: Exp[T, A])(implicit A: Intersect[A]): Exp[T, A] = dsl.and(exp, o)
 
   /**
     * Same as [[and]] but with higher precedent.
     */
-  def &&(o: Exp[T, A])(implicit A: Intersect[A]): Exp[T, A] = __.and(exp, o)
+  def &&(o: Exp[T, A])(implicit A: Intersect[A]): Exp[T, A] = dsl.and(exp, o)
 
   /**
     * Builds an OR expression using infix notation.
     */
-  def or(o: Exp[T, A])(implicit A: Union[A]): Exp[T, A] = __.or(exp, o)
+  def or(o: Exp[T, A])(implicit A: Union[A]): Exp[T, A] = dsl.or(exp, o)
 
   /**
     * Same as [[or]] but with higher precedent.
     */
-  def ||(o: Exp[T, A])(implicit A: Union[A]): Exp[T, A] = __.or(exp, o)
+  def ||(o: Exp[T, A])(implicit A: Union[A]): Exp[T, A] = dsl.or(exp, o)
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/TypedFactOps.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/TypedFactOps.scala
@@ -1,0 +1,17 @@
+package com.rallyhealth.vapors.factfilter.dsl
+
+import com.rallyhealth.vapors.factfilter.data.{FactType, FactTypeSet}
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
+
+private[dsl] trait TypedFactOps {
+
+  def withFactsOfType[T >: U, U : ClassTag : TypeTag](factType: FactType[U]): WhereFactsExpBuilder[T, U] = {
+    new WhereFactsExpBuilder[T, U](FactTypeSet.of(factType))
+  }
+
+  def withFactsOfTypeIn[T >: U, U : ClassTag : TypeTag](factTypeSet: FactTypeSet[U]): WhereFactsExpBuilder[T, U] = {
+    new WhereFactsExpBuilder[T, U](factTypeSet)
+  }
+}

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/package.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/package.scala
@@ -4,7 +4,7 @@ import cats.free.FreeApplicative
 import com.rallyhealth.vapors.core.algebra.ExpAlg
 import com.rallyhealth.vapors.factfilter.data.{Facts, FactsOfType, ResultSet, TypedResultSet}
 
-package object dsl extends Dsl with Evaluation with Syntax {
+package object dsl extends Dsl with Evaluation {
 
   /**
     * An alias to this [[dsl]] object, so you can use infix operators and more easily explore
@@ -16,7 +16,10 @@ package object dsl extends Dsl with Evaluation with Syntax {
     *     .whereAnyValue(__ > 35)
     * }}}
     */
-  final val __ = this
+  final val __ = new InfixOps
+
+  import scala.language.implicitConversions
+  implicit def logicalOps[T, A](exp: Exp[T, A]): LogicalOps[T, A] = new LogicalOps(exp)
 
   /**
     * The root of all expression types.

--- a/core/src/test/scala/com/rallyhealth/vapors/core/evaluator/FreeApEvaluatorSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/evaluator/FreeApEvaluatorSpec.scala
@@ -21,7 +21,7 @@ final class FreeApEvaluatorSpec extends AnyWordSpec {
           __.withFactsOfType(FactTypes.ProbabilityToUse)
             .withValuesAt(_.select(_.scores).atKey("weightloss"))
             .whereAnyValue {
-              __.exists(__ > 0.5)
+              exists(__ > 0.5)
             },
         )
       }
@@ -50,7 +50,7 @@ final class FreeApEvaluatorSpec extends AnyWordSpec {
           __.withFactsOfType(FactTypes.ProbabilityToUse)
             .withValuesAt(_.select(_.scores).atKey("weightloss"))
             .whereAnyValue {
-              __.exists(__ > 0.5)
+              exists(__ > 0.5)
             },
         )
       assertResult(FactsMatch(NonEmptyList.of(JoeSchmoe.probs))) {

--- a/core/src/test/scala/com/rallyhealth/vapors/core/fql/PrinterSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/fql/PrinterSpec.scala
@@ -45,12 +45,9 @@ class PrinterSpec extends AnyWordSpec {
         or(
           __.withFactsOfType(FactTypes.ProbabilityToUse)
             .withValuesAt(_.select(_.scores).atKey("weightloss"))
-            .whereAnyValue(
-              and(
-                exists(__ > 0.5),
-                exists(__ < 0.3),
-              ),
-            ),
+            .whereAnyValue {
+              and(exists(__ > 0.5), exists(__ < 0.3))
+            },
           __.withFactsOfType(FactTypes.WeightMeasurement)
             .whereAnyValue(__ > 150),
         )


### PR DESCRIPTION
It turns out that __.withFactsOfType didn’t actually work outside of this library. This separates the use of __ for infix and top-level operators from the other more generic dsl functions.