### PR TITLE
Combine the lenses of consecutive calls to .get() in ValExprBuilder

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/CaptureP.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/CaptureP.scala
@@ -92,12 +92,15 @@ object CaptureP extends CaptureUnitLowPriorityImplicit {
     *       to pass the captured params from this node's children up to the next parent.
     */
   final class AsMonoidAndPass[F[_], V, R, P : Monoid] extends AsMonoid[F, V, R, P] {
+
     override protected def foldWithParentParam(
       expr: Expr[F, V, R, P],
       input: Input[F, V],
       output: Output[R],
       processedChildren: P,
     ): Eval[P] = Eval.now(processedChildren)
+
+    override def toString: String = "captureParamAndPass"
   }
 
   /**
@@ -111,5 +114,15 @@ object CaptureP extends CaptureUnitLowPriorityImplicit {
 
 sealed trait CaptureUnitLowPriorityImplicit {
 
-  implicit def captureUnit[F[_], V, R]: CaptureP[F, V, R, Unit] = (_, _, _, _) => Eval.Unit
+  implicit def captureUnit[F[_], V, R]: CaptureP[F, V, R, Unit] = new CaptureP[F, V, R, Unit] {
+
+    override final def foldToParam(
+      expr: Expr[F, V, R, Unit],
+      input: Input[F, V],
+      output: Output[R],
+      subExprParams: List[Eval[Unit]],
+    ): Eval[Unit] = Eval.Unit
+
+    override final def toString: String = "captureUnit"
+  }
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
@@ -190,7 +190,16 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
     captureResult: CaptureP[Id, V, N[X], P],
   ): Expr[Id, V, N[X], P] = {
     val lens = buildLens(NamedLens.id[R])
-    Expr.SelectFromOutput(returnOutput, lens, captureResult)
+    // if the previous node was a SelectFromOutput, then combine the lenses and produce a single node
+    returnOutput match {
+      case prev: Expr.SelectFromOutput[Id, V, s, R, P] =>
+        // capture the starting type as an existential type parameter 's'
+        // it is ignored in the return type after the compile proves that this code is safe
+        Expr.SelectFromOutput[Id, V, s, N[X], P](prev.inputExpr, prev.lens.andThen(lens), captureResult)
+      case _ =>
+        // otherwise, build the lens as a new SelectFromOutput node
+        Expr.SelectFromOutput(returnOutput, lens, captureResult)
+    }
   }
 
   def get[X](

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilderCatsInstances.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilderCatsInstances.scala
@@ -9,4 +9,8 @@ trait ExprBuilderCatsInstances {
   implicit def traverseSet: Traverse[Set] = alleycats.std.set.alleyCatsSetTraverse
 
   implicit def traverseFilterSet: TraverseFilter[Set] = alleycats.std.set.alleyCatsSetTraverseFilter
+
+  implicit def traverseMap[K]: Traverse[Map[K, *]] = alleycats.std.map.alleycatsStdInstancesForMap
+
+  implicit def traverseFilterMap[K]: TraverseFilter[Map[K, *]] = alleycats.std.map.alleycatsStdMapTraverseFilter
 }

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilderSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilderSpec.scala
@@ -1,0 +1,60 @@
+package com.rallyhealth.vapors.factfilter.dsl
+
+import com.rallyhealth.vapors.core.algebra.Expr
+import com.rallyhealth.vapors.core.data.DataPath
+import com.rallyhealth.vapors.factfilter.Example.{FactTypes, GenericMeasurement, Probs}
+import com.rallyhealth.vapors.factfilter.dsl.ExprDsl._
+import org.scalatest.Inside.inside
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.Instant
+
+class ExprBuilderSpec extends AnyWordSpec {
+
+  "ValExprBuilder" should {
+
+    "combine lenses from chained .get() methods" in {
+      val q = withFactsOfType(FactTypes.GenericMeasurement).where {
+        _.exists {
+          _.get(_.select(_.value)).get(_.select(_.value)) > 0.0
+        }
+      }
+      inside(q) {
+        case Expr.WithFactsOfType(_, Expr.ExistsInOutput(_, condExpr, _), _) =>
+          inside(condExpr) {
+            case Expr.OutputWithinWindow(Expr.SelectFromOutput(_, valueLens, _), _, _) =>
+              assertResult(DataPath.empty.atField("value").atField("value")) {
+                valueLens.path
+              }
+              val fact = FactTypes.GenericMeasurement(GenericMeasurement("example", 1.0, "m", Instant.now()))
+              assertResult(fact.value.value) {
+                valueLens.get(fact)
+              }
+          }
+      }
+    }
+
+    "combine lenses from .get() and .getFoldable() methods" in {
+      val q = withFactsOfType(FactTypes.ProbabilityToUse).where {
+        _.exists {
+          _.get(_.select(_.value)).getFoldable(_.select(_.scores)).isEmpty
+        }
+      }
+      inside(q) {
+        case Expr.WithFactsOfType(_, Expr.ExistsInOutput(_, condExpr, _), _) =>
+          inside(condExpr) {
+            case Expr.OutputIsEmpty(Expr.SelectFromOutput(_, valueLens, _), _) =>
+              assertResult(DataPath.empty.atField("value").atField("scores")) {
+                valueLens.path
+              }
+              val fact = FactTypes.ProbabilityToUse(Probs(Map()))
+              assertResult(fact.value.scores) {
+                valueLens.get(fact)
+              }
+          }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
When looking at the debug output of consecutive `.get` calls.

For example:
```scala
_.get(_.select(_.value)).getFoldable(_.scores)
```

It would be nice to see a single lens path: `_.value.scores`

This PR does so by matching on the previous node to see if it is a Select node, and then chains the lenses together and returns a single combined node. This optimizes the query while it is being built.

This PR also:

- Adds `Map` instances for foldable / filter to the ExprDsl
- Uses a better `.toString` for the standard `captureUnit` and `captureParamAndPass` instances (previously showed lambda + memory location, which was always the same and not helpful)

Depends on:
- [x] https://github.com/jeffmay/vapors/pull/33