### PR TITLE
Add circe serialization of Expr and ExprResult

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,3 +40,9 @@ lazy val core = commonProject("core")
   .settings(
     libraryDependencies ++= Dependencies.CoreProject.all(scalaVersion.value),
   )
+
+lazy val circe = commonProject("circe")
+  .dependsOn(core % "compile;test->test")
+  .settings(
+    libraryDependencies ++= Dependencies.CirceProject.all(scalaVersion.value),
+  )

--- a/circe/src/main/scala/com/rallyhealth/vapors/circe/CirceCodecs.scala
+++ b/circe/src/main/scala/com/rallyhealth/vapors/circe/CirceCodecs.scala
@@ -1,0 +1,40 @@
+package com.rallyhealth.vapors.circe
+
+import com.rallyhealth.vapors.core.data._
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+
+object CirceCodecs extends CirceCodecs
+
+trait CirceCodecs {
+
+  private val encodeAnyFactType: Encoder[FactType[Any]] = Encoder[String].contramap(_.fullName)
+
+  implicit def encodeFactType[T]: Encoder[FactType[T]] = encodeAnyFactType.asInstanceOf[Encoder[FactType[T]]]
+
+  private val encodeAnyFactTypeSet: Encoder[FactTypeSet[Any]] =
+    Encoder.encodeList(encodeAnyFactType).contramap(_.typeList.toList)
+
+  implicit def encodeFactTypeSet[T]: Encoder[FactTypeSet[T]] =
+    encodeAnyFactTypeSet.asInstanceOf[Encoder[FactTypeSet[T]]]
+
+  def encodeUntypedFact(fact: Fact)(implicit encodeValue: Encoder[fact.Value]): Json = {
+    Json.obj(
+      "factName" -> fact.typeInfo.name.asJson,
+      "factType" -> fact.typeInfo.tt.tpe.toString.asJson,
+      "value" -> fact.value.asJson,
+    )
+  }
+
+  implicit def encodeTypedFact[T : Encoder]: Encoder[TypedFact[T]] = Encoder.instance { fact =>
+    encodeUntypedFact(fact)
+  }
+
+  val encodeFactWithToString: Encoder[Fact] = Encoder.instance { fact =>
+    encodeUntypedFact(fact)(_.toString.asJson)
+  }
+
+  val encodeEvidenceWithToString: Encoder[Evidence] =
+    Encoder.encodeList(encodeFactWithToString).contramapArray(_.factSet.toList)
+
+}

--- a/circe/src/main/scala/com/rallyhealth/vapors/circe/circe.scala
+++ b/circe/src/main/scala/com/rallyhealth/vapors/circe/circe.scala
@@ -1,0 +1,3 @@
+package com.rallyhealth.vapors
+
+package object circe extends CirceCodecs

--- a/circe/src/main/scala/com/rallyhealth/vapors/circe/interpreter/InterpretExprAsJson.scala
+++ b/circe/src/main/scala/com/rallyhealth/vapors/circe/interpreter/InterpretExprAsJson.scala
@@ -1,0 +1,238 @@
+package com.rallyhealth.vapors.circe.interpreter
+
+import cats.data.NonEmptyList
+import cats.kernel.Monoid
+import cats.{Align, FlatMap, Foldable, Functor, FunctorFilter, MonoidK, Order, Show, Traverse, TraverseFilter}
+import com.rallyhealth.vapors.circe._
+import com.rallyhealth.vapors.core.algebra.{Expr, ExprHCons, ExprLast, NonEmptyExprHList}
+import com.rallyhealth.vapors.core.data.{ExtractBoolean, Window}
+import com.rallyhealth.vapors.core.logic.{Conjunction, Disjunction, Negation}
+import com.rallyhealth.vapors.core.math.{Addition, Division, Multiplication, Negative, Subtraction}
+import io.circe.syntax._
+import io.circe.{Json, JsonObject}
+import shapeless.HList
+
+import scala.annotation.tailrec
+import scala.collection.MapView
+
+object InterpretExprAsJson {
+
+  type Out[R] = Json
+
+  def encode[V, R, P](expr: Expr[V, R, P]): Json = expr.visit(new InterpretExprAsJson())
+
+  private[vapors] def commonJsonEncoding(
+    expr: Expr[_, _, _],
+    additionalFields: Seq[(String, Json)] = Seq.empty,
+  ): Json = {
+    var obj = {
+      JsonObject(
+        "node" -> expr.getClass.getSimpleName.asJson,
+      )
+    }
+    obj = {
+      if (additionalFields.nonEmpty) JsonObject.fromIterable(additionalFields).deepMerge(obj)
+      else obj
+    }
+    Json.fromJsonObject(obj)
+  }
+}
+
+// TODO: Make it optional to stop encoding all subExpressions in the arguments list after a top-level expression?
+//       Or maybe only print the input expression of each node (and arguments will encode all subExpressions)?
+// TODO: Make it optional to unhide Embed node wrappers and just show their sub expression
+// TODO: Make it optional to hide ReturnInput nodes
+class InterpretExprAsJson[V, P](encodeSubExpressions: Boolean = true)
+  extends Expr.Visitor[V, P, InterpretExprAsJson.Out] {
+  import InterpretExprAsJson._
+
+  override def visitAddOutputs[R : Addition](expr: Expr.AddOutputs[V, R, P]): Json = commonJsonEncoding(expr)
+
+  override def visitAnd[R : Conjunction : ExtractBoolean](expr: Expr.And[V, R, P]): Json = {
+    commonJsonEncoding(expr, skipOrEncodeSubExprList(expr.inputExprList.toList))
+  }
+
+  override def visitCollectSomeOutput[M[_] : Foldable, U, R : Monoid](
+    expr: Expr.CollectFromOutput[V, M, U, R, P],
+  ): Json =
+    commonJsonEncoding(
+      expr,
+      skipOrEncodeSubExpr("collectSomeExpr", expr.collectExpr) ++
+        skipOrEncodeInputExpr(expr.inputExpr),
+    )
+
+  override def visitConcatOutput[M[_] : MonoidK, R](expr: Expr.ConcatOutput[V, M, R, P]): Out[M[R]] =
+    commonJsonEncoding(expr, skipOrEncodeInputExprList(expr.inputExprList.toList))
+
+  override def visitCustomFunction[A, R](expr: Expr.CustomFunction[V, A, R, P]): Out[R] =
+    commonJsonEncoding(expr, skipOrEncodeInputExpr(expr.inputExpr))
+
+  override def visitTakeFromOutput[M[_] : Traverse : TraverseFilter, R](expr: Expr.TakeFromOutput[V, M, R, P]): Json =
+    commonJsonEncoding(
+      expr,
+      Seq(
+        "take" -> expr.take.asJson,
+      ) ++ skipOrEncodeInputExpr(expr.inputExpr),
+    )
+
+  override def visitConstOutput[R](expr: Expr.ConstOutput[V, R, P]): Json = expr.value.toString.asJson
+
+  override def visitDefine[M[_] : Foldable, T](expr: Expr.Define[M, T, P]): Json = commonJsonEncoding(expr)
+
+  override def visitDivideOutputs[R : Division](expr: Expr.DivideOutputs[V, R, P]): Out[R] =
+    commonJsonEncoding(expr, skipOrEncodeInputExprList(expr.inputExprList.toList))
+
+  override def visitEmbed[R](expr: Expr.Embed[V, R, P]): Json = encode(expr.embeddedExpr)
+
+  override def visitExistsInOutput[M[_] : Foldable, U](expr: Expr.ExistsInOutput[V, M, U, P]): Json = {
+    commonJsonEncoding(
+      expr,
+      skipOrEncodeSubExpr("conditionExpr", expr.conditionExpr) ++
+        skipOrEncodeInputExpr(expr.inputExpr),
+    )
+  }
+
+  override def visitFlatMapOutput[M[_] : Foldable : FlatMap, U, X](expr: Expr.FlatMapOutput[V, M, U, X, P]): Json =
+    commonJsonEncoding(expr)
+
+  override def visitFilterOutput[M[_] : Foldable : FunctorFilter, R](expr: Expr.FilterOutput[V, M, R, P]): Json =
+    commonJsonEncoding(
+      expr,
+      skipOrEncodeSubExpr("filterExpr", expr.condExpr) ++
+        skipOrEncodeInputExpr(expr.inputExpr),
+    )
+
+  override def visitFoldOutput[M[_] : Foldable, R : Monoid](expr: Expr.FoldOutput[V, M, R, P]): Out[R] =
+    commonJsonEncoding(expr, skipOrEncodeInputExpr(expr.inputExpr))
+
+  override def visitGroupOutput[M[_] : Foldable, U : Order, K](
+    expr: Expr.GroupOutput[V, M, U, K, P],
+  ): Out[MapView[K, Seq[U]]] =
+    commonJsonEncoding(expr, skipOrEncodeInputExpr(expr.inputExpr))
+
+  override def visitMapOutput[M[_] : Foldable : Functor, U, R](expr: Expr.MapOutput[V, M, U, R, P]): Json =
+    commonJsonEncoding(expr)
+
+  override def visitMultiplyOutputs[R : Multiplication](expr: Expr.MultiplyOutputs[V, R, P]): Out[R] =
+    commonJsonEncoding(expr, skipOrEncodeInputExprList(expr.inputExprList.toList))
+
+  override def visitNegativeOutput[R : Negative](expr: Expr.NegativeOutput[V, R, P]): Json =
+    commonJsonEncoding(expr, skipOrEncodeSubExpr(expr.inputExpr))
+
+  override def visitNot[R : Negation](expr: Expr.Not[V, R, P]): Json = {
+    commonJsonEncoding(expr, skipOrEncodeSubExpr(expr.inputExpr))
+  }
+
+  override def visitOr[R : Disjunction : ExtractBoolean](expr: Expr.Or[V, R, P]): Json = {
+    commonJsonEncoding(expr, skipOrEncodeSubExprList(expr.inputExprList.toList))
+  }
+
+  override def visitOutputIsEmpty[M[_] : Foldable, R](expr: Expr.OutputIsEmpty[V, M, R, P]): Json =
+    commonJsonEncoding(
+      expr,
+      skipOrEncodeInputExpr(expr.inputExpr),
+    )
+
+  override def visitOutputWithinSet[R](expr: Expr.OutputWithinSet[V, R, P]): Json =
+    commonJsonEncoding(
+      expr,
+      Seq(
+        // TODO: Use Json encoding instead of toString?
+        "accepted" -> expr.accepted.toSeq.map(_.toString).asJson,
+      ) ++ skipOrEncodeInputExpr(expr.inputExpr),
+    )
+
+  override def visitSortOutput[M[_], R](expr: Expr.SortOutput[V, M, R, P]): Out[M[R]] =
+    commonJsonEncoding(
+      expr,
+      Seq(
+        "sorter" -> expr.sorter.sortDescription.asJson,
+      ) ++ skipOrEncodeInputExpr(expr.inputExpr),
+    )
+
+  override def visitOutputWithinWindow[R](expr: Expr.OutputWithinWindow[V, R, P]): Json = {
+    val windowAsString = Window.showWindowWithTerm[R]("input")(Show.fromToString).show(expr.window)
+    commonJsonEncoding(
+      expr,
+      Seq(
+        "comparison" -> windowAsString.asJson,
+      ) ++ skipOrEncodeInputExpr(expr.inputExpr),
+    )
+  }
+
+  override def visitReturnInput(expr: Expr.ReturnInput[V, P]): Json = "return input".asJson
+
+  override def visitSelectFromOutput[S, R](expr: Expr.SelectFromOutput[V, S, R, P]): Json = commonJsonEncoding(expr)
+
+  override def visitSubtractOutputs[R : Subtraction](expr: Expr.SubtractOutputs[V, R, P]): Json =
+    commonJsonEncoding(expr)
+
+  override def visitUsingDefinitions[R](expr: Expr.UsingDefinitions[V, R, P]): Json = commonJsonEncoding(expr)
+
+  override def visitWhen[R](expr: Expr.When[V, R, P]): Json = commonJsonEncoding(expr)
+
+  override def visitWithFactsOfType[T, R](expr: Expr.WithFactsOfType[T, R, P]): Json = {
+    val factTypesJson = expr.factTypeSet.asJson
+    commonJsonEncoding(
+      expr,
+      Seq(
+        "factTypes" -> factTypesJson,
+      ) ++ skipOrEncodeSubExpr(expr.subExpr),
+    )
+  }
+
+  override def visitWrapOutputHList[T <: HList, R](expr: Expr.WrapOutputHList[V, T, R, P]): Out[R] =
+    commonJsonEncoding(expr, skipOrEncodeInputExprList(exprHListAsList(expr.inputExprHList)))
+
+  override def visitWrapOutputSeq[R](expr: Expr.WrapOutputSeq[V, R, P]): Out[Seq[R]] =
+    commonJsonEncoding(expr, skipOrEncodeInputExprList(expr.inputExprList))
+
+  override def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](
+    expr: Expr.ZipOutput[V, M, L, R, P],
+  ): Out[M[R]] =
+    commonJsonEncoding(expr, skipOrEncodeInputExprList(exprHListAsList(expr.inputExprHList)))
+
+  private def exprHListAsList[M[_]](hl: NonEmptyExprHList[_, M, _, _]): Seq[Expr[_, _, _]] = {
+    @tailrec def appendAllExprs(
+      hl: NonEmptyExprHList[_, M, _, _],
+      acc: List[Expr[_, _, _]],
+    ): List[Expr[_, _, _]] = hl match {
+      case last: ExprLast[_, M, _, _] => last.last :: Nil
+      case cons: ExprHCons[_, M, _, _, _] => appendAllExprs(cons.tail, cons.head :: acc)
+    }
+    appendAllExprs(hl, Nil)
+  }
+
+  private def skipOrEncodeInputExpr(expr: Expr[_, _, _]): Seq[(String, Json)] =
+    skipOrEncodeInputExprList(Seq(expr))
+
+  private def skipOrEncodeInputExprList(exprs: Seq[Expr[_, _, _]]): Seq[(String, Json)] =
+    skipOrEncodeSubExprList("inputResults", exprs)
+
+  private def skipOrEncodeSubExpr(expr: Expr[_, _, _]): Seq[(String, Json)] =
+    skipOrEncodeSubExprList(Seq(expr))
+
+  private def skipOrEncodeSubExpr(
+    name: String,
+    expr: Expr[_, _, _],
+  ): Seq[(String, Json)] =
+    skipOrEncodeSubExprList(name, Seq(expr))
+
+  private def skipOrEncodeSubExprList(exprs: Seq[Expr[_, _, _]]): Seq[(String, Json)] =
+    skipOrEncodeSubExprList("subExpressions", exprs)
+
+  private def skipOrEncodeSubExprList(
+    name: String,
+    exprs: Seq[Expr[_, _, _]],
+  ): Seq[(String, Json)] = {
+    if (encodeSubExpressions) {
+      val filteredExpressions = exprs.flatMap {
+        case Expr.ReturnInput(_) => None
+        case keep => Some(encode(keep))
+      }
+      if (filteredExpressions.isEmpty) Nil
+      else Seq(name -> filteredExpressions.asJson)
+    } else Nil
+  }
+
+}

--- a/circe/src/main/scala/com/rallyhealth/vapors/circe/interpreter/InterpretExprResultAsJson.scala
+++ b/circe/src/main/scala/com/rallyhealth/vapors/circe/interpreter/InterpretExprResultAsJson.scala
@@ -1,0 +1,306 @@
+package com.rallyhealth.vapors.circe.interpreter
+
+import cats.{Align, Foldable, FunctorFilter, Monoid, MonoidK, Order, Traverse, TraverseFilter}
+import com.rallyhealth.vapors.circe._
+import com.rallyhealth.vapors.core.algebra.{Expr, ExprResult}
+import com.rallyhealth.vapors.core.data.Evidence
+import com.rallyhealth.vapors.core.interpreter.{ExprInput, ExprOutput}
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+import shapeless.HList
+
+import scala.collection.MapView
+
+object InterpretExprResultAsJson {
+
+  type Out[_] = Json
+
+  private final val instance = new InterpretExprResultAsJson[Any, Any]
+  private val exprEncoder: InterpretExprAsJson[Nothing, Nothing] = new InterpretExprAsJson(
+    encodeSubExpressions = false,
+  )
+
+  def apply[V, R](): InterpretExprResultAsJson[V, R] =
+    instance.asInstanceOf[InterpretExprResultAsJson[V, R]]
+
+  def encode[V, R, P](op: ExprResult[V, R, P]): Json = op.visit(InterpretExprResultAsJson())
+
+  /**
+    * Encodes the given [[Expr]] using [[InterpretExprAsJson]], but without encoding the sub-expressions.
+    */
+  def encodeExpr[V, P](expr: Expr[V, _, P]): Json =
+    expr.visit(exprEncoder.asInstanceOf[InterpretExprAsJson[V, P]])
+
+  implicit def encodeEvidence: Encoder[Evidence] = encodeEvidenceWithToString
+
+  implicit def encodeExprInput[V]: Encoder[ExprInput[V]] = { input =>
+    Json.obj(
+      "value" -> input.value.toString.asJson,
+      "evidence" -> input.evidence.asJson,
+    )
+  }
+
+  implicit def encodeExprOutput[R]: Encoder[ExprOutput[R]] = { output =>
+    Json.obj(
+      "value" -> output.value.toString.asJson,
+      "evidence" -> output.evidence.asJson,
+    )
+  }
+
+  protected def commonJsonEncoding(
+    expr: Expr[_, _, _],
+    context: ExprResult.Context[_, _, _],
+    additionalFields: Seq[(String, Json)] = Nil,
+  ): Json = {
+    val obj = encodeExpr(expr)
+    val result = {
+      if (additionalFields.isEmpty) obj
+      else Json.obj(additionalFields: _*).deepMerge(obj)
+    }
+    Json
+      .obj(
+        "input" -> context.input.asJson,
+        "output" -> context.output.asJson,
+      )
+      .deepMerge(result)
+      .asJson
+  }
+
+}
+
+// TODO: Serialize param P
+// TODO: Make it optional to stop encoding all subExpressions in the arguments list after a top-level expression?
+//       Or maybe only print the input expression of each node (and arguments will encode all subExpressions)?
+// TODO: Make it optional to unhide Embed node wrappers and just show their sub expression
+// TODO: Make it optional to hide ReturnInput nodes
+class InterpretExprResultAsJson[V, P] extends ExprResult.Visitor[V, P, InterpretExprResultAsJson.Out] {
+  import InterpretExprResultAsJson._
+
+  override def visitAddOutputs[R](result: ExprResult.AddOutputs[V, R, P]): Json =
+    commonJsonEncoding(result.expr, result.context, skipOrEncodeSubResultList(result.subResultList))
+
+  override def visitAnd[R](result: ExprResult.And[V, R, P]): Json =
+    commonJsonEncoding(result.expr, result.context, skipOrEncodeSubResultList(result.subResultList))
+
+  override def visitCollectFromOutput[M[_] : Foldable, U, R : Monoid](
+    result: ExprResult.CollectFromOutput[V, M, U, R, P],
+  ): Json =
+    commonJsonEncoding(result.expr, result.context, skipOrEncodeInput(result.inputResult))
+
+  override def visitConcatOutput[M[_] : MonoidK, R](result: ExprResult.ConcatOutput[V, M, R, P]): Out[M[R]] =
+    commonJsonEncoding(result.expr, result.context, skipOrEncodeInputList(result.inputResultList))
+
+  override def visitConstOutput[R](result: ExprResult.ConstOutput[V, R, P]): Json =
+    commonJsonEncoding(result.expr, result.context)
+
+  override def visitCustomFunction[A, R](result: ExprResult.CustomFunction[V, A, R, P]): Out[R] = ???
+
+  override def visitDeclare[M[_], T](result: ExprResult.Define[V, M, T, P]): Json = {
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+      skipOrEncodeSubResult("definitionResult", result.definitionResult),
+    )
+  }
+
+  override def visitDivideOutputs[R](result: ExprResult.DivideOutputs[V, R, P]): Out[R] = ???
+
+  override def visitEmbed[R](result: ExprResult.Embed[V, R, P]): Json = encode(result.embeddedResult)
+
+  override def visitExistsInOutput[M[_] : Foldable, U](result: ExprResult.ExistsInOutput[V, M, U, P]): Json = {
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+      skipOrEncodeInput(result.inputResult) ++
+        skipOrEncodeSubResultList("conditionResults", result.conditionResultList),
+    )
+  }
+
+  override def visitFilterOutput[M[_] : Foldable : FunctorFilter, R](
+    result: ExprResult.FilterOutput[V, M, R, P],
+  ): Out[M[R]] = {
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+      skipOrEncodeInput(result.inputResult) ++ skipOrEncodeSubResultList(result.condResultList),
+    )
+  }
+
+  override def visitFlatMapOutput[M[_], U, R](result: ExprResult.FlatMapOutput[V, M, U, R, P]): Json = {
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+      skipOrEncodeInput(result.inputResult) ++ skipOrEncodeSubResultList(result.subResultList),
+    )
+  }
+
+  override def visitFoldOutput[M[_] : Foldable, R : Monoid](result: ExprResult.FoldOutput[V, M, R, P]): Out[R] = ???
+
+  override def visitGroupOutput[M[_] : Foldable, U : Order, K](
+    result: ExprResult.GroupOutput[V, M, U, K, P],
+  ): Out[MapView[K, Seq[U]]] =
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+      skipOrEncodeInput(result.inputResult),
+    )
+
+  override def visitMapOutput[M[_], U, R](result: ExprResult.MapOutput[V, M, U, R, P]): Json =
+    commonJsonEncoding(result.expr, result.context)
+
+  override def visitMultiplyOutputs[R](result: ExprResult.MultiplyOutputs[V, R, P]): Out[R] = ???
+
+  override def visitNegativeOutput[R](result: ExprResult.NegativeOutput[V, R, P]): Json =
+    commonJsonEncoding(result.expr, result.context, skipOrEncodeSubResult(result.inputResult))
+
+  override def visitNot[R](result: ExprResult.Not[V, R, P]): Json =
+    commonJsonEncoding(result.expr, result.context, skipOrEncodeSubResult(result.subResult))
+
+  override def visitOr[R](result: ExprResult.Or[V, R, P]): Json =
+    commonJsonEncoding(result.expr, result.context, skipOrEncodeSubResultList(result.subResultList))
+
+  override def visitOutputIsEmpty[M[_] : Foldable, R](result: ExprResult.OutputIsEmpty[V, M, R, P]): Json =
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+      skipOrEncodeInput(result.inputResult),
+    )
+
+  override def visitOutputWithinSet[R](result: ExprResult.OutputWithinSet[V, R, P]): Json =
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+      skipOrEncodeInput(result.inputResult),
+    )
+
+  // TODO: Require a Show of R? Can this be done via post param if it took both R and P?
+  override def visitOutputWithinWindow[R](result: ExprResult.OutputWithinWindow[V, R, P]): Json = {
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+      skipOrEncodeInput(result.inputResult),
+    )
+  }
+
+  override def visitReturnInput(result: ExprResult.ReturnInput[V, P]): Json =
+    commonJsonEncoding(result.expr, result.context)
+
+  override def visitSelectFromOutput[S, R](result: ExprResult.SelectFromOutput[V, S, R, P]): Json = {
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+      skipOrEncodeInput(result.inputResult),
+    )
+  }
+
+  override def visitSortOutput[M[_], R](result: ExprResult.SortOutput[V, M, R, P]): Out[M[R]] = {
+    commonJsonEncoding(result.expr, result.context, skipOrEncodeSubResult(result.inputResult))
+  }
+
+  override def visitSubtractOutputs[R](result: ExprResult.SubtractOutputs[V, R, P]): Json =
+    commonJsonEncoding(result.expr, result.context, skipOrEncodeSubResultList(result.subResultList))
+
+  override def visitTakeFromOutput[M[_] : Traverse : TraverseFilter, R](
+    result: ExprResult.TakeFromOutput[V, M, R, P],
+  ): Json = {
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+      skipOrEncodeInput(result.inputResult),
+    )
+  }
+
+  override def visitUsingDefinitions[R](result: ExprResult.UsingDefinitions[V, R, P]): Json =
+    commonJsonEncoding(result.expr, result.context)
+
+  override def visitWhen[R](result: ExprResult.When[V, R, P]): Json = {
+    def encodeUnevaluatedExpr(expr: Expr[V, R, P]): Json = {
+      val additionalFields = Json.obj(
+        "output" -> Json.obj(
+          "value" -> "(not evaluated)".asJson,
+        ),
+      )
+      additionalFields.deepMerge(InterpretExprAsJson.encode(expr))
+    }
+
+    val condBranchesJson = result.expr.conditionBranches.toVector.map { branch =>
+      Json.obj(
+        "matched" -> result.matchedBranch.contains(branch).asJson,
+        "whenExpr" -> encodeExpr(branch.whenExpr),
+        "thenExpr" -> encodeUnevaluatedExpr(branch.thenExpr),
+      )
+    }
+    val elseExprJson = Json.obj(
+      "matched" -> result.matchedBranch.isEmpty.asJson,
+      "elseExpr" -> encodeUnevaluatedExpr(result.expr.defaultExpr),
+    )
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+      skipOrEncodeSubResult(result.subResult) ++ Seq(
+        "conditionBranches" -> (condBranchesJson :+ elseExprJson).asJson,
+      ),
+    )
+  }
+
+  override def visitWithFactsOfType[T, R](result: ExprResult.WithFactsOfType[V, T, R, P]): Json = {
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+      skipOrEncodeSubResult(result.subResult),
+    )
+  }
+
+  override def visitWrapOutputHList[T <: HList, R](result: ExprResult.WrapOutputHList[V, T, R, P]): Json = {
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+    )
+  }
+
+  override def visitWrapOutputSeq[R](result: ExprResult.WrapOutputSeq[V, R, P]): Out[Seq[R]] = {
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+    )
+  }
+
+  override def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](
+    result: ExprResult.ZipOutput[V, M, L, R, P],
+  ): Out[M[R]] = {
+    commonJsonEncoding(
+      result.expr,
+      result.context,
+    )
+  }
+
+  private final def skipOrEncodeInput(result: ExprResult[_, _, _]): Seq[(String, Json)] =
+    skipOrEncodeInputList(Seq(result))
+
+  private final def skipOrEncodeInputList(result: Seq[ExprResult[_, _, _]]): Seq[(String, Json)] =
+    skipOrEncodeSubResultList("inputResults", result)
+
+  private final def skipOrEncodeSubResult(result: ExprResult[_, _, _]): Seq[(String, Json)] =
+    skipOrEncodeSubResultList(Seq(result))
+
+  private final def skipOrEncodeSubResult(
+    name: String,
+    result: ExprResult[_, _, _],
+  ): Seq[(String, Json)] =
+    skipOrEncodeSubResultList(name, Seq(result))
+
+  private final def skipOrEncodeSubResultList(results: Seq[ExprResult[_, _, _]]): Seq[(String, Json)] =
+    skipOrEncodeSubResultList("subResults", results)
+
+  private final def skipOrEncodeSubResultList(
+    name: String,
+    results: Seq[ExprResult[_, _, _]],
+  ): Seq[(String, Json)] = {
+    val filteredResults = results.flatMap {
+      case ExprResult.ReturnInput(_, _) => None
+      case keep => Some(encode(keep))
+    }
+    if (filteredResults.isEmpty) Nil
+    else Seq(name -> filteredResults.asJson)
+  }
+}

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
@@ -1,7 +1,7 @@
 package com.rallyhealth.vapors.core.algebra
 
 import cats._
-import cats.data.NonEmptyList
+import cats.data.{NonEmptyList, NonEmptyVector}
 import com.rallyhealth.vapors.core.data._
 import com.rallyhealth.vapors.core.interpreter.{ExprOutput, InterpretExprAsResultFn}
 import com.rallyhealth.vapors.core.lens.NamedLens
@@ -266,7 +266,7 @@ object Expr {
     * @note this expression <i>does</i> short-circuit on the first branch whose condition is met
     */
   final case class When[V, R, P](
-    conditionBranches: NonEmptyList[ConditionBranch[V, R, P]],
+    conditionBranches: NonEmptyVector[ConditionBranch[V, R, P]],
     defaultExpr: Expr[V, R, P],
     capture: CaptureP[V, R, P],
   ) extends Expr[V, R, P] {

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprBuilder.scala
@@ -8,6 +8,7 @@ import com.rallyhealth.vapors.core.math._
 
 import scala.collection.{Factory, MapView, View}
 import scala.reflect.runtime.universe.TypeTag
+import scala.reflect.ClassTag
 
 // TODO: Make this more reusable for MapViewExprBuilder
 sealed class ExprBuilder[V, M[_], U, P](val returnOutput: Expr[V, M[U], P]) {
@@ -162,6 +163,7 @@ final class FoldableExprBuilder[V, M[_], U, P](returnOutput: Expr[V, M[U], P])
     factory: Factory[U, N[U]],
   )(implicit
     ev: M[U] <:< IterableOnce[U],
+    tag: ClassTag[N[U]],
     captureResult: CaptureResult[N[U]],
   ): FoldableExprBuilder[V, N, U, P] =
     new FoldableExprBuilder(

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WhenExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WhenExprBuilder.scala
@@ -23,7 +23,7 @@ final class WhenElseExprBuilder[V, R, P](private val branches: NonEmptyList[Cond
   )(implicit
     captureResult: CaptureP[V, R, P],
   ): Expr.When[V, R, P] =
-    Expr.When(branches.reverse, elseExpr, captureResult)
+    Expr.When(branches.reverse.toNev, elseExpr, captureResult)
 
   def elif(elifExpr: CondExpr[V, P]): WhenElifExprBuilder[V, R, P] = new WhenElifExprBuilder((elifExpr, branches))
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/lens/NamedLens.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/lens/NamedLens.scala
@@ -8,6 +8,7 @@ import shapeless.ops.hlist
 import shapeless.{Generic, HList}
 
 import scala.collection.{Factory, MapView, View}
+import scala.reflect.ClassTag
 
 object NamedLens extends NamedLensLowPriorityImplicits {
 
@@ -61,8 +62,11 @@ object NamedLens extends NamedLensLowPriorityImplicits {
 
     // TODO: Should there be any path information for conversion?
     //       List => Map seems important information as values with duplicate keys could be dropped
-    def to[B](factory: Factory[E, B]): NamedLens[A, B] =
-      lens.copy(get = lens.get.andThen(factory.fromSpecific(_)))
+    def to[B : ClassTag](factory: Factory[E, B]): NamedLens[A, B] =
+      lens.copy(
+        path = lens.path.to(factory),
+        get = lens.get.andThen(factory.fromSpecific(_)),
+      )
 
     def headOption: NamedLens[A, Option[E]] =
       lens.copy(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,6 +5,7 @@ object Dependencies {
   final val Scala_2_13 = "2.13.0"
 
   private final val catsVersion = "2.3.0"
+  private final val circeVersion = "0.13.0"
   private final val kindProjectorVersion = "0.11.0"
   private final val scalaCheckVersion = "1.15.1"
   private final val scalaCheckOpsVersion = "2.5.1"
@@ -15,6 +16,7 @@ object Dependencies {
   private val alleyCatsCore = "org.typelevel" %% "alleycats-core" % catsVersion
   private val catsCore = "org.typelevel" %% "cats-core" % catsVersion
   private val catsFree = "org.typelevel" %% "cats-free" % catsVersion
+  private val circeCore = "io.circe" %% "circe-core" % circeVersion
   private val scalaCheck = "org.scalacheck" %% "scalacheck" % scalaCheckVersion
   private val scalaCheckOps = "com.rallyhealth" %% "scalacheck-ops_1-14" % scalaCheckOpsVersion
   private val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion
@@ -46,6 +48,18 @@ object Dependencies {
         scalaTest,
         scalaTestPlusScalaCheck,
       ).map(_ % Test)
+  }
+
+  final object CirceProject {
+
+    def all(scalaVersion: String): Seq[ModuleID] = {
+      CoreProject.all(scalaVersion) ++ Seq(
+        circeCore,
+      )
+//      ) ++ Seq(
+//        circeParser,
+//      ).map(_ % Test)
+    }
   }
 
 }


### PR DESCRIPTION
**Main changes**
- Added circe dependencies to the build
- Added InterpretExprAsJson for Expr serialization
- Added InterpretExprResultAsJson for ExprResult serialization
- Created a circe package with standard encoders for facts, fact types and evidence

**Somewhat unrelated changes**
- Convert Expr.When to use Vector instead of List
- Add class information to DataPath when converting collection types