### PR TITLE
Add Expr.TakeFromOutput, builder methods, and unit tests

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/data/Window.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/data/Window.scala
@@ -1,6 +1,8 @@
 package com.rallyhealth.vapors.core.data
 
+import alleycats.{Empty, Zero}
 import cats.data.Ior
+import cats.kernel.Monoid
 import cats.{Invariant, Order, Show}
 
 import scala.collection.immutable.NumericRange
@@ -16,6 +18,17 @@ object Window {
   import cats.syntax.functor._
   import cats.syntax.order._
   import cats.syntax.show._
+
+  def empty[A : Order : Empty]: Window[A] = new EmptyWindow[A]
+
+  private final class EmptyWindow[A : Order : Empty] extends Window[A] {
+    private val zero = Empty[A].empty
+    override val order: Order[A] = Order[A]
+    override def contains(value: A): Boolean = false
+    override def bounds: Ior[Above[A], Below[A]] =
+      Ior.Both(Above(zero, inclusiveLowerBound = false), Below(zero, inclusiveUpperBound = false))
+    override def toString: String = s"Window.empty($zero)"
+  }
 
   implicit object InvariantWindow extends Invariant[Window] {
     override def imap[A, B](fa: Window[A])(f: A => B)(g: B => A): Window[B] = {

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/Example.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/Example.scala
@@ -74,6 +74,15 @@ object Example {
     timestamp: Instant,
   ) extends Measurement
 
+  final case class TagsUpdate(
+    tags: Set[String],
+    timestamp: Instant,
+  ) extends HasTimestamp
+
+  final object TagsUpdate {
+    implicit val orderByLatestTimestamp: Order[TagsUpdate] = Order.by(_.timestamp)
+  }
+
   final object FactTypes {
     val Name = FactType[String]("name")
     val Age = FactType[Int]("age")
@@ -85,6 +94,7 @@ object Example {
     val WeightSelfReported = FactType[WeightMeasurementLbs]("weight_self_reported")
     val BloodPressureMeasurement = FactType[BloodPressure]("blood_pressure")
     val Tag = FactType[String]("tag")
+    val TagsUpdate = FactType[TagsUpdate]("tags_update")
     val ProbabilityToUse = FactType[Probs]("probability_to_use")
   }
 

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/TakeFromOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/TakeFromOutputSpec.scala
@@ -34,6 +34,36 @@ class TakeFromOutputSpec extends AnyWordSpec {
       }
     }
 
+    "using .take(n) with a negative number" should {
+
+      "return an empty list if the collection is empty" in {
+        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(-1))
+        val res = eval(FactTable.empty)(q)
+        assert(res.output.value.isEmpty)
+      }
+
+      "return the number of elements selected from the end of the list by fact ordering" in {
+        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(-1))
+        val res = eval(FactTable(updateABC, updateDEF))(q)
+        assertResult(Seq(updateABC))(res.output.value)
+      }
+
+      "return all the elements of the list by fact ordering when the number requested is greater than the size" in {
+        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(-3))
+        val res = eval(FactTable(updateABC, updateDEF))(q)
+        assertResult(Seq(updateDEF, updateABC))(res.output.value)
+      }
+    }
+
+    "using .take(n) with 0" should {
+
+      "return an empty collection" in {
+        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(0))
+        val res = eval(FactTable(updateABC, updateDEF))(q)
+        assertResult(Seq.empty)(res.output.value)
+      }
+    }
+
     "using .headOption" should {
 
       "return None if the collection is empty" in {

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/TakeFromOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/TakeFromOutputSpec.scala
@@ -1,0 +1,52 @@
+package com.rallyhealth.vapors.factfilter.evaluator
+
+import com.rallyhealth.vapors.factfilter.Example.{FactTypes, TagsUpdate}
+import com.rallyhealth.vapors.factfilter.data.FactTable
+import com.rallyhealth.vapors.factfilter.dsl.ExprDsl._
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.Instant
+
+class TakeFromOutputSpec extends AnyWordSpec {
+
+  "Expr.TakeFromOutput" when {
+    val updateABC = FactTypes.TagsUpdate(TagsUpdate(Set("A", "B", "C"), Instant.now().minusSeconds(60 * 60 * 24)))
+    val updateDEF = FactTypes.TagsUpdate(TagsUpdate(Set("D", "E", "F"), Instant.now()))
+
+    "using .take(n) with a positive number" should {
+
+      "return an empty list if the collection is empty" in {
+        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(1))
+        val res = eval(FactTable.empty)(q)
+        assert(res.output.value.isEmpty)
+      }
+
+      "return the number of elements selected from the start of the list by fact ordering" in {
+        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(1))
+        val res = eval(FactTable(updateABC, updateDEF))(q)
+        assertResult(Seq(updateDEF))(res.output.value)
+      }
+
+      "return all the elements of the list by fact ordering when the number requested is greater than the size" in {
+        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(3))
+        val res = eval(FactTable(updateABC, updateDEF))(q)
+        assertResult(Seq(updateDEF, updateABC))(res.output.value)
+      }
+    }
+
+    "using .headOption" should {
+
+      "return None if the collection is empty" in {
+        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.headOption)
+        val res = eval(FactTable.empty)(q)
+        assertResult(None)(res.output.value)
+      }
+
+      "return the head of the collection by fact ordering" in {
+        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.headOption)
+        val res = eval(FactTable(updateABC, updateDEF))(q)
+        assertResult(Some(updateDEF))(res.output.value)
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Add `Expr.TakeFromOutput`
- Add `.headOption` and `.take` operators to the builder
- Add `Window.empty`
- Add unit tests