### PR TITLE
Make CaptureP.unit the low priority default and remove all unnecessary imports

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/data/DataPath.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/data/DataPath.scala
@@ -37,10 +37,8 @@ final case class DataPath(nodes: List[DataPath.Node]) extends AnyVal {
   def atKey[K : ValidDataPathKey](key: K): DataPath =
     DataPath(nodes ::: MapKey(ValidDataPathKey[K].stringify(key)) :: Nil)
 
-  def filterKeys[K : ValidDataPathKey](keys: NonEmptySet[K]): DataPath = {
-    import cats.instances.string._
+  def filterKeys[K : ValidDataPathKey](keys: NonEmptySet[K]): DataPath =
     DataPath(nodes ::: FilterKeys(keys.map(ValidDataPathKey[K].stringify).toSortedSet) :: Nil)
-  }
 
   def atField(name: String): DataPath = DataPath(nodes ::: Field(name) :: Nil)
 

--- a/core/src/main/scala/com/rallyhealth/vapors/core/data/Window.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/data/Window.scala
@@ -26,8 +26,6 @@ object Window {
   }
 
   def showWindowWithTerm[A : Show](term: String): Show[Window[A]] = Show.show { window =>
-    import cats.instances.string._
-    import cats.instances.tuple._
     val (op1, op2) = window.bounds
       .bimap(
         b => (if (b.inclusiveLowerBound) ">=" else ">", ""),
@@ -44,14 +42,11 @@ object Window {
 
   implicit def showWindow[A : Show]: Show[Window[A]] = showWindowWithTerm("x")
 
-  def fromRange(range: Range): Window[Int] = {
-    import cats.instances.int._
+  def fromRange(range: Range): Window[Int] =
     Window.between(range.start, includeMin = true, range.end, includeMax = range.isInclusive)
-  }
 
-  def fromRange[A : Order](range: NumericRange[A]): Window[A] = {
+  def fromRange[A : Order](range: NumericRange[A]): Window[A] =
     Window.between(range.start, includeMin = true, range.end, includeMax = range.isInclusive)
-  }
 
   def lessThan[A : Order](
     max: A,

--- a/core/src/main/scala/com/rallyhealth/vapors/core/evaluator/EvalLoop.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/evaluator/EvalLoop.scala
@@ -1,10 +1,8 @@
 package com.rallyhealth.vapors.core.evaluator
 
 import cats.data.NonEmptyList
-import cats.instances.function._
 import cats.~>
 import com.rallyhealth.vapors.core.algebra._
-import com.rallyhealth.vapors.core.logic.{Intersect, Union}
 import com.rallyhealth.vapors.factfilter.dsl.Exp
 
 private[evaluator] final class EvalLoop[T] extends (ExpAlg[T, *] ~> (T => *)) {

--- a/core/src/main/scala/com/rallyhealth/vapors/core/evaluator/package.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/evaluator/package.scala
@@ -4,7 +4,6 @@ import cats.free.FreeApplicative
 import com.rallyhealth.vapors.core.algebra.ExpAlg
 
 package object evaluator {
-  import cats.instances.function._
 
   def eval[T, A](input: T)(exp: FreeApplicative[ExpAlg[T, *], A]): A = {
     exp.foldMap(new EvalLoop[T]).apply(input)

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/FactType.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/FactType.scala
@@ -95,10 +95,7 @@ object FactType {
 
   implicit def orderingByName[T]: Ordering[FactType[T]] = Ordering.by(_.fullName)
 
-  implicit def orderByName[T]: Order[FactType[T]] = {
-    import cats.instances.string._
-    Order.by(_.fullName)
-  }
+  implicit def orderByName[T]: Order[FactType[T]] = Order.by(_.fullName)
 
   implicit def validDataPathKey[T]: ValidDataPathKey[FactType[T]] = _.fullName
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/FactTypeSet.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/FactTypeSet.scala
@@ -47,10 +47,8 @@ object FactTypeSet {
   def of[A](
     one: FactType[A],
     others: FactType[A]*,
-  ): FactTypeSet[A] = {
-    import cats.instances.string._
+  ): FactTypeSet[A] =
     new FactTypeSet(NonEmptyMap.of(one.fullName -> one, others.map(a => (a.fullName, a)): _*))
-  }
 
   def fromFactsNel[A](facts: NonEmptyList[TypedFact[A]]): FactTypeSet[A] = fromNel(facts.map(_.typeInfo))
 

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/CaptureP.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/CaptureP.scala
@@ -31,7 +31,7 @@ trait CaptureP[F[_], V, R, P] {
   ): Eval[P]
 }
 
-object CaptureP {
+object CaptureP extends CaptureUnitLowPriorityImplicit {
 
   /**
     * Captures the type parameter from facts with a value of type [[T]].
@@ -107,9 +107,9 @@ object CaptureP {
   abstract class AsMonoidCompanion[P](protected implicit final val P: Monoid[P]) {
     implicit def captureParamAndPass[F[_], V, R]: CaptureP[F, V, R, P] = new AsMonoidAndPass[F, V, R, P]
   }
+}
 
-  object unit {
+sealed trait CaptureUnitLowPriorityImplicit {
 
-    implicit def captureUnit[F[_], V, R]: CaptureP[F, V, R, Unit] = (_, _, _, _) => Eval.Unit
-  }
+  implicit def captureUnit[F[_], V, R]: CaptureP[F, V, R, Unit] = (_, _, _, _) => Eval.Unit
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/evaluator/InterpretExprAsFunction.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/evaluator/InterpretExprAsFunction.scala
@@ -408,7 +408,6 @@ object InterpretExprAsFunction {
       */
     implicit def conjunction[R : Conjunction : ExtractBoolean]: Conjunction[Output[R]] =
       (lhs: Output[R], rhs: Output[R]) => {
-        import cats.instances.option._
         import cats.syntax.apply._
         val R = ExtractBoolean[R]
         @inline def isTrue(output: Output[R]): Boolean = R.isTrue(output.value)
@@ -456,7 +455,6 @@ object InterpretExprAsFunction {
       */
     implicit def disjunction[R : Disjunction : ExtractBoolean]: Disjunction[Output[R]] =
       (lhs: Output[R], rhs: Output[R]) => {
-        import cats.instances.option._
         import cats.syntax.apply._
         val R = ExtractBoolean[R]
         @inline def isTrue(output: Output[R]): Boolean = R.isTrue(output.value)

--- a/core/src/test/scala/com/rallyhealth/vapors/core/data/WindowSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/data/WindowSpec.scala
@@ -14,9 +14,6 @@ import scala.reflect.runtime.universe.{typeOf, TypeTag}
 
 class WindowSpec extends AnyWordSpec {
 
-  import cats.instances.int._
-  import Ordering.Implicits._
-
   class BoundedWindowTests[A : Arbitrary : Order](buildWindow: (A, A) => Window[A]) {
     import cats.syntax.order._
 
@@ -211,6 +208,8 @@ class WindowSpec extends AnyWordSpec {
             }
           }
         }
+
+        import cats.syntax.order._
 
         "greaterThan() contains a value greaterThan a given window boundary" in {
           assertContainsValue(Window.greaterThan(_), _ min _, inclusive = false)

--- a/core/src/test/scala/com/rallyhealth/vapors/core/evaluator/FreeApEvaluatorSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/evaluator/FreeApEvaluatorSpec.scala
@@ -1,6 +1,5 @@
 package com.rallyhealth.vapors.core.evaluator
 
-import cats.instances.string._
 import com.rallyhealth.vapors.core.data.Window
 import com.rallyhealth.vapors.factfilter.Example._
 import com.rallyhealth.vapors.factfilter.data.{FactTypeSet, FactsMatch}
@@ -8,11 +7,6 @@ import com.rallyhealth.vapors.factfilter.dsl._
 import org.scalatest.wordspec.AnyWordSpec
 
 final class FreeApEvaluatorSpec extends AnyWordSpec {
-
-  import cats.instances.ordering._
-  import cats.instances.order._
-  import cats.instances.int._
-  import cats.instances.double._
 
   "evaluator" should {
 

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/CapturePSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/CapturePSpec.scala
@@ -1,6 +1,5 @@
 package com.rallyhealth.vapors.factfilter.evaluator
 
-import cats.instances.double._
 import com.rallyhealth.vapors.factfilter.Example.{FactTypes, JoeSchmoe}
 import com.rallyhealth.vapors.factfilter.data.Evidence
 import com.rallyhealth.vapors.factfilter.dsl.ExprDsl._

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/EmbeddedExpressionSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/EmbeddedExpressionSpec.scala
@@ -12,9 +12,6 @@ import java.time.LocalDate
 
 class EmbeddedExpressionSpec extends AnyWordSpec {
 
-  import cats.instances.all._
-  import com.rallyhealth.vapors.factfilter.dsl.CaptureP.unit._
-
   // TODO: Do the real computation here
   // TODO: Make a named function to call out to "dateCompare()" (maybe a primitive algebra?)
   //       Or just hack it for now.

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/InterpretExprAsFunctionSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/InterpretExprAsFunctionSpec.scala
@@ -7,13 +7,9 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class InterpretExprAsFunctionSpec extends AnyWordSpec {
 
-  import cats.instances.all._
-
   "InterpretExprAsFunction" when {
 
     "using no post processing" should {
-
-      import com.rallyhealth.vapors.factfilter.dsl.CaptureP.unit._
 
       "find a single fact from a query" in {
         val q = withFactsOfType(FactTypes.Age).where {

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/LogicalExprSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/LogicalExprSpec.scala
@@ -13,8 +13,6 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class LogicalExprSpec extends AnyWordSpec {
 
-  import CaptureP.unit._
-
   private type LogicExpr[R] = Expr[Id, Unit, R, Unit]
 
   private type LogicOpBuilder[R] =

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/OutputWithinSetExprSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/OutputWithinSetExprSpec.scala
@@ -1,10 +1,9 @@
 package com.rallyhealth.vapors.factfilter.evaluator
 
 import com.rallyhealth.vapors.factfilter.Example.{FactTypes, JoeSchmoe}
-import com.rallyhealth.vapors.factfilter.data.{Evidence, FactSet}
-import com.rallyhealth.vapors.factfilter.dsl.CaptureP.unit._
-import org.scalatest.wordspec.AnyWordSpec
+import com.rallyhealth.vapors.factfilter.data.Evidence
 import com.rallyhealth.vapors.factfilter.dsl.ExprDsl._
+import org.scalatest.wordspec.AnyWordSpec
 
 class OutputWithinSetExprSpec extends AnyWordSpec {
 


### PR DESCRIPTION
- Remove all imports of CaptureP.unit
- Remove all imports of cats.instances (except `cats.instances.order._`)