### PR TITLE
Limit results of where builders to only matching facts

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExpAlg.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExpAlg.scala
@@ -1,6 +1,7 @@
 package com.rallyhealth.vapors.core.algebra
 
 import cats.Eq
+import cats.data.NonEmptyList
 import cats.free.FreeApplicative
 import com.rallyhealth.vapors.core.data.{NamedLens, Window}
 
@@ -21,14 +22,14 @@ object ExpAlg {
   final case class ForAll[T, U, A](
     toIterable: T => IterableOnce[U],
     condition: FreeApplicative[ExpAlg[U, *], Boolean],
+    foundFalse: NonEmptyList[U] => A,
     whenTrue: T => A,
-    whenFalse: T => A,
   ) extends ExpAlg[T, A]
 
   final case class Exists[T, U, A](
     toIterable: T => IterableOnce[U],
     condition: FreeApplicative[ExpAlg[U, *], Boolean],
-    whenTrue: T => A,
+    foundTrue: NonEmptyList[U] => A,
     whenFalse: T => A,
   ) extends ExpAlg[T, A]
 

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/Dsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/Dsl.scala
@@ -10,7 +10,7 @@ import com.rallyhealth.vapors.factfilter.data._
 private[dsl] class Dsl extends TypedFactOps {
 
   def forall[T, V](cond: CondExp[V])(implicit ev: T <:< IterableOnce[V]): CondExp[T] = liftCondExp {
-    ExpAlg.ForAll[T, V, Boolean](ev, cond, True, False)
+    ExpAlg.ForAll[T, V, Boolean](ev, cond, False, True)
   }
 
   def exists[T, V](cond: CondExp[V])(implicit ev: T <:< IterableOnce[V]): CondExp[T] = liftCondExp {

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/WhereExpBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/WhereExpBuilder.scala
@@ -76,7 +76,7 @@ class WhereBuilder[T, U <: T : ClassTag : TypeTag] private[dsl] (factTypeSet: Fa
     ExpAlg.Exists[FactsOfType[U], TypedFact[U], TypedResultSet[U]](
       _.toList,
       buildExp(new CondBuilder(lens)),
-      FactsMatch(_),
+      found => TypedResultSet.fromNel(found),
       _ => NoFactsMatch(),
     )
   }
@@ -111,8 +111,8 @@ class WhereBuilder[T, U <: T : ClassTag : TypeTag] private[dsl] (factTypeSet: Fa
     ExpAlg.ForAll[FactsOfType[U], TypedFact[U], TypedResultSet[U]](
       _.toList,
       buildExp(new CondBuilder(lens)),
-      FactsMatch(_),
       _ => NoFactsMatch(),
+      TypedFactsMatch(_),
     )
   }
 }

--- a/core/src/test/scala/com/rallyhealth/vapors/core/evaluator/FreeApEvaluatorSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/evaluator/FreeApEvaluatorSpec.scala
@@ -76,7 +76,7 @@ final class FreeApEvaluatorSpec extends AnyWordSpec {
           _.within(Window.between(100, 250))
         }
       }
-      assertResult(FactsMatch(Facts(JoeSchmoe.weight, JoeSchmoe.weightSelfReported))) {
+      assertResult(FactsMatch(Facts(JoeSchmoe.weightSelfReported))) {
         evalWithFacts(JoeSchmoe.facts)(q)
       }
     }
@@ -123,8 +123,7 @@ final class FreeApEvaluatorSpec extends AnyWordSpec {
           value >= Role.Admin
         }
       }
-      // TODO: This is wrong... it should only be the admin role.
-      assertResult(FactsMatch(Facts(JoeSchmoe.adminRole, JoeSchmoe.userRole))) {
+      assertResult(FactsMatch(Facts(JoeSchmoe.adminRole))) {
         evalWithFacts(JoeSchmoe.facts)(q)
       }
     }


### PR DESCRIPTION
This fixes the bug where you have an expression that filters to a specific type like the following:
```
withType(Tag).whereAnyFactValue { tag =>
  tag === "A" or tag === "B"
}
```

And you have some facts of the same type that don't match the expression's filter:
```
Facts(
  Tag("A"),
  Tag("C"),
)
```

And the result used to return all facts of the selected type if at least one of them matched:
```
ResultSet(
  Facts(
    Tag("A"),
    Tag("C"),
  ),
)
```

But now it will only return the specific facts that matched:
```
ResultSet(
  Facts(
    Tag("A"),
  ),
)
```