### PR TITLE
Add equals / not equals operators as well as set filtering operators and unit tests

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
@@ -53,6 +53,7 @@ object Expr {
     def visitNegativeOutput[R : Negative](expr: NegativeOutput[F, V, R, P]): G[R]
     def visitNot[R : Negation](expr: Not[F, V, R, P]): G[R]
     def visitOr[R : Disjunction : ExtractBoolean](expr: Or[F, V, R, P]): G[R]
+    def visitOutputIsEmpty[M[_] : Foldable, R](expr: OutputIsEmpty[F, V, M, R, P]): G[Boolean]
     def visitOutputWithinSet[R](expr: OutputWithinSet[F, V, R, P]): G[Boolean]
     def visitOutputWithinWindow[R](expr: OutputWithinWindow[F, V, R, P]): G[Boolean]
     def visitReturnInput(expr: ReturnInput[F, V, P]): G[F[V]]
@@ -303,6 +304,13 @@ object Expr {
     capture: CaptureP[F, V, M[R], P],
   ) extends Expr[F, V, M[R], P] {
     override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitMapOutput(this)
+  }
+
+  final case class OutputIsEmpty[F[_], V, M[_] : Foldable, R, P](
+    inputExpr: Expr[F, V, M[R], P],
+    capture: CaptureP[F, V, Boolean, P],
+  ) extends Expr[F, V, Boolean, P] {
+    override def visit[G[_]](v: Visitor[F, V, P, G]): G[Boolean] = v.visitOutputIsEmpty(this)
   }
 
   /**

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
@@ -9,8 +9,6 @@ import com.rallyhealth.vapors.core.math.{Addition, Negative, Subtraction}
 import com.rallyhealth.vapors.factfilter.data._
 import com.rallyhealth.vapors.factfilter.dsl.CaptureP
 
-import scala.collection.immutable.SortedSet
-
 /**
   * The core expression algebra.
   *
@@ -131,7 +129,7 @@ object Expr {
     */
   final case class WithFactsOfType[T, R, P](
     factTypeSet: FactTypeSet[T],
-    subExpr: Expr[SortedSet, TypedFact[T], R, P],
+    subExpr: Expr[Set, TypedFact[T], R, P],
     capture: CaptureP[Id, FactTable, R, P],
   ) extends Expr[Id, FactTable, R, P] {
     override def visit[G[_]](v: Visitor[Id, FactTable, P, G]): G[R] = v.visitWithFactsOfType(this)

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
@@ -51,6 +51,7 @@ object ExprResult {
     def visitNegativeOutput[R](result: NegativeOutput[F, V, R, P]): G[R]
     def visitNot[R](result: Not[F, V, R, P]): G[R]
     def visitOr[R](result: Or[F, V, R, P]): G[R]
+    def visitOutputIsEmpty[M[_] : Foldable, R](result: OutputIsEmpty[F, V, M, R, P]): G[Boolean]
     def visitOutputWithinSet[R](result: OutputWithinSet[F, V, R, P]): G[Boolean]
     def visitOutputWithinWindow[R](result: OutputWithinWindow[F, V, R, P]): G[Boolean]
     def visitReturnInput(result: ReturnInput[F, V, P]): G[F[V]]
@@ -194,6 +195,14 @@ object ExprResult {
     subResultList: List[ExprResult[Id, U, R, P]],
   ) extends ExprResult[F, V, M[R], P] {
     override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitMapOutput(this)
+  }
+
+  final case class OutputIsEmpty[F[_], V, M[_] : Foldable, R, P](
+    expr: Expr.OutputIsEmpty[F, V, M, R, P],
+    context: Context[F, V, Boolean, P],
+    inputResult: ExprResult[F, V, M[R], P],
+  ) extends ExprResult[F, V, Boolean, P] {
+    override def visit[G[_]](v: Visitor[F, V, P, G]): G[Boolean] = v.visitOutputIsEmpty(this)
   }
 
   final case class ExistsInOutput[F[_], V, M[_] : Foldable, U, P](

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
@@ -6,7 +6,6 @@ import com.rallyhealth.vapors.factfilter.data.{Fact, FactSet, FactTable, TypedFa
 import com.rallyhealth.vapors.factfilter.evaluator.InterpretExprAsFunction.{Input, Output}
 
 import scala.collection.BitSet
-import scala.collection.immutable.SortedSet
 
 /**
   * The result of evaluating an [[Expr]] with some given [[Input]].
@@ -100,7 +99,7 @@ object ExprResult {
   final case class WithFactsOfType[F[_], V, T, R, P](
     expr: Expr.WithFactsOfType[T, R, P],
     context: Context[F, V, R, P],
-    subResult: ExprResult[SortedSet, TypedFact[T], R, P],
+    subResult: ExprResult[Set, TypedFact[T], R, P],
   ) extends ExprResult[F, V, R, P] {
     override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitWithFactsOfType(this)
   }
@@ -163,7 +162,7 @@ object ExprResult {
     override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitSelectFromOutput(this)
   }
 
-  final case class FilterOutput[F[_], V, M[_], R, P](
+  final case class FilterOutput[F[_], V, M[_] : Foldable : FunctorFilter, R, P](
     expr: Expr.FilterOutput[F, V, M, R, P],
     context: Context[F, V, M[R], P],
     inputResult: ExprResult[F, V, M[R], P],

--- a/core/src/main/scala/com/rallyhealth/vapors/core/data/Window.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/data/Window.scala
@@ -48,6 +48,9 @@ object Window {
   def fromRange[A : Order](range: NumericRange[A]): Window[A] =
     Window.between(range.start, includeMin = true, range.end, includeMax = range.isInclusive)
 
+  def equalTo[A : Order](value: A): Window[A] =
+    Window.betweenInclusive(value, value)
+
   def lessThan[A : Order](
     max: A,
     inclusive: Boolean,
@@ -97,6 +100,8 @@ object Window {
       case Ior.Right(ub) if ub.inclusiveUpperBound => _ <= ub.upperBound
       case Ior.Right(ub) => _ < ub.upperBound
 
+      case Ior.Both(lb, ub) if lb.lowerBound == ub.upperBound && (lb.inclusiveLowerBound || ub.inclusiveUpperBound) =>
+        a => a == lb.lowerBound
       case Ior.Both(lb, ub) if lb.inclusiveLowerBound && ub.inclusiveUpperBound =>
         a => a >= lb.lowerBound && a <= ub.upperBound
       case Ior.Both(lb, ub) if ub.inclusiveUpperBound =>

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/CaptureP.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/CaptureP.scala
@@ -36,7 +36,7 @@ object CaptureP extends CaptureUnitLowPriorityImplicit {
   /**
     * Captures the type parameter from facts with a value of type [[T]].
     */
-  trait FromFactsOfType[T, R, P] extends CaptureP[SortedSet, TypedFact[T], R, P]
+  trait FromFactsOfType[T, R, P] extends CaptureP[Set, TypedFact[T], R, P]
 
   /**
     * Captures the type parameter from facts with a value of type [[T]] (assuming [[P]] is a [[Monoid]])
@@ -44,7 +44,7 @@ object CaptureP extends CaptureUnitLowPriorityImplicit {
     * @see [[AsMonoid]]
     */
   abstract class AsMonoidFromFactsOfType[T, R, P : Monoid]
-    extends AsMonoid[SortedSet, TypedFact[T], R, P]
+    extends AsMonoid[Set, TypedFact[T], R, P]
     with FromFactsOfType[T, R, P]
 
   // TODO: This is not very safe. Nodes will often combine the params of their input expressions and sub expressions.

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
@@ -1,14 +1,13 @@
 package com.rallyhealth.vapors.factfilter.dsl
 
-import cats.{FlatMap, Foldable, Functor, FunctorFilter, Id, Order}
+import cats.{FlatMap, Foldable, Functor, FunctorFilter, Id, MonoidK, Order}
 import com.rallyhealth.vapors.core.algebra.Expr
 import com.rallyhealth.vapors.core.data.{NamedLens, Window}
 import com.rallyhealth.vapors.core.math.{Addition, Negative, Subtraction}
 import com.rallyhealth.vapors.factfilter.data.{Evidence, Fact, TypedFact}
-import com.sun.tools.javac.code.TypeTag
 
 import scala.collection.Factory
-import scala.reflect.runtime.universe.typeOf
+import scala.reflect.runtime.universe.{typeOf, TypeTag}
 
 sealed class ExprBuilder[F[_], V, M[_], U, P](val returnOutput: Expr[F, V, M[U], P]) {
 

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
@@ -235,6 +235,30 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
   ): ValExprBuilder[V, Boolean, P] =
     new ValExprBuilder(ExprDsl.within(returnOutput, window))
 
+  def isEqualTo(
+    value: R,
+  )(implicit
+    orderR: Order[R],
+    captureResult: CaptureCond,
+  ): ValExprBuilder[V, Boolean, P] =
+    within(Window.equalTo(value))
+
+  def ===(
+    value: R,
+  )(implicit
+    orderR: Order[R],
+    captureResult: CaptureCond,
+  ): ValExprBuilder[V, Boolean, P] =
+    within(Window.equalTo(value))
+
+  def !==(
+    value: R,
+  )(implicit
+    orderR: Order[R],
+    captureResult: CaptureCond,
+  ): ValExprBuilder[V, Boolean, P] =
+    Expr.Not(within(Window.equalTo(value)), captureResult)
+
   def <(
     value: R,
   )(implicit

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
@@ -4,7 +4,7 @@ import cats.{FlatMap, Foldable, Functor, Id, Order}
 import com.rallyhealth.vapors.core.algebra.Expr
 import com.rallyhealth.vapors.core.data.{NamedLens, Window}
 import com.rallyhealth.vapors.core.math.{Addition, Negative, Subtraction}
-import com.rallyhealth.vapors.factfilter.data.TypedFact
+import com.rallyhealth.vapors.factfilter.data.{Evidence, TypedFact}
 
 import scala.collection.Factory
 
@@ -187,7 +187,7 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
     R: Addition[R],
     captureResult: CaptureResult[R],
   ): ValExprBuilder[V, R, P] =
-    new ValExprBuilder(ExprDsl.add(returnOutput, ExprDsl.const(rhs)))
+    new ValExprBuilder(ExprDsl.add(returnOutput, Expr.ConstOutput(rhs, Evidence.none, captureResult)))
 
   def addTo(
     lhs: R,
@@ -195,7 +195,7 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
     R: Addition[R],
     captureResult: CaptureResult[R],
   ): ValExprBuilder[V, R, P] =
-    new ValExprBuilder(ExprDsl.add(ExprDsl.const(lhs), returnOutput))
+    new ValExprBuilder(ExprDsl.add(Expr.ConstOutput(lhs, Evidence.none, captureResult), returnOutput))
 
   def subtract(
     rhs: R,
@@ -211,7 +211,7 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
     R: Subtraction[R],
     captureResult: CaptureResult[R],
   ): ValExprBuilder[V, R, P] =
-    new ValExprBuilder(ExprDsl.subtract(returnOutput, ExprDsl.const(rhs)))
+    new ValExprBuilder(ExprDsl.subtract(returnOutput, Expr.ConstOutput(rhs, Evidence.none, captureResult)))
 
   def subtractFrom(
     lhs: R,
@@ -219,7 +219,7 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
     R: Subtraction[R],
     captureResult: CaptureResult[R],
   ): ValExprBuilder[V, R, P] =
-    new ValExprBuilder(ExprDsl.subtract(ExprDsl.const(lhs), returnOutput))
+    new ValExprBuilder(ExprDsl.subtract(Expr.ConstOutput(lhs, Evidence.none, captureResult), returnOutput))
 
   def unary_-(
     implicit

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
@@ -120,6 +120,12 @@ sealed class FoldableExprBuilder[F[_] : Foldable, V, M[_] : Foldable, U, P](retu
     new FoldableExprBuilder(next)
   }
 
+  def isEmpty(
+    implicit
+    captureResult: CaptureCond,
+  ): FoldInExprBuilder[F, V, Boolean, P] =
+    new FoldInExprBuilder(Expr.OutputIsEmpty(returnOutput, captureResult))
+
   def exists(
     buildFn: ValExprBuilder[U, U, P] => ExprBuilder[Id, U, Id, Boolean, P],
   )(implicit
@@ -139,6 +145,21 @@ sealed class FoldableExprBuilder[F[_] : Foldable, V, M[_] : Foldable, U, P](retu
     captureResult: CaptureResult[M[U]],
   ): FoldableExprBuilder[F, V, M, U, P] =
     new FoldableExprBuilder(Expr.FilterOutput(returnOutput, validValues, typeOf[U] <:< typeOf[Fact], captureResult))
+
+  def containsAny(
+    validValues: Set[U],
+  )(implicit
+    filterM: FunctorFilter[M],
+    tt: TypeTag[U],
+    captureResult: CaptureResult[M[U]],
+    captureCond: CaptureCond,
+  ): FoldInExprBuilder[F, V, Boolean, P] =
+    new FoldInExprBuilder(
+      Expr.Not(
+        filter(validValues).isEmpty,
+        captureCond,
+      ),
+    )
 }
 
 final class FoldInExprBuilder[F[_] : Foldable, V, R, P](returnOutput: Expr[F, V, R, P])

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilderCatsInstances.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilderCatsInstances.scala
@@ -1,0 +1,12 @@
+package com.rallyhealth.vapors.factfilter.dsl
+
+import cats.{Monad, Traverse, TraverseFilter}
+
+trait ExprBuilderCatsInstances {
+
+  implicit def monadSet: Monad[Set] = alleycats.std.set.alleyCatsStdSetMonad
+
+  implicit def traverseSet: Traverse[Set] = alleycats.std.set.alleyCatsSetTraverse
+
+  implicit def traverseFilterSet: TraverseFilter[Set] = alleycats.std.set.alleyCatsSetTraverseFilter
+}

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprDsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprDsl.scala
@@ -33,22 +33,22 @@ object ExprDsl extends ExprBuilderSyntax {
   /**
     * Lifts the given value into the output of an expression with no evidence.
     */
-  def const[F[_], V, R, P](
+  def const[R, P](
     value: R,
     evidence: Evidence = Evidence.none,
   )(implicit
-    post: CaptureP[F, V, R, P],
-  ): Expr[F, V, R, P] =
+    post: CaptureRootExpr[R, P],
+  ): RootExpr[R, P] =
     Expr.ConstOutput(value, evidence, post)
 
   /**
     * Uses the value of a given fact and also considers the fact as evidence of its own value.
     */
-  def factValue[F[_], V, R, P](
+  def factValue[R, P](
     typedFact: TypedFact[R],
   )(implicit
-    post: CaptureP[F, V, R, P],
-  ): Expr[F, V, R, P] =
+    post: CaptureRootExpr[R, P],
+  ): RootExpr[R, P] =
     const(typedFact.value, Evidence(typedFact))
 
   def input[F[_], V, P](

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprDsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprDsl.scala
@@ -10,9 +10,7 @@ import com.rallyhealth.vapors.core.math.{Addition, Negative, Subtraction}
 import com.rallyhealth.vapors.factfilter.data._
 import com.rallyhealth.vapors.factfilter.evaluator.InterpretExprAsFunction
 
-import scala.collection.immutable.SortedSet
-
-object ExprDsl extends ExprBuilderSyntax {
+object ExprDsl extends ExprBuilderSyntax with ExprBuilderCatsInstances {
 
   final type CondExpr[F[_], V, P] = Expr[F, V, Boolean, P]
 
@@ -22,7 +20,7 @@ object ExprDsl extends ExprBuilderSyntax {
   type RootExpr[R, P] = Expr[Id, FactTable, R, P]
 
   type CaptureRootExpr[R, P] = CaptureP[Id, FactTable, R, P]
-  type CaptureFromFacts[T, P] = CaptureP[SortedSet, TypedFact[T], SortedSet[TypedFact[T]], P]
+  type CaptureFromFacts[T, P] = CaptureP[Set, TypedFact[T], Set[TypedFact[T]], P]
 
   import InterpretExprAsFunction._
 
@@ -160,22 +158,21 @@ object ExprDsl extends ExprBuilderSyntax {
   ) {
 
     def where[M[_], U](
-      buildSubExpr: ExprBuilder.FoldableFn[SortedSet, TypedFact[T], M, U, P],
+      buildSubExpr: ExprBuilder.FoldableFn[Set, TypedFact[T], M, U, P],
     )(implicit
       postResult: CaptureRootExpr[M[U], P],
-    ): RootExpr[M[U], P] = {
+    ): RootExpr[M[U], P] =
       Expr.WithFactsOfType(
         factTypeSet,
         buildSubExpr(new FoldableExprBuilder(ExprDsl.input)).returnOutput,
         postResult,
       )
-    }
 
     def returnInput(
       implicit
       postInput: CaptureFromFacts[T, P],
-      postResult: CaptureRootExpr[SortedSet[TypedFact[T]], P],
-    ): RootExpr[SortedSet[TypedFact[T]], P] =
+      postResult: CaptureRootExpr[Set[TypedFact[T]], P],
+    ): RootExpr[Set[TypedFact[T]], P] =
       Expr.WithFactsOfType(factTypeSet, input(postInput), postResult)
   }
 

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/evaluator/InterpretExprAsFunction.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/evaluator/InterpretExprAsFunction.scala
@@ -8,7 +8,7 @@ import com.rallyhealth.vapors.core.math.{Addition, Negative, Subtraction}
 import com.rallyhealth.vapors.factfilter.data._
 import com.rallyhealth.vapors.factfilter.evaluator.InterpretExprAsFunction.{Input, Output}
 
-import scala.collection.immutable.{BitSet, SortedSet}
+import scala.collection.immutable.BitSet
 
 // TODO: Make R the last parameter?
 final class InterpretExprAsFunction[F[_] : Foldable, V, P]
@@ -312,11 +312,12 @@ final class InterpretExprAsFunction[F[_] : Foldable, V, P]
   override def visitWithFactsOfType[T, R](
     expr: Expr.WithFactsOfType[T, R, P],
   ): Input[F, V] => ExprResult[F, V, R, P] = { input =>
+    import alleycats.std.set._
     val inputFactTable = input.withValue(input.factTable)
     val withMatchingFactsFn = expr.subExpr.visit(InterpretExprAsFunction())
     val matchingFacts = input.factTable.getAllByFactType(expr.factTypeSet)
     // facts will always be added as their own evidence when used, so we do not need to add them to the evidence here
-    val subInput = input.withFoldableValue[SortedSet, TypedFact[T]](matchingFacts)
+    val subInput = input.withFoldableValue[Set, TypedFact[T]](matchingFacts)
     val subResult = withMatchingFactsFn(subInput)
     val postParam = expr.capture.foldToParam(expr, inputFactTable, subResult.output, subResult.param :: Nil)
     ExprResult.WithFactsOfType(

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/evaluator/InterpretExprAsFunction.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/evaluator/InterpretExprAsFunction.scala
@@ -218,6 +218,16 @@ final class InterpretExprAsFunction[F[_] : Foldable, V, P]
     }
   }
 
+  override def visitOutputIsEmpty[M[_] : Foldable, R](
+    expr: Expr.OutputIsEmpty[F, V, M, R, P],
+  ): Input[F, V] => ExprResult[F, V, Boolean, P] = { input =>
+    val inputResult = expr.inputExpr.visit(this)(input)
+    val isEmpty = inputResult.output.value.isEmpty
+    resultOfPureExpr(expr, input, isEmpty, inputResult.output.evidence) {
+      ExprResult.OutputIsEmpty(_, _, inputResult)
+    }
+  }
+
   override def visitOutputWithinSet[R](
     expr: Expr.OutputWithinSet[F, V, R, P],
   ): Input[F, V] => ExprResult[F, V, Boolean, P] = { input =>

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/extras/CaptureTimeRange.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/extras/CaptureTimeRange.scala
@@ -6,16 +6,14 @@ import com.rallyhealth.vapors.factfilter.data.TypedFact
 import com.rallyhealth.vapors.factfilter.dsl.CaptureP
 import com.rallyhealth.vapors.factfilter.evaluator.InterpretExprAsFunction
 
-import scala.collection.immutable.SortedSet
-
 object CaptureTimeRange extends CaptureP.AsMonoidCompanion[TimeRange] {
 
   implicit def captureTimeRangeFromFacts[T : ExtractInstant, R]: CaptureP.AsMonoidFromFactsOfType[T, R, TimeRange] = {
     new CaptureP.AsMonoidFromFactsOfType[T, R, TimeRange] {
 
       override protected def foldWithParentParam(
-        expr: Expr[SortedSet, TypedFact[T], R, TimeRange],
-        input: InterpretExprAsFunction.Input[SortedSet, TypedFact[T]],
+        expr: Expr[Set, TypedFact[T], R, TimeRange],
+        input: InterpretExprAsFunction.Input[Set, TypedFact[T]],
         output: InterpretExprAsFunction.Output[R],
         processedChildren: TimeRange,
       ): Eval[TimeRange] = {

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/Example.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/Example.scala
@@ -85,6 +85,14 @@ object Example {
     val Weight = FactTypeSet.of(WeightMeasurement, WeightSelfReported)
   }
 
+  final object Tags {
+    val asthma = FactTypes.Tag("asthma")
+    val obeseBmi = FactTypes.Tag("obese_bmi")
+    val normalBmi = FactTypes.Tag("normal_bmi")
+    val smoker = FactTypes.Tag("smoker")
+    val nonSmoker = FactTypes.Tag("non_smoker")
+  }
+
   final object JoeSchmoe {
     val name = FactTypes.Name("Joe Schmoe")
     val age = FactTypes.Age(32)

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/FilterOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/FilterOutputSpec.scala
@@ -1,0 +1,152 @@
+package com.rallyhealth.vapors.factfilter.evaluator
+
+import com.rallyhealth.vapors.factfilter.Example.{FactTypes, Tags}
+import com.rallyhealth.vapors.factfilter.data.{Evidence, FactTable}
+import org.scalatest.wordspec.AnyWordSpec
+import com.rallyhealth.vapors.factfilter.dsl.ExprDsl._
+
+class FilterOutputSpec extends AnyWordSpec {
+
+  private val sampleFactTable = FactTable(Seq(Tags.smoker, Tags.asthma, Tags.normalBmi))
+
+  "Expr.FilterOutput" when {
+
+    "using containsAny op" should {
+
+      "return 'true' when the fact table contains a superset of the given set" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.toList.map(_.value).containsAny(Set(Tags.asthma).map(_.value))
+        }
+        val res = eval(sampleFactTable)(q)
+        assert(res.output.value)
+      }
+
+      "return the correct evidence for the facts that contain a superset of the given set" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.toList.map(_.value).containsAny(Set(Tags.asthma).map(_.value))
+        }
+        val res = eval(sampleFactTable)(q)
+        pendingUntilFixed {
+          assertResult(Evidence(Tags.asthma))(res.output.evidence)
+        }
+      }
+
+      "return 'true' when the fact table contains a subset of the given set" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.toList.map(_.value).containsAny(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+        }
+        val res = eval(sampleFactTable)(q)
+        assert(res.output.value)
+      }
+
+      "return the correct evidence for the facts that contain a subset of the given set" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.toList.map(_.value).containsAny(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+        }
+        val res = eval(sampleFactTable)(q)
+        pendingUntilFixed {
+          assertResult(Evidence(Tags.asthma))(res.output.evidence)
+        }
+      }
+
+      "return 'false' when the facts do not contain anything in the given set" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.toList.map(_.value).containsAny(Set(Tags.obeseBmi).map(_.value))
+        }
+        val res = eval(sampleFactTable)(q)
+        assert(!res.output.value)
+      }
+
+      "return empty evidence when the fact table does not contain anything in the given set" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.toList.map(_.value).containsAny(Set(Tags.obeseBmi).map(_.value))
+        }
+        val res = eval(sampleFactTable)(q)
+        pendingUntilFixed {
+          assert(res.output.evidence.isEmpty)
+        }
+      }
+    }
+
+    "using filter op" should {
+
+      "return all matching facts from a given subset" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.filter(Set(Tags.asthma))
+        }
+        val res = eval(sampleFactTable)(q)
+        assertResult(Set(Tags.asthma))(res.output.value)
+      }
+
+      "return all matching values from a given subset" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.toList.map(_.value).filter(Set(Tags.asthma).map(_.value))
+        }
+        val res = eval(sampleFactTable)(q)
+        assertResult(List(Tags.asthma).map(_.value))(res.output.value)
+      }
+
+      "return the correct evidence for the matching values from a given subset" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.toList.map(_.value).filter(Set(Tags.asthma).map(_.value))
+        }
+        val res = eval(sampleFactTable)(q)
+        pendingUntilFixed {
+          assertResult(Evidence(Tags.asthma))(res.output.evidence)
+        }
+      }
+
+      "return all matching facts from a given superset" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.filter(Set(Tags.asthma, Tags.obeseBmi))
+        }
+        val res = eval(sampleFactTable)(q)
+        assertResult(Set(Tags.asthma))(res.output.value)
+      }
+
+      "return the matching values from a given superset" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.toList.map(_.value).filter(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+        }
+        val res = eval(sampleFactTable)(q)
+        assertResult(List(Tags.asthma).map(_.value))(res.output.value)
+      }
+
+      "return the correct evidence for the matching values from a given superset" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.toList.map(_.value).filter(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+        }
+        val res = eval(sampleFactTable)(q)
+        pendingUntilFixed {
+          assertResult(Evidence(Tags.asthma))(res.output.evidence)
+        }
+      }
+
+      "return an empty list of facts when given a set that contains no common elements" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.filter(Set(Tags.obeseBmi))
+        }
+        val res = eval(sampleFactTable)(q)
+        assert(res.output.value.isEmpty)
+      }
+
+      "return an empty list of values when given a set that contains no common elements" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.toList.map(_.value).filter(Set(Tags.obeseBmi).map(_.value))
+        }
+        val res = eval(sampleFactTable)(q)
+        assert(res.output.value.isEmpty)
+      }
+
+      "return empty evidence when given a set that contains no common elements" in {
+        val q = withFactsOfType(FactTypes.Tag).where { facts =>
+          facts.toList.map(_.value).filter(Set(Tags.obeseBmi).map(_.value))
+        }
+        val res = eval(sampleFactTable)(q)
+        pendingUntilFixed {
+          assert(res.output.evidence.isEmpty)
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/OutputWithinWindowSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/OutputWithinWindowSpec.scala
@@ -1,0 +1,41 @@
+package com.rallyhealth.vapors.factfilter.evaluator
+
+import com.rallyhealth.vapors.factfilter.data.FactTable
+import org.scalatest.wordspec.AnyWordSpec
+import com.rallyhealth.vapors.factfilter.dsl.ExprDsl._
+
+class OutputWithinWindowSpec extends AnyWordSpec {
+
+  "Expr.OutputWithinWindow" when {
+
+    "using the === operator" should {
+
+      "return 'true' when the values are equal" in {
+        val q = const(2 + 2) === 4
+        val result = eval(FactTable.empty)(q)
+        assert(result.output.value)
+      }
+
+      "return 'false' when the values are not equal" in {
+        val q = const(2 + 2) === 5
+        val result = eval(FactTable.empty)(q)
+        assert(!result.output.value)
+      }
+    }
+
+    "using the !== operator" should {
+
+      "return 'false' when the values are equal" in {
+        val q = const(2 + 2) !== 4
+        val result = eval(FactTable.empty)(q)
+        assert(!result.output.value)
+      }
+
+      "return 'true' when the values are not equal" in {
+        val q = const(2 + 2) !== 5
+        val result = eval(FactTable.empty)(q)
+        assert(result.output.value)
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Add `FilterOutput` expression node for filtering a collection of values down to a given set
- Add `OutputIsEmpty` expression node for converting a collection to a boolean, returning whether it is empty or not
- Update `OutputWithinWindow` to support `equalTo`, `===`, and `!==` operations
- Add `Window.equalTo` method that creates an inclusive range
- Add unit tests that ignore evidence tracking