### PR TITLE
Convert FilterOutput to take a condition expression

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
@@ -257,8 +257,7 @@ object Expr {
 
   final case class FilterOutput[F[_], V, M[_] : Foldable : FunctorFilter, R, P](
     inputExpr: Expr[F, V, M[R], P],
-    validValues: Set[R],
-    valuesAsEvidence: Boolean,
+    condExpr: Expr[Id, R, Boolean, P],
     capture: CaptureP[F, V, M[R], P],
   ) extends Expr[F, V, M[R], P] {
     override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitFilterOutput(this)

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
@@ -167,6 +167,7 @@ object ExprResult {
     expr: Expr.FilterOutput[F, V, M, R, P],
     context: Context[F, V, M[R], P],
     inputResult: ExprResult[F, V, M[R], P],
+    condResultList: List[ExprResult[Id, R, Boolean, P]],
   ) extends ExprResult[F, V, M[R], P] {
     override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitFilterOutput(this)
   }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
@@ -7,7 +7,6 @@ import com.rallyhealth.vapors.core.math.{Addition, Negative, Subtraction}
 import com.rallyhealth.vapors.factfilter.data.{Evidence, Fact, TypedFact}
 
 import scala.collection.Factory
-import scala.reflect.runtime.universe.{typeOf, TypeTag}
 
 sealed class ExprBuilder[F[_], V, M[_], U, P](val returnOutput: Expr[F, V, M[U], P]) {
 

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/ExprBuilder.scala
@@ -12,15 +12,15 @@ import scala.reflect.runtime.universe.{typeOf, TypeTag}
 sealed class ExprBuilder[F[_], V, M[_], U, P](val returnOutput: Expr[F, V, M[U], P]) {
 
   type CaptureResult[R] = CaptureP[F, V, R, P]
-  type CaptureCond = CaptureResult[Boolean]
 
   type CaptureInput[G[_]] = CaptureP[G, V, G[V], P]
+  type CaptureAllInputCond = CaptureResult[Boolean]
   type CaptureAllInput = CaptureInput[F]
   type CaptureEachInput = CaptureInput[Id]
 
-  type CaptureOutput[G[_]] = CaptureP[G, U, G[U], P]
-  type CaptureAllOutput = CaptureOutput[M]
-  type CaptureEachOutput = CaptureOutput[Id]
+  type CaptureEachOutputResult[R] = CaptureP[Id, U, R, P]
+  type CaptureEachOutput = CaptureEachOutputResult[U]
+  type CaptureEachOutputCond = CaptureEachOutputResult[Boolean]
 
   def returnInput(implicit captureInput: CaptureAllInput): Expr[F, V, F[V], P] = Expr.ReturnInput(captureInput)
 
@@ -155,7 +155,7 @@ sealed class FoldableExprBuilder[F[_] : Foldable, V, M[_] : Foldable, U, P](retu
 
   def isEmpty(
     implicit
-    captureResult: CaptureCond,
+    captureResult: CaptureAllInputCond,
   ): FoldInExprBuilder[F, V, Boolean, P] =
     new FoldInExprBuilder(Expr.OutputIsEmpty(returnOutput, captureResult))
 
@@ -163,7 +163,7 @@ sealed class FoldableExprBuilder[F[_] : Foldable, V, M[_] : Foldable, U, P](retu
     buildFn: ValExprBuilder[U, U, P] => ExprBuilder[Id, U, Id, Boolean, P],
   )(implicit
     postEachOutput: CaptureP[Id, U, U, P],
-    captureResult: CaptureCond,
+    captureResult: CaptureAllInputCond,
   ): FoldInExprBuilder[F, V, Boolean, P] = {
     val condExpr = buildFn(new ValExprBuilder(Expr.ReturnInput[Id, U, P](postEachOutput)))
     val next = Expr.ExistsInOutput(returnOutput, condExpr.returnOutput, captureResult)
@@ -171,25 +171,30 @@ sealed class FoldableExprBuilder[F[_] : Foldable, V, M[_] : Foldable, U, P](retu
   }
 
   def filter(
-    validValues: Set[U],
+    buildFn: ValExprBuilder[U, U, P] => ExprBuilder[Id, U, Id, Boolean, P],
   )(implicit
     filterM: FunctorFilter[M],
-    tt: TypeTag[U],
+    captureEachOutput: CaptureEachOutput,
     captureResult: CaptureResult[M[U]],
-  ): FoldableExprBuilder[F, V, M, U, P] =
-    new FoldableExprBuilder(Expr.FilterOutput(returnOutput, validValues, typeOf[U] <:< typeOf[Fact], captureResult))
+  ): FoldableExprBuilder[F, V, M, U, P] = {
+    val condExpr = buildFn(
+      new ValExprBuilder(Expr.ReturnInput[Id, U, P](captureEachOutput)),
+    )
+    new FoldableExprBuilder(Expr.FilterOutput(returnOutput, condExpr.returnOutput, captureResult))
+  }
 
   def containsAny(
     validValues: Set[U],
   )(implicit
     filterM: FunctorFilter[M],
-    tt: TypeTag[U],
+    captureEachOutput: CaptureEachOutput,
+    captureEachOutputCond: CaptureEachOutputCond,
     captureResult: CaptureResult[M[U]],
-    captureCond: CaptureCond,
+    captureCond: CaptureAllInputCond,
   ): FoldInExprBuilder[F, V, Boolean, P] =
     new FoldInExprBuilder(
       Expr.Not(
-        filter(validValues).isEmpty,
+        filter(_ in validValues).isEmpty,
         captureCond,
       ),
     )
@@ -305,7 +310,7 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
   def within(
     window: Window[R],
   )(implicit
-    captureResult: CaptureCond,
+    captureResult: CaptureAllInputCond,
   ): ValExprBuilder[V, Boolean, P] =
     new ValExprBuilder(ExprDsl.within(returnOutput, window))
 
@@ -313,7 +318,7 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
     value: R,
   )(implicit
     orderR: Order[R],
-    captureResult: CaptureCond,
+    captureResult: CaptureAllInputCond,
   ): ValExprBuilder[V, Boolean, P] =
     within(Window.equalTo(value))
 
@@ -321,7 +326,7 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
     value: R,
   )(implicit
     orderR: Order[R],
-    captureResult: CaptureCond,
+    captureResult: CaptureAllInputCond,
   ): ValExprBuilder[V, Boolean, P] =
     within(Window.equalTo(value))
 
@@ -329,7 +334,7 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
     value: R,
   )(implicit
     orderR: Order[R],
-    captureResult: CaptureCond,
+    captureResult: CaptureAllInputCond,
   ): ValExprBuilder[V, Boolean, P] =
     Expr.Not(within(Window.equalTo(value)), captureResult)
 
@@ -337,7 +342,7 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
     value: R,
   )(implicit
     orderR: Order[R],
-    captureResult: CaptureCond,
+    captureResult: CaptureAllInputCond,
   ): ValExprBuilder[V, Boolean, P] =
     within(Window.lessThan(value))
 
@@ -345,7 +350,7 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
     value: R,
   )(implicit
     orderR: Order[R],
-    captureResult: CaptureCond,
+    captureResult: CaptureAllInputCond,
   ): ValExprBuilder[V, Boolean, P] =
     within(Window.lessThanOrEqual(value))
 
@@ -353,7 +358,7 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
     value: R,
   )(implicit
     orderR: Order[R],
-    captureResult: CaptureCond,
+    captureResult: CaptureAllInputCond,
   ): ValExprBuilder[V, Boolean, P] =
     within(Window.greaterThan(value))
 
@@ -361,7 +366,7 @@ final class ValExprBuilder[V, R, P](returnOutput: Expr[Id, V, R, P])
     value: R,
   )(implicit
     orderR: Order[R],
-    captureResult: CaptureCond,
+    captureResult: CaptureAllInputCond,
   ): ValExprBuilder[V, Boolean, P] =
     within(Window.greaterThanOrEqual(value))
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/evaluator/InterpretExprAsFunction.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/evaluator/InterpretExprAsFunction.scala
@@ -190,7 +190,6 @@ final class InterpretExprAsFunction[F[_] : Foldable, V, P]
       mapFn(mapInput)
     }
     val allValues = allResults.map(_.output.value)
-    // TODO: Shouldn't I only look at the evidence of results that aren't empty?
     val (allEvidence, allParams) = allResults.foldMap { elemResult =>
       (elemResult.output.evidence, elemResult.param :: Nil)
     }

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/FilterOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/FilterOutputSpec.scala
@@ -8,11 +8,10 @@ import org.scalatest.matchers.should.Matchers._
 
 class FilterOutputSpec extends AnyWordSpec {
 
-  private val sampleFactTable = FactTable(Seq(Tags.smoker, Tags.asthma, Tags.normalBmi))
-
   "Expr.FilterOutput" when {
 
     "using with an 'OutputWithinSet' op" when {
+      val tagFacts = FactTable(Tags.smoker, Tags.asthma, Tags.normalBmi)
 
       "comparing facts" should {
 
@@ -20,7 +19,7 @@ class FilterOutputSpec extends AnyWordSpec {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
             facts.filter(_ in Set(Tags.asthma))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           res.output.value should contain theSameElementsAs Seq(Tags.asthma)
           assertResult(Evidence(Tags.asthma))(res.output.evidence)
         }
@@ -29,7 +28,7 @@ class FilterOutputSpec extends AnyWordSpec {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
             facts.filter(_ in Set(Tags.asthma, Tags.obeseBmi))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           res.output.value should contain theSameElementsAs Seq(Tags.asthma)
           assertResult(Evidence(Tags.asthma))(res.output.evidence)
         }
@@ -38,7 +37,7 @@ class FilterOutputSpec extends AnyWordSpec {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
             facts.filter(_ in Set(Tags.obeseBmi))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           assert(res.output.value.isEmpty)
           assert(res.output.evidence.isEmpty)
         }
@@ -48,17 +47,17 @@ class FilterOutputSpec extends AnyWordSpec {
 
         "return all matching values from a given subset" in {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.toList.map(_.value).filter(_ in Set(Tags.asthma).map(_.value))
+            facts.map(_.value).filter(_ in Set(Tags.asthma).map(_.value))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           res.output.value should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
         }
 
         "return the correct evidence for the matching values from a given subset" in {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.toList.map(_.value).filter(_ in Set(Tags.asthma).map(_.value))
+            facts.map(_.value).filter(_ in Set(Tags.asthma).map(_.value))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           pendingUntilFixed {
             // TODO: Merge this assertion the above unit test when it passes
             assertResult(Evidence(Tags.asthma))(res.output.evidence)
@@ -67,17 +66,17 @@ class FilterOutputSpec extends AnyWordSpec {
 
         "return the matching values from a given superset" in {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.toList.map(_.value).filter(_ in Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+            facts.map(_.value).filter(_ in Set(Tags.asthma, Tags.obeseBmi).map(_.value))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           res.output.value should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
         }
 
         "return the correct evidence for the matching values from a given superset" in {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.toList.map(_.value).filter(_ in Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+            facts.map(_.value).filter(_ in Set(Tags.asthma, Tags.obeseBmi).map(_.value))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           pendingUntilFixed {
             // TODO: Merge this assertion the above unit test when it passes
             assertResult(Evidence(Tags.asthma))(res.output.evidence)
@@ -86,9 +85,9 @@ class FilterOutputSpec extends AnyWordSpec {
 
         "return an empty list of values when given a set that contains no common elements" in {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.toList.map(_.value).filter(_ in Set(Tags.obeseBmi).map(_.value))
+            facts.map(_.value).filter(_ in Set(Tags.obeseBmi).map(_.value))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           assert(res.output.value.isEmpty)
           assert(res.output.evidence.isEmpty)
         }
@@ -98,17 +97,17 @@ class FilterOutputSpec extends AnyWordSpec {
 
         "return 'true' when the fact table contains a superset of the given set" in {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.toList.map(_.value).containsAny(Set(Tags.asthma).map(_.value))
+            facts.map(_.value).containsAny(Set(Tags.asthma).map(_.value))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           assert(res.output.value)
         }
 
         "return the correct evidence for the facts that contain a superset of the given set" in {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.toList.map(_.value).containsAny(Set(Tags.asthma).map(_.value))
+            facts.map(_.value).containsAny(Set(Tags.asthma).map(_.value))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           pendingUntilFixed {
             // TODO: Merge this assertion the above unit test when it passes
             assertResult(Evidence(Tags.asthma))(res.output.evidence)
@@ -117,17 +116,17 @@ class FilterOutputSpec extends AnyWordSpec {
 
         "return 'true' when the fact table contains a subset of the given set" in {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.toList.map(_.value).containsAny(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+            facts.map(_.value).containsAny(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           assert(res.output.value)
         }
 
         "return the correct evidence for the facts that contain a subset of the given set" in {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.toList.map(_.value).containsAny(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+            facts.map(_.value).containsAny(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           pendingUntilFixed {
             // TODO: Merge this assertion the above unit test when it passes
             assertResult(Evidence(Tags.asthma))(res.output.evidence)
@@ -136,9 +135,9 @@ class FilterOutputSpec extends AnyWordSpec {
 
         "return 'false' with no Evidence when the facts do not contain anything in the given set" in {
           val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.toList.map(_.value).containsAny(Set(Tags.obeseBmi).map(_.value))
+            facts.map(_.value).containsAny(Set(Tags.obeseBmi).map(_.value))
           }
-          val res = eval(sampleFactTable)(q)
+          val res = eval(tagFacts)(q)
           assert(!res.output.value)
           assert(res.output.evidence.isEmpty)
         }

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/FilterOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/FilterOutputSpec.scala
@@ -143,5 +143,58 @@ class FilterOutputSpec extends AnyWordSpec {
         }
       }
     }
+
+    "using with an 'OutputWithinRange' operator" should {
+      val low = FactTypes.Age(10)
+      val middle = FactTypes.Age(18)
+      val high = FactTypes.Age(85)
+      val numericFacts = FactTable(low, middle, high)
+
+      "return all values that match the condition" in {
+        val q = withFactsOfType(FactTypes.Age).where { facts =>
+          facts.map(_.value).filter(_ >= middle.value)
+        }
+        val res = eval(numericFacts)(q)
+        res.output.value should contain theSameElementsAs Seq(middle, high).map(_.value)
+      }
+
+      "return the correct evidence for the matching values from a given subset" in {
+        val q = withFactsOfType(FactTypes.Age).where { facts =>
+          facts.map(_.value).filter(_ >= middle.value)
+        }
+        val res = eval(numericFacts)(q)
+        pendingUntilFixed {
+          // TODO: Merge this assertion the above unit test when it passes
+          assertResult(Evidence(middle, high))(res.output.evidence)
+        }
+      }
+
+      "return all facts that match the condition" in {
+        val q = withFactsOfType(FactTypes.Age).where { facts =>
+          facts.filter(_.value >= middle.value)
+        }
+        val res = eval(numericFacts)(q)
+        res.output.value should contain theSameElementsAs Seq(middle, high)
+        assertResult(Evidence(middle, high))(res.output.evidence)
+      }
+
+      "return an empty list of values when none of the elements meet the condition" in {
+        val q = withFactsOfType(FactTypes.Age).where { facts =>
+          facts.map(_.value).filter(_ > high.value)
+        }
+        val res = eval(numericFacts)(q)
+        assert(res.output.value.isEmpty)
+        assert(res.output.evidence.isEmpty)
+      }
+
+      "return an empty list of facts when none meet the condition" in {
+        val q = withFactsOfType(FactTypes.Age).where { facts =>
+          facts.filter(_.value > high.value)
+        }
+        val res = eval(numericFacts)(q)
+        assert(res.output.value.isEmpty)
+        assert(res.output.evidence.isEmpty)
+      }
+    }
   }
 }

--- a/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/FilterOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/factfilter/evaluator/FilterOutputSpec.scala
@@ -12,139 +12,134 @@ class FilterOutputSpec extends AnyWordSpec {
 
   "Expr.FilterOutput" when {
 
-    "using containsAny op" should {
+    "using with an 'OutputWithinSet' op" when {
 
-      "return 'true' when the fact table contains a superset of the given set" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.toList.map(_.value).containsAny(Set(Tags.asthma).map(_.value))
-        }
-        val res = eval(sampleFactTable)(q)
-        assert(res.output.value)
-      }
+      "comparing facts" should {
 
-      "return the correct evidence for the facts that contain a superset of the given set" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.toList.map(_.value).containsAny(Set(Tags.asthma).map(_.value))
-        }
-        val res = eval(sampleFactTable)(q)
-        pendingUntilFixed {
+        "return all matching facts from a given subset" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.filter(_ in Set(Tags.asthma))
+          }
+          val res = eval(sampleFactTable)(q)
+          res.output.value should contain theSameElementsAs Seq(Tags.asthma)
           assertResult(Evidence(Tags.asthma))(res.output.evidence)
         }
-      }
 
-      "return 'true' when the fact table contains a subset of the given set" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.toList.map(_.value).containsAny(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
-        }
-        val res = eval(sampleFactTable)(q)
-        assert(res.output.value)
-      }
-
-      "return the correct evidence for the facts that contain a subset of the given set" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.toList.map(_.value).containsAny(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
-        }
-        val res = eval(sampleFactTable)(q)
-        pendingUntilFixed {
+        "return all matching facts from a given superset" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.filter(_ in Set(Tags.asthma, Tags.obeseBmi))
+          }
+          val res = eval(sampleFactTable)(q)
+          res.output.value should contain theSameElementsAs Seq(Tags.asthma)
           assertResult(Evidence(Tags.asthma))(res.output.evidence)
         }
-      }
 
-      "return 'false' when the facts do not contain anything in the given set" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.toList.map(_.value).containsAny(Set(Tags.obeseBmi).map(_.value))
-        }
-        val res = eval(sampleFactTable)(q)
-        assert(!res.output.value)
-      }
-
-      "return empty evidence when the fact table does not contain anything in the given set" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.toList.map(_.value).containsAny(Set(Tags.obeseBmi).map(_.value))
-        }
-        val res = eval(sampleFactTable)(q)
-        pendingUntilFixed {
+        "return an empty list of facts when given a set that contains no common elements" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.filter(_ in Set(Tags.obeseBmi))
+          }
+          val res = eval(sampleFactTable)(q)
+          assert(res.output.value.isEmpty)
           assert(res.output.evidence.isEmpty)
         }
       }
-    }
 
-    "using filter op" should {
+      "comparing values" should {
 
-      "return all matching facts from a given subset" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.filter(Set(Tags.asthma))
+        "return all matching values from a given subset" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.toList.map(_.value).filter(_ in Set(Tags.asthma).map(_.value))
+          }
+          val res = eval(sampleFactTable)(q)
+          res.output.value should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
         }
-        val res = eval(sampleFactTable)(q)
-        res.output.value should contain theSameElementsAs Seq(Tags.asthma)
-      }
 
-      "return all matching values from a given subset" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.toList.map(_.value).filter(Set(Tags.asthma).map(_.value))
+        "return the correct evidence for the matching values from a given subset" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.toList.map(_.value).filter(_ in Set(Tags.asthma).map(_.value))
+          }
+          val res = eval(sampleFactTable)(q)
+          pendingUntilFixed {
+            // TODO: Merge this assertion the above unit test when it passes
+            assertResult(Evidence(Tags.asthma))(res.output.evidence)
+          }
         }
-        val res = eval(sampleFactTable)(q)
-        res.output.value should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
-      }
 
-      "return the correct evidence for the matching values from a given subset" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.toList.map(_.value).filter(Set(Tags.asthma).map(_.value))
+        "return the matching values from a given superset" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.toList.map(_.value).filter(_ in Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+          }
+          val res = eval(sampleFactTable)(q)
+          res.output.value should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
         }
-        val res = eval(sampleFactTable)(q)
-        pendingUntilFixed {
-          assertResult(Evidence(Tags.asthma))(res.output.evidence)
-        }
-      }
 
-      "return all matching facts from a given superset" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.filter(Set(Tags.asthma, Tags.obeseBmi))
+        "return the correct evidence for the matching values from a given superset" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.toList.map(_.value).filter(_ in Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+          }
+          val res = eval(sampleFactTable)(q)
+          pendingUntilFixed {
+            // TODO: Merge this assertion the above unit test when it passes
+            assertResult(Evidence(Tags.asthma))(res.output.evidence)
+          }
         }
-        val res = eval(sampleFactTable)(q)
-        res.output.value should contain theSameElementsAs Seq(Tags.asthma)
-      }
 
-      "return the matching values from a given superset" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.toList.map(_.value).filter(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
-        }
-        val res = eval(sampleFactTable)(q)
-        res.output.value should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
-      }
-
-      "return the correct evidence for the matching values from a given superset" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.toList.map(_.value).filter(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
-        }
-        val res = eval(sampleFactTable)(q)
-        pendingUntilFixed {
-          assertResult(Evidence(Tags.asthma))(res.output.evidence)
+        "return an empty list of values when given a set that contains no common elements" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.toList.map(_.value).filter(_ in Set(Tags.obeseBmi).map(_.value))
+          }
+          val res = eval(sampleFactTable)(q)
+          assert(res.output.value.isEmpty)
+          assert(res.output.evidence.isEmpty)
         }
       }
 
-      "return an empty list of facts when given a set that contains no common elements" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.filter(Set(Tags.obeseBmi))
-        }
-        val res = eval(sampleFactTable)(q)
-        assert(res.output.value.isEmpty)
-      }
+      "using the 'containsAny' op" should {
 
-      "return an empty list of values when given a set that contains no common elements" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.toList.map(_.value).filter(Set(Tags.obeseBmi).map(_.value))
+        "return 'true' when the fact table contains a superset of the given set" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.toList.map(_.value).containsAny(Set(Tags.asthma).map(_.value))
+          }
+          val res = eval(sampleFactTable)(q)
+          assert(res.output.value)
         }
-        val res = eval(sampleFactTable)(q)
-        assert(res.output.value.isEmpty)
-      }
 
-      "return empty evidence when given a set that contains no common elements" in {
-        val q = withFactsOfType(FactTypes.Tag).where { facts =>
-          facts.toList.map(_.value).filter(Set(Tags.obeseBmi).map(_.value))
+        "return the correct evidence for the facts that contain a superset of the given set" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.toList.map(_.value).containsAny(Set(Tags.asthma).map(_.value))
+          }
+          val res = eval(sampleFactTable)(q)
+          pendingUntilFixed {
+            // TODO: Merge this assertion the above unit test when it passes
+            assertResult(Evidence(Tags.asthma))(res.output.evidence)
+          }
         }
-        val res = eval(sampleFactTable)(q)
-        pendingUntilFixed {
+
+        "return 'true' when the fact table contains a subset of the given set" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.toList.map(_.value).containsAny(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+          }
+          val res = eval(sampleFactTable)(q)
+          assert(res.output.value)
+        }
+
+        "return the correct evidence for the facts that contain a subset of the given set" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.toList.map(_.value).containsAny(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+          }
+          val res = eval(sampleFactTable)(q)
+          pendingUntilFixed {
+            // TODO: Merge this assertion the above unit test when it passes
+            assertResult(Evidence(Tags.asthma))(res.output.evidence)
+          }
+        }
+
+        "return 'false' with no Evidence when the facts do not contain anything in the given set" in {
+          val q = withFactsOfType(FactTypes.Tag).where { facts =>
+            facts.toList.map(_.value).containsAny(Set(Tags.obeseBmi).map(_.value))
+          }
+          val res = eval(sampleFactTable)(q)
+          assert(!res.output.value)
           assert(res.output.evidence.isEmpty)
         }
       }


### PR DESCRIPTION
- Convert FilterOutput to take a condition expression
- Update unit tests to reflect the expanded scope of the filter operator
- Update the ExprBuilder methods