### PR TITLE
Revert to Seq instead of SortedSet for facts

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
@@ -129,7 +129,7 @@ object Expr {
     */
   final case class WithFactsOfType[T, R, P](
     factTypeSet: FactTypeSet[T],
-    subExpr: Expr[Set, TypedFact[T], R, P],
+    subExpr: Expr[Seq, TypedFact[T], R, P],
     capture: CaptureP[Id, FactTable, R, P],
   ) extends Expr[Id, FactTable, R, P] {
     override def visit[G[_]](v: Visitor[Id, FactTable, P, G]): G[R] = v.visitWithFactsOfType(this)

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
@@ -99,7 +99,7 @@ object ExprResult {
   final case class WithFactsOfType[F[_], V, T, R, P](
     expr: Expr.WithFactsOfType[T, R, P],
     context: Context[F, V, R, P],
-    subResult: ExprResult[Set, TypedFact[T], R, P],
+    subResult: ExprResult[Seq, TypedFact[T], R, P],
   ) extends ExprResult[F, V, R, P] {
     override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitWithFactsOfType(this)
   }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/Evidence.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/Evidence.scala
@@ -1,13 +1,13 @@
 package com.rallyhealth.vapors.factfilter.data
 
+import cats.Monoid
 import cats.data.NonEmptySet
 import cats.instances.order._
-import cats.{Monoid, Order}
 
 import scala.annotation.tailrec
 import scala.collection.immutable.SortedSet
 
-final class Evidence private (val factSet: SortedSet[Fact]) extends AnyVal {
+final class Evidence private (val factSet: Set[Fact]) extends AnyVal {
 
   def isEmpty: Boolean = factSet.isEmpty
   def nonEmpty: Boolean = factSet.nonEmpty
@@ -15,11 +15,7 @@ final class Evidence private (val factSet: SortedSet[Fact]) extends AnyVal {
   @inline def ++(that: Evidence): Evidence = union(that)
   @inline def |(that: Evidence): Evidence = union(that)
 
-  def ofType[T](
-    factTypeSet: FactTypeSet[T],
-  )(implicit
-    orderFacts: Order[TypedFact[T]],
-  ): Option[NonEmptySet[TypedFact[T]]] = {
+  def ofType[T](factTypeSet: FactTypeSet[T]): Option[NonEmptySet[TypedFact[T]]] = {
     val matchingFacts = SortedSet.from(this.factSet.iterator.collect(factTypeSet.collector))
     NonEmptySet.fromSet(matchingFacts)
   }
@@ -57,14 +53,14 @@ final class Evidence private (val factSet: SortedSet[Fact]) extends AnyVal {
 
 object Evidence {
 
-  def unapply(evidence: Evidence): Some[SortedSet[Fact]] = Some(evidence.factSet)
+  def unapply(evidence: Evidence): Some[Set[Fact]] = Some(evidence.factSet)
 
   @inline final def apply(facts: FactOrFactSet*): Evidence = {
     if (facts.isEmpty) none
     else new Evidence(FactOrFactSet.flatten(facts))
   }
 
-  final val none = new Evidence(SortedSet.empty[Fact])
+  final val none = new Evidence(Set.empty)
 
   /**
     * Convert any given value into [[Evidence]] by inspecting whether it is a fact or valid collection of facts.

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/Fact.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/Fact.scala
@@ -73,13 +73,13 @@ object TypedFact {
     case DerivedFactOfType(typeInfo, value, _) => Some((typeInfo, value))
   }
 
-  def orderByTypedFactValue[T]: Order[TypedFact[T]] = { (x, y) =>
+  def orderTypedFactByValue[T]: Order[TypedFact[T]] = { (x, y) =>
     x.typeInfo.order.compare(x.value, y.value)
   }
 
-  implicit def order[T](implicit orderFactNames: Order[String]): Order[TypedFact[T]] = { (x, y) =>
+  implicit def orderFactByNameThenValue[T](implicit orderFactNames: Order[String]): Order[TypedFact[T]] = { (x, y) =>
     orderFactNames.compare(x.typeInfo.name, y.typeInfo.name) match {
-      case 0 => orderByTypedFactValue[T].compare(x, y)
+      case 0 => orderTypedFactByValue[T].compare(x, y)
       case orderByName => orderByName
     }
   }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/FactOrFactSet.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/FactOrFactSet.scala
@@ -1,20 +1,15 @@
 package com.rallyhealth.vapors.factfilter.data
 
-import cats.Order
-import cats.instances.order._
-
-import scala.collection.immutable.SortedSet
-
-final class FactOrFactSet private[FactOrFactSet] (val toSortedSet: SortedSet[Fact]) extends AnyVal
+final class FactOrFactSet private[FactOrFactSet] (val toSet: Set[Fact]) extends AnyVal
 
 object FactOrFactSet {
 
-  implicit def setOfOneFact(fact: Fact)(implicit order: Order[Fact]): FactOrFactSet = new FactOrFactSet(SortedSet(fact))
+  implicit def setOfOneFact(fact: Fact): FactOrFactSet = new FactOrFactSet(Set(fact))
 
-  implicit def iterableSetOfFacts(facts: Iterable[Fact])(implicit order: Order[Fact]): FactOrFactSet =
-    new FactOrFactSet(SortedSet.from(facts))
+  implicit def iterableSetOfFacts(facts: Iterable[Fact]): FactOrFactSet =
+    new FactOrFactSet(Set.from(facts))
 
   def flatten(factOrFactSets: Iterable[FactOrFactSet]): FactSet = {
-    factOrFactSets.foldLeft(FactSet.empty)(_ | _.toSortedSet)
+    factOrFactSets.foldLeft(FactSet.empty)(_ | _.toSet)
   }
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/FactSet.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/FactSet.scala
@@ -1,23 +1,20 @@
 package com.rallyhealth.vapors.factfilter.data
 
-import cats.{Foldable, Order}
-import cats.instances.order._
-
-import scala.collection.immutable.SortedSet
+import cats.Foldable
 
 /**
   * @see [[FactSet]]
   */
 object FactSet {
 
-  final val empty: FactSet = SortedSet.empty[Fact]
+  final val empty: FactSet = Set.empty[Fact]
 
-  @inline final def apply(facts: Fact*)(implicit order: Order[Fact]): FactSet = SortedSet.from(facts)
+  @inline final def apply(facts: Fact*): FactSet = Set.from(facts)
 
-  @inline final def from(facts: IterableOnce[Fact])(implicit order: Order[Fact]): FactSet = SortedSet.from(facts)
+  @inline final def from(facts: IterableOnce[Fact]): FactSet = Set.from(facts)
 
-  @inline final def fromFoldable[F[_] : Foldable](facts: F[Fact])(implicit order: Order[Fact]): FactSet = {
-    SortedSet.from(Foldable[F].toIterable(facts))
+  @inline final def fromFoldable[F[_] : Foldable](facts: F[Fact]): FactSet = {
+    Set.from(Foldable[F].toIterable(facts))
   }
 }
 
@@ -26,9 +23,9 @@ object FactSet {
   */
 object TypedFactSet {
 
-  @inline final def empty[T : OrderTypedFacts]: TypedFactSet[T] = SortedSet.empty[TypedFact[T]]
+  @inline final def empty[T]: TypedFactSet[T] = Set.empty[TypedFact[T]]
 
-  @inline final def apply[T : OrderTypedFacts](facts: TypedFact[T]*): TypedFactSet[T] = SortedSet.from(facts)
+  @inline final def apply[T](facts: TypedFact[T]*): TypedFactSet[T] = Set.from(facts)
 
-  @inline final def from[T : OrderTypedFacts](facts: Iterable[TypedFact[T]]): TypedFactSet[T] = SortedSet.from(facts)
+  @inline final def from[T](facts: Iterable[TypedFact[T]]): TypedFactSet[T] = Set.from(facts)
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/package.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/data/package.scala
@@ -4,8 +4,6 @@ import cats.Order
 import cats.data.NonEmptyList
 import com.rallyhealth.vapors.core.data.NamedLens
 
-import scala.collection.immutable.SortedSet
-
 package object data {
 
   /**
@@ -18,14 +16,14 @@ package object data {
   /**
     * An ordered set of untyped [[Fact]]s.
     */
-  final type FactSet = SortedSet[Fact]
+  final type FactSet = Set[Fact]
 
   /**
     * An ordered set of [[TypedFact]]s.
     *
     * @note not to be confused with a [[FactTypeSet]] (which is a set of [[FactType]]s, with not values)
     */
-  final type TypedFactSet[T] = SortedSet[TypedFact[T]]
+  final type TypedFactSet[T] = Set[TypedFact[T]]
 
   /**
     * A [[NamedLens]] defined over a [[TypedFact]] of a known type.

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/CaptureP.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/CaptureP.scala
@@ -36,7 +36,7 @@ object CaptureP extends CaptureUnitLowPriorityImplicit {
   /**
     * Captures the type parameter from facts with a value of type [[T]].
     */
-  trait FromFactsOfType[T, R, P] extends CaptureP[Set, TypedFact[T], R, P]
+  trait FromFactsOfType[T, R, P] extends CaptureP[Seq, TypedFact[T], R, P]
 
   /**
     * Captures the type parameter from facts with a value of type [[T]] (assuming [[P]] is a [[Monoid]])
@@ -44,7 +44,7 @@ object CaptureP extends CaptureUnitLowPriorityImplicit {
     * @see [[AsMonoid]]
     */
   abstract class AsMonoidFromFactsOfType[T, R, P : Monoid]
-    extends AsMonoid[Set, TypedFact[T], R, P]
+    extends AsMonoid[Seq, TypedFact[T], R, P] // TODO: Use Iterable instead of Seq?
     with FromFactsOfType[T, R, P]
 
   // TODO: This is not very safe. Nodes will often combine the params of their input expressions and sub expressions.

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprDsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprDsl.scala
@@ -2,7 +2,6 @@ package com.rallyhealth.vapors.factfilter.dsl
 
 import cats.data.NonEmptyList
 import cats.{Foldable, Id, Monoid}
-import com.rallyhealth.vapors.core.algebra.Expr.Definition
 import com.rallyhealth.vapors.core.algebra.{Expr, ExprResult}
 import com.rallyhealth.vapors.core.data.{NamedLens, Window}
 import com.rallyhealth.vapors.core.logic.{Conjunction, Disjunction, Negation}
@@ -20,7 +19,7 @@ object ExprDsl extends ExprBuilderSyntax with ExprBuilderCatsInstances {
   type RootExpr[R, P] = Expr[Id, FactTable, R, P]
 
   type CaptureRootExpr[R, P] = CaptureP[Id, FactTable, R, P]
-  type CaptureFromFacts[T, P] = CaptureP[Set, TypedFact[T], Set[TypedFact[T]], P]
+  type CaptureFromFacts[T, P] = CaptureP[Seq, TypedFact[T], Seq[TypedFact[T]], P]
 
   import InterpretExprAsFunction._
 
@@ -158,7 +157,7 @@ object ExprDsl extends ExprBuilderSyntax with ExprBuilderCatsInstances {
   ) {
 
     def where[M[_], U](
-      buildSubExpr: ExprBuilder.FoldableFn[Set, TypedFact[T], M, U, P],
+      buildSubExpr: ExprBuilder.FoldableFn[Seq, TypedFact[T], M, U, P],
     )(implicit
       postResult: CaptureRootExpr[M[U], P],
     ): RootExpr[M[U], P] =
@@ -171,8 +170,8 @@ object ExprDsl extends ExprBuilderSyntax with ExprBuilderCatsInstances {
     def returnInput(
       implicit
       postInput: CaptureFromFacts[T, P],
-      postResult: CaptureRootExpr[Set[TypedFact[T]], P],
-    ): RootExpr[Set[TypedFact[T]], P] =
+      postResult: CaptureRootExpr[Seq[TypedFact[T]], P],
+    ): RootExpr[Seq[TypedFact[T]], P] =
       Expr.WithFactsOfType(factTypeSet, input(postInput), postResult)
   }
 

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/evaluator/InterpretExprAsFunction.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/evaluator/InterpretExprAsFunction.scala
@@ -315,9 +315,9 @@ final class InterpretExprAsFunction[F[_] : Foldable, V, P]
     import alleycats.std.set._
     val inputFactTable = input.withValue(input.factTable)
     val withMatchingFactsFn = expr.subExpr.visit(InterpretExprAsFunction())
-    val matchingFacts = input.factTable.getAllByFactType(expr.factTypeSet)
+    val matchingFacts = input.factTable.getSortedSeq(expr.factTypeSet)
     // facts will always be added as their own evidence when used, so we do not need to add them to the evidence here
-    val subInput = input.withFoldableValue[Set, TypedFact[T]](matchingFacts)
+    val subInput = input.withFoldableValue[Seq, TypedFact[T]](matchingFacts)
     val subResult = withMatchingFactsFn(subInput)
     val postParam = expr.capture.foldToParam(expr, inputFactTable, subResult.output, subResult.param :: Nil)
     ExprResult.WithFactsOfType(

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/extras/CaptureTimeRange.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/extras/CaptureTimeRange.scala
@@ -12,8 +12,8 @@ object CaptureTimeRange extends CaptureP.AsMonoidCompanion[TimeRange] {
     new CaptureP.AsMonoidFromFactsOfType[T, R, TimeRange] {
 
       override protected def foldWithParentParam(
-        expr: Expr[Set, TypedFact[T], R, TimeRange],
-        input: InterpretExprAsFunction.Input[Set, TypedFact[T]],
+        expr: Expr[Seq, TypedFact[T], R, TimeRange],
+        input: InterpretExprAsFunction.Input[Seq, TypedFact[T]],
         output: InterpretExprAsFunction.Output[R],
         processedChildren: TimeRange,
       ): Eval[TimeRange] = {

--- a/core/src/test/scala/com/rallyhealth/vapors/core/data/FactTableSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/data/FactTableSpec.scala
@@ -1,0 +1,37 @@
+package com.rallyhealth.vapors.core.data
+
+import com.rallyhealth.vapors.factfilter.Example._
+import com.rallyhealth.vapors.factfilter.data.{FactTable, TypedFact}
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.Instant
+
+class FactTableSpec extends AnyWordSpec {
+
+  "FactTable" when {
+
+    "given facts that have the same value sort order" should {
+      val now = Instant.now()
+      val measurementsAtSameTime = Seq(
+        GenericMeasurement("systolic", 120, "mmHg", now),
+        GenericMeasurement("diastolic", 80, "mmHg", now),
+      ).map(FactTypes.GenericMeasurement(_))
+      val unsortedMeasurements = measurementsAtSameTime.toSet
+      // GenericMeasurements are only sorted by timestamp, so these should all produce a comparison of 0
+      val sortedMeasurements =
+        measurementsAtSameTime.sorted(TypedFact.orderTypedFactByValue[GenericMeasurement].toOrdering)
+
+      "not use that Order instance to remove duplicates" in {
+        assertResult(unsortedMeasurements) {
+          FactTable(measurementsAtSameTime).getSet(FactTypes.GenericMeasurement)
+        }
+      }
+
+      "return the results as a Seq in the expected sort order" in {
+        assertResult(sortedMeasurements) {
+          FactTable(measurementsAtSameTime).getSortedSeq(FactTypes.GenericMeasurement)
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/Example.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/Example.scala
@@ -67,12 +67,20 @@ object Example {
     override def unit: String = "lbs"
   }
 
+  final case class GenericMeasurement(
+    name: String,
+    value: Double,
+    unit: String,
+    timestamp: Instant,
+  ) extends Measurement
+
   final object FactTypes {
     val Name = FactType[String]("name")
     val Age = FactType[Int]("age")
     val Role = FactType[Role]("role")
     val BirthYear = FactType[Int]("year_of_birth")
     val DateOfBirth = FactType[LocalDate]("date_of_birth")
+    val GenericMeasurement = FactType[GenericMeasurement]("generic_measurement")
     val WeightMeasurement = FactType[WeightMeasurementLbs]("weight_measurement")
     val WeightSelfReported = FactType[WeightMeasurementLbs]("weight_self_reported")
     val BloodPressureMeasurement = FactType[BloodPressure]("blood_pressure")

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/CapturePSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/CapturePSpec.scala
@@ -4,9 +4,10 @@ import com.rallyhealth.vapors.factfilter.Example.{FactTypes, JoeSchmoe}
 import com.rallyhealth.vapors.factfilter.data.Evidence
 import com.rallyhealth.vapors.factfilter.dsl.ExprDsl._
 import com.rallyhealth.vapors.factfilter.extras.TimeRange
+import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.wordspec.AnyWordSpec
 
-class CapturePSpec extends AnyWordSpec {
+class CapturePSpec extends AnyWordSpec with TypeCheckedTripleEquals {
 
   "CaptureP" should {
 

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/FilterOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/FilterOutputSpec.scala
@@ -4,6 +4,7 @@ import com.rallyhealth.vapors.factfilter.Example.{FactTypes, Tags}
 import com.rallyhealth.vapors.factfilter.data.{Evidence, FactTable}
 import org.scalatest.wordspec.AnyWordSpec
 import com.rallyhealth.vapors.factfilter.dsl.ExprDsl._
+import org.scalatest.matchers.should.Matchers._
 
 class FilterOutputSpec extends AnyWordSpec {
 
@@ -75,7 +76,7 @@ class FilterOutputSpec extends AnyWordSpec {
           facts.filter(Set(Tags.asthma))
         }
         val res = eval(sampleFactTable)(q)
-        assertResult(Set(Tags.asthma))(res.output.value)
+        res.output.value should contain theSameElementsAs Seq(Tags.asthma)
       }
 
       "return all matching values from a given subset" in {
@@ -83,7 +84,7 @@ class FilterOutputSpec extends AnyWordSpec {
           facts.toList.map(_.value).filter(Set(Tags.asthma).map(_.value))
         }
         val res = eval(sampleFactTable)(q)
-        assertResult(List(Tags.asthma).map(_.value))(res.output.value)
+        res.output.value should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
       }
 
       "return the correct evidence for the matching values from a given subset" in {
@@ -101,7 +102,7 @@ class FilterOutputSpec extends AnyWordSpec {
           facts.filter(Set(Tags.asthma, Tags.obeseBmi))
         }
         val res = eval(sampleFactTable)(q)
-        assertResult(Set(Tags.asthma))(res.output.value)
+        res.output.value should contain theSameElementsAs Seq(Tags.asthma)
       }
 
       "return the matching values from a given superset" in {
@@ -109,7 +110,7 @@ class FilterOutputSpec extends AnyWordSpec {
           facts.toList.map(_.value).filter(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
         }
         val res = eval(sampleFactTable)(q)
-        assertResult(List(Tags.asthma).map(_.value))(res.output.value)
+        res.output.value should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
       }
 
       "return the correct evidence for the matching values from a given superset" in {


### PR DESCRIPTION
**Problem:**
When adding facts to the `FactTable`, the library was using the given `Order` for that type to determine duplicates. This was not the intended purpose for the defined `Order`, so it was causing some non-duplicate facts to get removed from the `FactTable`. Prior to this, we switched from using a `SortedSet` to using a `Set` to store the facts (for other reasons). Because of this, it would be easy to just switch to using a `Set` for storage, and rely on equality checking *only*. Now, when receiving the facts as an input, the sequence will be sorted by the `FactType.order`, but it will not remove any instances when the comparator returns 0. In addition a `.toSet` operation was added to the builder for backwards compatibility and possibly other benefits of using a `Set` in expressions.

**Fixes:**
- Use `Seq[TypedFact[T]]` input for `withFactsOfType` builder
- Add method to get a `SortedSet` of facts (returned as `Set`) from the builder