### PR TITLE
Remove the F[_] parameter from Expr

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
@@ -25,46 +25,46 @@ import shapeless.HList
   * R = Return type
   * P = Captured param
   */
-sealed abstract class Expr[F[_], V, R, P] {
+sealed abstract class Expr[V, R, P] {
 
-  def visit[G[_]](v: Expr.Visitor[F, V, P, G]): G[R]
+  def visit[G[_]](v: Expr.Visitor[V, P, G]): G[R]
 
-  def capture: CaptureP[F, V, R, P]
+  def capture: CaptureP[V, R, P]
 }
 
 object Expr {
 
   import cats.{~>, Id}
 
-  trait Visitor[F[_], V, P, G[_]] extends (Expr[F, V, *, P] ~> G) {
+  trait Visitor[V, P, G[_]] extends (Expr[V, *, P] ~> G) {
     // Please keep the following methods in alphabetical order
-    override final def apply[R](fa: Expr[F, V, R, P]): G[R] = fa.visit(this)
-    def visitAddOutputs[R : Addition](expr: AddOutputs[F, V, R, P]): G[R]
-    def visitAnd[R : Conjunction : ExtractBoolean](expr: And[F, V, R, P]): G[R]
-    def visitCollectSomeOutput[M[_] : Foldable, U, R : Monoid](expr: CollectFromOutput[F, V, M, U, R, P]): G[R]
-    def visitConstOutput[R](expr: ConstOutput[F, V, R, P]): G[R]
+    override final def apply[R](fa: Expr[V, R, P]): G[R] = fa.visit(this)
+    def visitAddOutputs[R : Addition](expr: AddOutputs[V, R, P]): G[R]
+    def visitAnd[R : Conjunction : ExtractBoolean](expr: And[V, R, P]): G[R]
+    def visitCollectSomeOutput[M[_] : Foldable, U, R : Monoid](expr: CollectFromOutput[V, M, U, R, P]): G[R]
+    def visitConstOutput[R](expr: ConstOutput[V, R, P]): G[R]
     def visitDefine[M[_] : Foldable, T](expr: Define[M, T, P]): G[FactSet]
-    def visitEmbed[R](expr: Embed[F, V, R, P]): G[R]
-    def visitExistsInOutput[M[_] : Foldable, U](expr: ExistsInOutput[F, V, M, U, P]): G[Boolean]
-    def visitFilterOutput[M[_] : Foldable : FunctorFilter, R](expr: FilterOutput[F, V, M, R, P]): G[M[R]]
-    def visitFlatMapOutput[M[_] : Foldable : FlatMap, U, X](expr: FlatMapOutput[F, V, M, U, X, P]): G[M[X]]
-    def visitMapOutput[M[_] : Foldable : Functor, U, R](expr: MapOutput[F, V, M, U, R, P]): G[M[R]]
-    def visitNegativeOutput[R : Negative](expr: NegativeOutput[F, V, R, P]): G[R]
-    def visitNot[R : Negation](expr: Not[F, V, R, P]): G[R]
-    def visitOr[R : Disjunction : ExtractBoolean](expr: Or[F, V, R, P]): G[R]
-    def visitOutputIsEmpty[M[_] : Foldable, R](expr: OutputIsEmpty[F, V, M, R, P]): G[Boolean]
-    def visitOutputWithinSet[R](expr: OutputWithinSet[F, V, R, P]): G[Boolean]
-    def visitOutputWithinWindow[R](expr: OutputWithinWindow[F, V, R, P]): G[Boolean]
-    def visitReturnInput(expr: ReturnInput[F, V, P]): G[F[V]]
-    def visitSelectFromOutput[S, R](expr: SelectFromOutput[F, V, S, R, P]): G[R]
-    def visitSortOutput[M[_], R](expr: SortOutput[F, V, M, R, P]): G[M[R]]
-    def visitSubtractOutputs[R : Subtraction](expr: SubtractOutputs[F, V, R, P]): G[R]
-    def visitTakeFromOutput[M[_] : Traverse : TraverseFilter, R](expr: TakeFromOutput[F, V, M, R, P]): G[M[R]]
-    def visitUsingDefinitions[R](expr: UsingDefinitions[F, V, R, P]): G[R]
-    def visitWhen[R](expr: When[F, V, R, P]): G[R]
-    def visitWrapOutput[T <: HList, R](expr: WrapOutput[F, V, T, R, P]): G[R]
+    def visitEmbed[R](expr: Embed[V, R, P]): G[R]
+    def visitExistsInOutput[M[_] : Foldable, U](expr: ExistsInOutput[V, M, U, P]): G[Boolean]
+    def visitFilterOutput[M[_] : Foldable : FunctorFilter, R](expr: FilterOutput[V, M, R, P]): G[M[R]]
+    def visitFlatMapOutput[M[_] : Foldable : FlatMap, U, X](expr: FlatMapOutput[V, M, U, X, P]): G[M[X]]
+    def visitMapOutput[M[_] : Foldable : Functor, U, R](expr: MapOutput[V, M, U, R, P]): G[M[R]]
+    def visitNegativeOutput[R : Negative](expr: NegativeOutput[V, R, P]): G[R]
+    def visitNot[R : Negation](expr: Not[V, R, P]): G[R]
+    def visitOr[R : Disjunction : ExtractBoolean](expr: Or[V, R, P]): G[R]
+    def visitOutputIsEmpty[M[_] : Foldable, R](expr: OutputIsEmpty[V, M, R, P]): G[Boolean]
+    def visitOutputWithinSet[R](expr: OutputWithinSet[V, R, P]): G[Boolean]
+    def visitOutputWithinWindow[R](expr: OutputWithinWindow[V, R, P]): G[Boolean]
+    def visitReturnInput(expr: ReturnInput[V, P]): G[V]
+    def visitSelectFromOutput[S, R](expr: SelectFromOutput[V, S, R, P]): G[R]
+    def visitSortOutput[M[_], R](expr: SortOutput[V, M, R, P]): G[M[R]]
+    def visitSubtractOutputs[R : Subtraction](expr: SubtractOutputs[V, R, P]): G[R]
+    def visitTakeFromOutput[M[_] : Traverse : TraverseFilter, R](expr: TakeFromOutput[V, M, R, P]): G[M[R]]
+    def visitUsingDefinitions[R](expr: UsingDefinitions[V, R, P]): G[R]
+    def visitWhen[R](expr: When[V, R, P]): G[R]
+    def visitWrapOutput[T <: HList, R](expr: WrapOutput[V, T, R, P]): G[R]
     def visitWithFactsOfType[T, R](expr: WithFactsOfType[T, R, P]): G[R]
-    def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](expr: ZipOutput[F, V, M, L, R, P]): G[M[R]]
+    def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](expr: ZipOutput[V, M, L, R, P]): G[M[R]]
   }
 
   /*
@@ -84,12 +84,12 @@ object Expr {
   /**
     * Uses the given value as the output of this expression and ignores the input.
     */
-  final case class ConstOutput[F[_], V, R, P](
+  final case class ConstOutput[V, R, P](
     value: R,
     evidence: Evidence,
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitConstOutput(this)
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitConstOutput(this)
   }
 
   /**
@@ -102,8 +102,8 @@ object Expr {
     *       This is useful to avoid needing to define separate nodes for the input / output sides of an expression.
     *       Instead, you just take an `inputExpr` and you can pass this node to move the input into the output.
     */
-  final case class ReturnInput[F[_], V, P](capture: CaptureP[F, V, F[V], P]) extends Expr[F, V, F[V], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[F[V]] = v.visitReturnInput(this)
+  final case class ReturnInput[V, P](capture: CaptureP[V, V, P]) extends Expr[V, V, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[V] = v.visitReturnInput(this)
   }
 
   /**
@@ -116,11 +116,11 @@ object Expr {
     * Typically, these nodes only exist to satisfy the type system and are skipped by visitors, however, the
     * input to the [[Embed]] node can be captured via the input parameters and folded into the final result.
     */
-  final case class Embed[F[_], V, R, P](
-    embeddedExpr: Expr[Id, FactTable, R, P],
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitEmbed(this)
+  final case class Embed[V, R, P](
+    embeddedExpr: Expr[FactTable, R, P],
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitEmbed(this)
   }
 
   /**
@@ -134,10 +134,10 @@ object Expr {
     */
   final case class WithFactsOfType[T, R, P](
     factTypeSet: FactTypeSet[T],
-    subExpr: Expr[Seq, TypedFact[T], R, P],
-    capture: CaptureP[Id, FactTable, R, P],
-  ) extends Expr[Id, FactTable, R, P] {
-    override def visit[G[_]](v: Visitor[Id, FactTable, P, G]): G[R] = v.visitWithFactsOfType(this)
+    subExpr: Expr[Seq[TypedFact[T]], R, P],
+    capture: CaptureP[FactTable, R, P],
+  ) extends Expr[FactTable, R, P] {
+    override def visit[G[_]](v: Visitor[FactTable, P, G]): G[R] = v.visitWithFactsOfType(this)
   }
 
   /**
@@ -149,7 +149,7 @@ object Expr {
     *
     * @see https://github.com/scala/bug/issues/8039 for more info
     */
-  sealed trait Definition[P] extends Expr[Id, FactTable, FactSet, P]
+  sealed trait Definition[P] extends Expr[FactTable, FactSet, P]
 
   /**
     * Define or add another source for a [[FactType]].
@@ -159,10 +159,10 @@ object Expr {
     */
   final case class Define[M[_] : Foldable, T, P](
     factType: FactType[T],
-    definitionExpr: Expr[Id, FactTable, M[T], P],
-    capture: CaptureP[Id, FactTable, FactSet, P],
+    definitionExpr: Expr[FactTable, M[T], P],
+    capture: CaptureP[FactTable, FactSet, P],
   ) extends Definition[P] {
-    override def visit[G[_]](v: Visitor[Id, FactTable, P, G]): G[FactSet] = v.visitDefine(this)
+    override def visit[G[_]](v: Visitor[FactTable, P, G]): G[FactSet] = v.visitDefine(this)
   }
 
   /**
@@ -176,12 +176,12 @@ object Expr {
     *       graph of dependencies has been sequenced properly. Including the same fact definition twice is
     *       likely idempotent, however, there is no currently machinery to avoid unnecessary re-computation.
     */
-  final case class UsingDefinitions[F[_], V, R, P](
+  final case class UsingDefinitions[V, R, P](
     definitions: Vector[Definition[P]],
-    subExpr: Expr[F, V, R, P],
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitUsingDefinitions(this)
+    subExpr: Expr[V, R, P],
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitUsingDefinitions(this)
   }
 
   /**
@@ -195,11 +195,11 @@ object Expr {
     *       If you want to apply short-circuiting, you must implement it within the algebra using sorting,
     *       filtering, and limiting operators.
     */
-  final case class And[F[_], V, R : Conjunction : ExtractBoolean, P](
-    inputExprList: NonEmptyList[Expr[F, V, R, P]],
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitAnd(this)
+  final case class And[V, R : Conjunction : ExtractBoolean, P](
+    inputExprList: NonEmptyList[Expr[V, R, P]],
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitAnd(this)
   }
 
   /**
@@ -213,21 +213,21 @@ object Expr {
     *       If you want to apply short-circuiting, you must implement it within the algebra using sorting,
     *       filtering, and limiting operators.
     */
-  final case class Or[F[_], V, R : Disjunction : ExtractBoolean, P](
-    inputExprList: NonEmptyList[Expr[F, V, R, P]],
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitOr(this)
+  final case class Or[V, R : Disjunction : ExtractBoolean, P](
+    inputExprList: NonEmptyList[Expr[V, R, P]],
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitOr(this)
   }
 
   /**
     * Negates the output from the given [[inputExpr]], but keeps the same evidence.
     */
-  final case class Not[F[_], V, R : Negation, P](
-    inputExpr: Expr[F, V, R, P],
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitNot(this)
+  final case class Not[V, R : Negation, P](
+    inputExpr: Expr[V, R, P],
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitNot(this)
   }
 
   /**
@@ -236,12 +236,12 @@ object Expr {
     *
     * @note this expression <i>does</i> short-circuit on the first branch whose condition is met
     */
-  final case class When[F[_], V, R, P](
-    conditionBranches: NonEmptyList[ConditionBranch[F, V, R, P]],
-    defaultExpr: Expr[F, V, R, P],
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitWhen(this)
+  final case class When[V, R, P](
+    conditionBranches: NonEmptyList[ConditionBranch[V, R, P]],
+    defaultExpr: Expr[V, R, P],
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitWhen(this)
   }
 
   /**
@@ -249,20 +249,20 @@ object Expr {
     *
     * @note if you want to select from the input [[F]] of [[V]], you can pass [[ReturnInput]] as the [[inputExpr]].
     */
-  final case class SelectFromOutput[F[_], V, S, R, P](
-    inputExpr: Expr[F, V, S, P],
+  final case class SelectFromOutput[V, S, R, P](
+    inputExpr: Expr[V, S, P],
     lens: NamedLens[S, R],
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitSelectFromOutput(this)
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitSelectFromOutput(this)
   }
 
-  final case class FilterOutput[F[_], V, M[_] : Foldable : FunctorFilter, R, P](
-    inputExpr: Expr[F, V, M[R], P],
-    condExpr: Expr[Id, R, Boolean, P],
-    capture: CaptureP[F, V, M[R], P],
-  ) extends Expr[F, V, M[R], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitFilterOutput(this)
+  final case class FilterOutput[V, M[_] : Foldable : FunctorFilter, R, P](
+    inputExpr: Expr[V, M[R], P],
+    condExpr: Expr[R, Boolean, P],
+    capture: CaptureP[V, M[R], P],
+  ) extends Expr[V, M[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitFilterOutput(this)
   }
 
   /**
@@ -271,12 +271,12 @@ object Expr {
     * @note if you want to apply this to the input (i.e. `F[V]`), you can pass [[ReturnInput]] as the [[inputExpr]].
     */
   // TODO: Rename to CollectFoldSomeOutput?
-  final case class CollectFromOutput[F[_], V, M[_] : Foldable, U, R : Monoid, P](
-    inputExpr: Expr[F, V, M[U], P],
-    collectExpr: Expr[Id, U, Option[R], P],
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitCollectSomeOutput(this)
+  final case class CollectFromOutput[V, M[_] : Foldable, U, R : Monoid, P](
+    inputExpr: Expr[V, M[U], P],
+    collectExpr: Expr[U, Option[R], P],
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitCollectSomeOutput(this)
   }
 
   /**
@@ -284,12 +284,12 @@ object Expr {
     *
     * @note if you want to apply this to the input (i.e. `F[V]`), you can pass [[ReturnInput]] as the [[inputExpr]].
     */
-  final case class FlatMapOutput[F[_], V, M[_] : Foldable : FlatMap, U, R, P](
-    inputExpr: Expr[F, V, M[U], P],
-    flatMapExpr: Expr[Id, U, M[R], P],
-    capture: CaptureP[F, V, M[R], P],
-  ) extends Expr[F, V, M[R], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitFlatMapOutput(this)
+  final case class FlatMapOutput[V, M[_] : Foldable : FlatMap, U, R, P](
+    inputExpr: Expr[V, M[U], P],
+    flatMapExpr: Expr[U, M[R], P],
+    capture: CaptureP[V, M[R], P],
+  ) extends Expr[V, M[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitFlatMapOutput(this)
   }
 
   /**
@@ -297,12 +297,12 @@ object Expr {
     *
     * @note if you want to apply this to the input (i.e. `F[V]`), you can pass [[ReturnInput]] as the [[inputExpr]].
     */
-  final case class MapOutput[F[_], V, M[_] : Foldable : Functor, U, R, P](
-    inputExpr: Expr[F, V, M[U], P],
-    mapExpr: Expr[Id, U, R, P],
-    capture: CaptureP[F, V, M[R], P],
-  ) extends Expr[F, V, M[R], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitMapOutput(this)
+  final case class MapOutput[V, M[_] : Foldable : Functor, U, R, P](
+    inputExpr: Expr[V, M[U], P],
+    mapExpr: Expr[U, R, P],
+    capture: CaptureP[V, M[R], P],
+  ) extends Expr[V, M[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitMapOutput(this)
   }
 
   /**
@@ -310,12 +310,12 @@ object Expr {
     *
     * @note if you want to apply this to the input (i.e. `F[V]`), you can pass [[ReturnInput]] as the [[inputExpr]].
     */
-  final case class SortOutput[F[_], V, M[_], R, P](
-    inputExpr: Expr[F, V, M[R], P],
+  final case class SortOutput[V, M[_], R, P](
+    inputExpr: Expr[V, M[R], P],
     sorter: ExprSorter[M, R],
-    capture: CaptureP[F, V, M[R], P],
-  ) extends Expr[F, V, M[R], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitSortOutput(this)
+    capture: CaptureP[V, M[R], P],
+  ) extends Expr[V, M[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitSortOutput(this)
   }
 
   /**
@@ -325,34 +325,34 @@ object Expr {
     * anything other than a single instance of the expected type, so you don't need any type-classes for the
     * return type.
     */
-  final case class WrapOutput[F[_], V, L <: HList, R, P](
-    inputExprHList: NonEmptyExprHList[F, V, Id, L, P],
+  final case class WrapOutput[V, L <: HList, R, P](
+    inputExprHList: NonEmptyExprHList[V, Id, L, P],
     converter: ExprConverter[L, R],
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitWrapOutput(this)
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitWrapOutput(this)
   }
 
   /**
     * Apply a given [[converter]] to every HList produced by zipping the outputs of expressions that return the
     * same higher-kinded sequence, stopping at the shortest sequence.
     */
-  final case class ZipOutput[F[_], V, M[_] : Align : FunctorFilter, L <: HList, R, P](
-    inputExprHList: NonEmptyExprHList[F, V, M, L, P],
+  final case class ZipOutput[V, M[_] : Align : FunctorFilter, L <: HList, R, P](
+    inputExprHList: NonEmptyExprHList[V, M, L, P],
     converter: ExprConverter[L, R],
-    capture: CaptureP[F, V, M[R], P],
-  ) extends Expr[F, V, M[R], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitZipOutput(this)
+    capture: CaptureP[V, M[R], P],
+  ) extends Expr[V, M[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitZipOutput(this)
   }
 
   /**
     * Return true if the output of the given [[inputExpr]] is an empty collection.
     */
-  final case class OutputIsEmpty[F[_], V, M[_] : Foldable, R, P](
-    inputExpr: Expr[F, V, M[R], P],
-    capture: CaptureP[F, V, Boolean, P],
-  ) extends Expr[F, V, Boolean, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[Boolean] = v.visitOutputIsEmpty(this)
+  final case class OutputIsEmpty[V, M[_] : Foldable, R, P](
+    inputExpr: Expr[V, M[R], P],
+    capture: CaptureP[V, Boolean, P],
+  ) extends Expr[V, Boolean, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[Boolean] = v.visitOutputIsEmpty(this)
   }
 
   /**
@@ -362,12 +362,12 @@ object Expr {
     * If negative, it will pull that number of elements from the tail of the sequence. If zero, it will return
     * an empty sequence.
     */
-  final case class TakeFromOutput[F[_], V, M[_] : Traverse : TraverseFilter, R, P](
-    inputExpr: Expr[F, V, M[R], P],
+  final case class TakeFromOutput[V, M[_] : Traverse : TraverseFilter, R, P](
+    inputExpr: Expr[V, M[R], P],
     take: Int,
-    capture: CaptureP[F, V, M[R], P],
-  ) extends Expr[F, V, M[R], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitTakeFromOutput(this)
+    capture: CaptureP[V, M[R], P],
+  ) extends Expr[V, M[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitTakeFromOutput(this)
   }
 
   /**
@@ -378,22 +378,22 @@ object Expr {
     * @note if you want to apply this to the input (i.e. `F[V]`), you can pass [[ReturnInput]] as the [[inputExpr]].
     * @see [[Foldable.exists]] for more details.
     */
-  final case class ExistsInOutput[F[_], V, M[_] : Foldable, U, P](
-    inputExpr: Expr[F, V, M[U], P],
-    conditionExpr: Expr[Id, U, Boolean, P],
-    capture: CaptureP[F, V, Boolean, P],
-  ) extends Expr[F, V, Boolean, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[Boolean] = v.visitExistsInOutput(this)
+  final case class ExistsInOutput[V, M[_] : Foldable, U, P](
+    inputExpr: Expr[V, M[U], P],
+    conditionExpr: Expr[U, Boolean, P],
+    capture: CaptureP[V, Boolean, P],
+  ) extends Expr[V, Boolean, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[Boolean] = v.visitExistsInOutput(this)
   }
 
   /**
     * Adds the results of all expressions in [[inputExprList]] using the provided definition for [[Addition]].
     */
-  final case class AddOutputs[F[_], V, R : Addition, P](
-    inputExprList: NonEmptyList[Expr[F, V, R, P]],
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitAddOutputs(this)
+  final case class AddOutputs[V, R : Addition, P](
+    inputExprList: NonEmptyList[Expr[V, R, P]],
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitAddOutputs(this)
   }
 
   /**
@@ -401,32 +401,32 @@ object Expr {
     *
     * @note the order of expressions matters for subtraction, so all subtraction is applied left-to-right.
     */
-  final case class SubtractOutputs[F[_], V, R : Subtraction, P](
-    inputExprList: NonEmptyList[Expr[F, V, R, P]],
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitSubtractOutputs(this)
+  final case class SubtractOutputs[V, R : Subtraction, P](
+    inputExprList: NonEmptyList[Expr[V, R, P]],
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitSubtractOutputs(this)
   }
 
   /**
     * Returns the negative result value of [[inputExpr]] using the provided definition for [[Negative]].
     */
-  final case class NegativeOutput[F[_], V, R : Negative, P](
-    inputExpr: Expr[F, V, R, P],
-    capture: CaptureP[F, V, R, P],
-  ) extends Expr[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitNegativeOutput(this)
+  final case class NegativeOutput[V, R : Negative, P](
+    inputExpr: Expr[V, R, P],
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitNegativeOutput(this)
   }
 
   /**
     * Checks if the result of the [[inputExpr]] is contained within the given set of [[accepted]] values.
     */
-  final case class OutputWithinSet[F[_], V, R, P](
-    inputExpr: Expr[F, V, R, P],
+  final case class OutputWithinSet[V, R, P](
+    inputExpr: Expr[V, R, P],
     accepted: Set[R],
-    capture: CaptureP[F, V, Boolean, P],
-  ) extends Expr[F, V, Boolean, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[Boolean] = v.visitOutputWithinSet(this)
+    capture: CaptureP[V, Boolean, P],
+  ) extends Expr[V, Boolean, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[Boolean] = v.visitOutputWithinSet(this)
   }
 
   /**
@@ -436,12 +436,12 @@ object Expr {
     *
     * @see [[Window]] for more details.
     */
-  final case class OutputWithinWindow[F[_], V, R, P](
-    inputExpr: Expr[F, V, R, P],
+  final case class OutputWithinWindow[V, R, P](
+    inputExpr: Expr[V, R, P],
     window: Window[R],
-    capture: CaptureP[F, V, Boolean, P],
-  ) extends Expr[F, V, Boolean, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[Boolean] = v.visitOutputWithinWindow(this)
+    capture: CaptureP[V, Boolean, P],
+  ) extends Expr[V, Boolean, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[Boolean] = v.visitOutputWithinWindow(this)
   }
 }
 
@@ -453,7 +453,7 @@ object Expr {
   * @param whenExpr a conditional expression that guards the resulting [[thenExpr]]
   * @param thenExpr an expression to compute the result if the [[whenExpr]] returns true
   */
-final case class ConditionBranch[F[_], V, R, P](
-  whenExpr: Expr[F, V, Boolean, P],
-  thenExpr: Expr[F, V, R, P],
+final case class ConditionBranch[V, R, P](
+  whenExpr: Expr[V, Boolean, P],
+  thenExpr: Expr[V, R, P],
 )

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
@@ -14,56 +14,56 @@ import scala.collection.BitSet
   * You can fold over this result to see the input, output, value, and captured custom parameter at each node in the
   * original expression. Every node of this algebra matches to the [[Expr]] subclass with the same name.
   */
-sealed trait ExprResult[F[_], V, R, P] {
+sealed trait ExprResult[V, R, P] {
 
-  def context: ExprResult.Context[F, V, R, P]
+  def context: ExprResult.Context[V, R, P]
 
-  @inline final def input: ExprInput[F, V] = context.input
+  @inline final def input: ExprInput[V] = context.input
 
   @inline final def output: ExprOutput[R] = context.output
 
   @inline final def param: Eval[P] = context.param
 
-  def visit[G[_]](v: ExprResult.Visitor[F, V, P, G]): G[R]
+  def visit[G[_]](v: ExprResult.Visitor[V, P, G]): G[R]
 }
 
 object ExprResult {
 
-  final case class Context[F[_], V, R, P](
-    input: ExprInput[F, V],
+  final case class Context[V, R, P](
+    input: ExprInput[V],
     output: ExprOutput[R],
     param: Eval[P],
   )
 
-  trait Visitor[F[_], V, P, G[_]] extends (ExprResult[F, V, *, P] ~> G) {
+  trait Visitor[V, P, G[_]] extends (ExprResult[V, *, P] ~> G) {
     // Please keep the following methods in alphabetical order
-    override final def apply[R](fa: ExprResult[F, V, R, P]): G[R] = fa.visit(this)
-    def visitAddOutputs[R](result: AddOutputs[F, V, R, P]): G[R]
-    def visitAnd[R](result: And[F, V, R, P]): G[R]
-    def visitCollectFromOutput[M[_] : Foldable, U, R : Monoid](result: CollectFromOutput[F, V, M, U, R, P]): G[R]
-    def visitConstOutput[R](result: ConstOutput[F, V, R, P]): G[R]
-    def visitDeclare[M[_], T](result: Define[F, V, M, T, P]): G[FactSet]
-    def visitEmbed[R](result: Embed[F, V, R, P]): G[R]
-    def visitExistsInOutput[M[_] : Foldable, U](result: ExistsInOutput[F, V, M, U, P]): G[Boolean]
-    def visitFilterOutput[M[_] : Foldable : FunctorFilter, R](result: FilterOutput[F, V, M, R, P]): G[M[R]]
-    def visitFlatMapOutput[M[_], U, R](result: FlatMapOutput[F, V, M, U, R, P]): G[M[R]]
-    def visitMapOutput[M[_], U, R](result: MapOutput[F, V, M, U, R, P]): G[M[R]]
-    def visitNegativeOutput[R](result: NegativeOutput[F, V, R, P]): G[R]
-    def visitNot[R](result: Not[F, V, R, P]): G[R]
-    def visitOr[R](result: Or[F, V, R, P]): G[R]
-    def visitOutputIsEmpty[M[_] : Foldable, R](result: OutputIsEmpty[F, V, M, R, P]): G[Boolean]
-    def visitOutputWithinSet[R](result: OutputWithinSet[F, V, R, P]): G[Boolean]
-    def visitOutputWithinWindow[R](result: OutputWithinWindow[F, V, R, P]): G[Boolean]
-    def visitReturnInput(result: ReturnInput[F, V, P]): G[F[V]]
-    def visitSelectFromOutput[S, R](result: SelectFromOutput[F, V, S, R, P]): G[R]
-    def visitSortOutput[M[_], R](result: SortOutput[F, V, M, R, P]): G[M[R]]
-    def visitSubtractOutputs[R](result: SubtractOutputs[F, V, R, P]): G[R]
-    def visitTakeFromOutput[M[_] : Traverse : TraverseFilter, R](result: TakeFromOutput[F, V, M, R, P]): G[M[R]]
-    def visitUsingDefinitions[R](result: UsingDefinitions[F, V, R, P]): G[R]
-    def visitWhen[R](result: When[F, V, R, P]): G[R]
-    def visitWrapOutput[T <: HList, R](result: WrapOutput[F, V, T, R, P]): G[R]
-    def visitWithFactsOfType[T, R](result: WithFactsOfType[F, V, T, R, P]): G[R]
-    def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](result: ZipOutput[F, V, M, L, R, P]): G[M[R]]
+    override final def apply[R](fa: ExprResult[V, R, P]): G[R] = fa.visit(this)
+    def visitAddOutputs[R](result: AddOutputs[V, R, P]): G[R]
+    def visitAnd[R](result: And[V, R, P]): G[R]
+    def visitCollectFromOutput[M[_] : Foldable, U, R : Monoid](result: CollectFromOutput[V, M, U, R, P]): G[R]
+    def visitConstOutput[R](result: ConstOutput[V, R, P]): G[R]
+    def visitDeclare[M[_], T](result: Define[V, M, T, P]): G[FactSet]
+    def visitEmbed[R](result: Embed[V, R, P]): G[R]
+    def visitExistsInOutput[M[_] : Foldable, U](result: ExistsInOutput[V, M, U, P]): G[Boolean]
+    def visitFilterOutput[M[_] : Foldable : FunctorFilter, R](result: FilterOutput[V, M, R, P]): G[M[R]]
+    def visitFlatMapOutput[M[_], U, R](result: FlatMapOutput[V, M, U, R, P]): G[M[R]]
+    def visitMapOutput[M[_], U, R](result: MapOutput[V, M, U, R, P]): G[M[R]]
+    def visitNegativeOutput[R](result: NegativeOutput[V, R, P]): G[R]
+    def visitNot[R](result: Not[V, R, P]): G[R]
+    def visitOr[R](result: Or[V, R, P]): G[R]
+    def visitOutputIsEmpty[M[_] : Foldable, R](result: OutputIsEmpty[V, M, R, P]): G[Boolean]
+    def visitOutputWithinSet[R](result: OutputWithinSet[V, R, P]): G[Boolean]
+    def visitOutputWithinWindow[R](result: OutputWithinWindow[V, R, P]): G[Boolean]
+    def visitReturnInput(result: ReturnInput[V, P]): G[V]
+    def visitSelectFromOutput[S, R](result: SelectFromOutput[V, S, R, P]): G[R]
+    def visitSortOutput[M[_], R](result: SortOutput[V, M, R, P]): G[M[R]]
+    def visitSubtractOutputs[R](result: SubtractOutputs[V, R, P]): G[R]
+    def visitTakeFromOutput[M[_] : Traverse : TraverseFilter, R](result: TakeFromOutput[V, M, R, P]): G[M[R]]
+    def visitUsingDefinitions[R](result: UsingDefinitions[V, R, P]): G[R]
+    def visitWhen[R](result: When[V, R, P]): G[R]
+    def visitWrapOutput[T <: HList, R](result: WrapOutput[V, T, R, P]): G[R]
+    def visitWithFactsOfType[T, R](result: WithFactsOfType[V, T, R, P]): G[R]
+    def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](result: ZipOutput[V, M, L, R, P]): G[M[R]]
   }
 
   /*
@@ -79,215 +79,215 @@ object ExprResult {
    * without the compiler complaining.
    */
 
-  final case class ConstOutput[F[_], V, R, P](
-    expr: Expr.ConstOutput[F, V, R, P],
-    context: Context[F, V, R, P],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitConstOutput(this)
+  final case class ConstOutput[V, R, P](
+    expr: Expr.ConstOutput[V, R, P],
+    context: Context[V, R, P],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitConstOutput(this)
   }
 
-  final case class ReturnInput[F[_], V, P](
-    expr: Expr.ReturnInput[F, V, P],
-    context: Context[F, V, F[V], P],
-  ) extends ExprResult[F, V, F[V], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[F[V]] = v.visitReturnInput(this)
+  final case class ReturnInput[V, P](
+    expr: Expr.ReturnInput[V, P],
+    context: Context[V, V, P],
+  ) extends ExprResult[V, V, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[V] = v.visitReturnInput(this)
   }
 
-  final case class Embed[F[_], V, R, P](
-    expr: Expr.Embed[F, V, R, P],
-    context: Context[F, V, R, P],
-    embeddedResult: ExprResult[Id, FactTable, R, P],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitEmbed(this)
+  final case class Embed[V, R, P](
+    expr: Expr.Embed[V, R, P],
+    context: Context[V, R, P],
+    embeddedResult: ExprResult[FactTable, R, P],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitEmbed(this)
   }
 
-  final case class WithFactsOfType[F[_], V, T, R, P](
+  final case class WithFactsOfType[V, T, R, P](
     expr: Expr.WithFactsOfType[T, R, P],
-    context: Context[F, V, R, P],
-    subResult: ExprResult[Seq, TypedFact[T], R, P],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitWithFactsOfType(this)
+    context: Context[V, R, P],
+    subResult: ExprResult[Seq[TypedFact[T]], R, P],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitWithFactsOfType(this)
   }
 
-  final case class Define[F[_], V, M[_], T, P](
+  final case class Define[V, M[_], T, P](
     expr: Expr.Define[M, T, P],
-    context: Context[F, V, FactSet, P],
-    definitionResult: ExprResult[Id, FactTable, M[T], P],
-  ) extends ExprResult[F, V, FactSet, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[FactSet] = v.visitDeclare(this)
+    context: Context[V, FactSet, P],
+    definitionResult: ExprResult[FactTable, M[T], P],
+  ) extends ExprResult[V, FactSet, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[FactSet] = v.visitDeclare(this)
   }
 
-  final case class UsingDefinitions[F[_], V, R, P](
-    expr: Expr.UsingDefinitions[F, V, R, P],
-    context: Context[F, V, R, P],
-    subResult: ExprResult[F, V, R, P],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitUsingDefinitions(this)
+  final case class UsingDefinitions[V, R, P](
+    expr: Expr.UsingDefinitions[V, R, P],
+    context: Context[V, R, P],
+    subResult: ExprResult[V, R, P],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitUsingDefinitions(this)
   }
 
-  final case class And[F[_], V, R, P](
-    expr: Expr.And[F, V, R, P],
-    context: Context[F, V, R, P],
-    subResultList: List[ExprResult[F, V, R, P]],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitAnd(this)
+  final case class And[V, R, P](
+    expr: Expr.And[V, R, P],
+    context: Context[V, R, P],
+    subResultList: List[ExprResult[V, R, P]],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitAnd(this)
   }
 
-  final case class Or[F[_], V, R, P](
-    expr: Expr.Or[F, V, R, P],
-    context: Context[F, V, R, P],
-    subResultList: List[ExprResult[F, V, R, P]],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitOr(this)
+  final case class Or[V, R, P](
+    expr: Expr.Or[V, R, P],
+    context: Context[V, R, P],
+    subResultList: List[ExprResult[V, R, P]],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitOr(this)
   }
 
-  final case class Not[F[_], V, R, P](
-    expr: Expr.Not[F, V, R, P],
-    context: Context[F, V, R, P],
-    subResult: ExprResult[F, V, R, P],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitNot(this)
+  final case class Not[V, R, P](
+    expr: Expr.Not[V, R, P],
+    context: Context[V, R, P],
+    subResult: ExprResult[V, R, P],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitNot(this)
   }
 
-  final case class When[F[_], V, R, P](
-    expr: Expr.When[F, V, R, P],
-    context: Context[F, V, R, P],
-    matchedBranch: Option[ConditionBranch[F, V, R, P]],
-    subResult: ExprResult[F, V, R, P],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitWhen(this)
-    val thenExpr: Expr[F, V, R, P] = matchedBranch.map(_.thenExpr).getOrElse(expr.defaultExpr)
+  final case class When[V, R, P](
+    expr: Expr.When[V, R, P],
+    context: Context[V, R, P],
+    matchedBranch: Option[ConditionBranch[V, R, P]],
+    subResult: ExprResult[V, R, P],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitWhen(this)
+    val thenExpr: Expr[V, R, P] = matchedBranch.map(_.thenExpr).getOrElse(expr.defaultExpr)
   }
 
-  final case class SelectFromOutput[F[_], V, S, R, P](
-    expr: Expr.SelectFromOutput[F, V, S, R, P],
-    context: Context[F, V, R, P],
-    inputResult: ExprResult[F, V, S, P],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitSelectFromOutput(this)
+  final case class SelectFromOutput[V, S, R, P](
+    expr: Expr.SelectFromOutput[V, S, R, P],
+    context: Context[V, R, P],
+    inputResult: ExprResult[V, S, P],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitSelectFromOutput(this)
   }
 
-  final case class FilterOutput[F[_], V, M[_] : Foldable : FunctorFilter, R, P](
-    expr: Expr.FilterOutput[F, V, M, R, P],
-    context: Context[F, V, M[R], P],
-    inputResult: ExprResult[F, V, M[R], P],
-    condResultList: List[ExprResult[Id, R, Boolean, P]],
-  ) extends ExprResult[F, V, M[R], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitFilterOutput(this)
+  final case class FilterOutput[V, M[_] : Foldable : FunctorFilter, R, P](
+    expr: Expr.FilterOutput[V, M, R, P],
+    context: Context[V, M[R], P],
+    inputResult: ExprResult[V, M[R], P],
+    condResultList: List[ExprResult[R, Boolean, P]],
+  ) extends ExprResult[V, M[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitFilterOutput(this)
   }
 
-  final case class CollectFromOutput[F[_], V, M[_] : Foldable, U, R : Monoid, P](
-    expr: Expr.CollectFromOutput[F, V, M, U, R, P],
-    context: Context[F, V, R, P],
-    inputResult: ExprResult[F, V, M[U], P],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitCollectFromOutput(this)
+  final case class CollectFromOutput[V, M[_] : Foldable, U, R : Monoid, P](
+    expr: Expr.CollectFromOutput[V, M, U, R, P],
+    context: Context[V, R, P],
+    inputResult: ExprResult[V, M[U], P],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitCollectFromOutput(this)
   }
 
-  final case class FlatMapOutput[F[_], V, M[_], U, R, P](
-    expr: Expr.FlatMapOutput[F, V, M, U, R, P],
-    context: Context[F, V, M[R], P],
-    inputResult: ExprResult[F, V, M[U], P],
-    subResultList: List[ExprResult[Id, U, M[R], P]],
-  ) extends ExprResult[F, V, M[R], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitFlatMapOutput(this)
+  final case class FlatMapOutput[V, M[_], U, R, P](
+    expr: Expr.FlatMapOutput[V, M, U, R, P],
+    context: Context[V, M[R], P],
+    inputResult: ExprResult[V, M[U], P],
+    subResultList: List[ExprResult[U, M[R], P]],
+  ) extends ExprResult[V, M[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitFlatMapOutput(this)
   }
 
-  final case class MapOutput[F[_], V, M[_], U, R, P](
-    expr: Expr.MapOutput[F, V, M, U, R, P],
-    context: Context[F, V, M[R], P],
-    inputResult: ExprResult[F, V, M[U], P],
-    subResultList: List[ExprResult[Id, U, R, P]],
-  ) extends ExprResult[F, V, M[R], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitMapOutput(this)
+  final case class MapOutput[V, M[_], U, R, P](
+    expr: Expr.MapOutput[V, M, U, R, P],
+    context: Context[V, M[R], P],
+    inputResult: ExprResult[V, M[U], P],
+    subResultList: List[ExprResult[U, R, P]],
+  ) extends ExprResult[V, M[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitMapOutput(this)
   }
 
-  final case class SortOutput[F[_], V, M[_], R, P](
-    expr: Expr.SortOutput[F, V, M, R, P],
-    context: Context[F, V, M[R], P],
-    inputResult: ExprResult[F, V, M[R], P],
-  ) extends ExprResult[F, V, M[R], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitSortOutput(this)
+  final case class SortOutput[V, M[_], R, P](
+    expr: Expr.SortOutput[V, M, R, P],
+    context: Context[V, M[R], P],
+    inputResult: ExprResult[V, M[R], P],
+  ) extends ExprResult[V, M[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitSortOutput(this)
   }
 
-  final case class OutputIsEmpty[F[_], V, M[_] : Foldable, R, P](
-    expr: Expr.OutputIsEmpty[F, V, M, R, P],
-    context: Context[F, V, Boolean, P],
-    inputResult: ExprResult[F, V, M[R], P],
-  ) extends ExprResult[F, V, Boolean, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[Boolean] = v.visitOutputIsEmpty(this)
+  final case class OutputIsEmpty[V, M[_] : Foldable, R, P](
+    expr: Expr.OutputIsEmpty[V, M, R, P],
+    context: Context[V, Boolean, P],
+    inputResult: ExprResult[V, M[R], P],
+  ) extends ExprResult[V, Boolean, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[Boolean] = v.visitOutputIsEmpty(this)
   }
 
-  final case class TakeFromOutput[F[_], V, M[_] : Traverse : TraverseFilter, R, P](
-    expr: Expr.TakeFromOutput[F, V, M, R, P],
-    context: Context[F, V, M[R], P],
-    inputResult: ExprResult[F, V, M[R], P],
-  ) extends ExprResult[F, V, M[R], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitTakeFromOutput(this)
+  final case class TakeFromOutput[V, M[_] : Traverse : TraverseFilter, R, P](
+    expr: Expr.TakeFromOutput[V, M, R, P],
+    context: Context[V, M[R], P],
+    inputResult: ExprResult[V, M[R], P],
+  ) extends ExprResult[V, M[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitTakeFromOutput(this)
   }
 
-  final case class ExistsInOutput[F[_], V, M[_] : Foldable, U, P](
-    expr: Expr.ExistsInOutput[F, V, M, U, P],
-    context: Context[F, V, Boolean, P],
-    inputResult: ExprResult[F, V, M[U], P],
-    conditionResultList: List[ExprResult[Id, U, Boolean, P]],
+  final case class ExistsInOutput[V, M[_] : Foldable, U, P](
+    expr: Expr.ExistsInOutput[V, M, U, P],
+    context: Context[V, Boolean, P],
+    inputResult: ExprResult[V, M[U], P],
+    conditionResultList: List[ExprResult[U, Boolean, P]],
     matchedIndexes: BitSet,
-  ) extends ExprResult[F, V, Boolean, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[Boolean] = v.visitExistsInOutput(this)
+  ) extends ExprResult[V, Boolean, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[Boolean] = v.visitExistsInOutput(this)
   }
 
-  final case class AddOutputs[F[_], V, R, P](
-    expr: Expr.AddOutputs[F, V, R, P],
-    context: Context[F, V, R, P],
-    subResultList: List[ExprResult[F, V, R, P]],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitAddOutputs(this)
+  final case class AddOutputs[V, R, P](
+    expr: Expr.AddOutputs[V, R, P],
+    context: Context[V, R, P],
+    subResultList: List[ExprResult[V, R, P]],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitAddOutputs(this)
   }
 
-  final case class SubtractOutputs[F[_], V, R, P](
-    expr: Expr.SubtractOutputs[F, V, R, P],
-    context: Context[F, V, R, P],
-    subResultList: List[ExprResult[F, V, R, P]],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitSubtractOutputs(this)
+  final case class SubtractOutputs[V, R, P](
+    expr: Expr.SubtractOutputs[V, R, P],
+    context: Context[V, R, P],
+    subResultList: List[ExprResult[V, R, P]],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitSubtractOutputs(this)
   }
 
-  final case class WrapOutput[F[_], V, T <: HList, R, P](
-    expr: Expr.WrapOutput[F, V, T, R, P],
-    context: Context[F, V, R, P],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitWrapOutput(this)
+  final case class WrapOutput[V, T <: HList, R, P](
+    expr: Expr.WrapOutput[V, T, R, P],
+    context: Context[V, R, P],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitWrapOutput(this)
   }
 
-  final case class ZipOutput[F[_], V, M[_] : Align : FunctorFilter, L <: HList, R, P](
-    expr: Expr.ZipOutput[F, V, M, L, R, P],
-    context: Context[F, V, M[R], P],
-  ) extends ExprResult[F, V, M[R], P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[M[R]] = v.visitZipOutput(this)
+  final case class ZipOutput[V, M[_] : Align : FunctorFilter, L <: HList, R, P](
+    expr: Expr.ZipOutput[V, M, L, R, P],
+    context: Context[V, M[R], P],
+  ) extends ExprResult[V, M[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitZipOutput(this)
   }
 
-  final case class NegativeOutput[F[_], V, R, P](
-    expr: Expr.NegativeOutput[F, V, R, P],
-    context: Context[F, V, R, P],
-    inputResult: ExprResult[F, V, R, P],
-  ) extends ExprResult[F, V, R, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[R] = v.visitNegativeOutput(this)
+  final case class NegativeOutput[V, R, P](
+    expr: Expr.NegativeOutput[V, R, P],
+    context: Context[V, R, P],
+    inputResult: ExprResult[V, R, P],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitNegativeOutput(this)
   }
 
-  final case class OutputWithinSet[F[_], V, R, P](
-    expr: Expr.OutputWithinSet[F, V, R, P],
-    context: Context[F, V, Boolean, P],
-    inputResult: ExprResult[F, V, R, P],
-  ) extends ExprResult[F, V, Boolean, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[Boolean] = v.visitOutputWithinSet(this)
+  final case class OutputWithinSet[V, R, P](
+    expr: Expr.OutputWithinSet[V, R, P],
+    context: Context[V, Boolean, P],
+    inputResult: ExprResult[V, R, P],
+  ) extends ExprResult[V, Boolean, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[Boolean] = v.visitOutputWithinSet(this)
   }
 
-  final case class OutputWithinWindow[F[_], V, R, P](
-    expr: Expr.OutputWithinWindow[F, V, R, P],
-    context: Context[F, V, Boolean, P],
-    inputResult: ExprResult[F, V, R, P],
-  ) extends ExprResult[F, V, Boolean, P] {
-    override def visit[G[_]](v: Visitor[F, V, P, G]): G[Boolean] = v.visitOutputWithinWindow(this)
+  final case class OutputWithinWindow[V, R, P](
+    expr: Expr.OutputWithinWindow[V, R, P],
+    context: Context[V, Boolean, P],
+    inputResult: ExprResult[V, R, P],
+  ) extends ExprResult[V, Boolean, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[Boolean] = v.visitOutputWithinWindow(this)
   }
 
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprDsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprDsl.scala
@@ -176,17 +176,25 @@ trait ExprDsl extends WrapExprSyntax with WrapEachExprSyntax {
   ): Expr.ExistsInOutput[V, M, U, P] =
     Expr.ExistsInOutput(inputExpr, condExpr, capture)
 
+  def returnInput[V, P](
+    implicit
+    capture: CaptureP[V, V, P],
+  ): Expr.ReturnInput[V, P] =
+    Expr.ReturnInput(capture)
+
+  @deprecated("Use returnInput instead", "0.10.0")
   def returnInputFoldable[V, P](
     implicit
     capture: CaptureP[V, V, P],
   ): Expr.ReturnInput[V, P] =
     Expr.ReturnInput(capture)
 
+  @deprecated("Use returnInput instead", "0.10.0")
   def returnInputValue[V, P](
     implicit
     capture: CaptureP[V, V, P],
   ): Expr.ReturnInput[V, P] =
-    Expr.ReturnInput[V, P](capture)
+    Expr.ReturnInput(capture)
 
   def within[V, R, P](
     inputExpr: Expr[V, R, P],

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprDsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprDsl.scala
@@ -13,22 +13,22 @@ import com.rallyhealth.vapors.core.math.{Addition, Negative, Subtraction}
 object ExprDsl extends ExprDsl {
 
   @deprecated("Use com.rallyhealth.vapors.core.dsl.CondExpr instead.", "0.8.0")
-  final type CondExpr[F[_], V, P] = Expr[F, V, Boolean, P]
+  final type CondExpr[V, P] = Expr[V, Boolean, P]
 
   @deprecated("Use com.rallyhealth.vapors.core.dsl.ValExpr instead.", "0.8.0")
-  final type ValExpr[V, R, P] = Expr[Id, V, R, P]
+  final type ValExpr[V, R, P] = Expr[V, R, P]
 
   @deprecated("Use com.rallyhealth.vapors.core.dsl.ValCondExpr instead.", "0.8.0")
   final type ValCondExpr[V, P] = dsl.ValExpr[V, Boolean, P]
 
   @deprecated("Use com.rallyhealth.vapors.core.dsl.RootExpr instead.", "0.8.0")
-  final type RootExpr[R, P] = Expr[Id, FactTable, R, P]
+  final type RootExpr[R, P] = Expr[FactTable, R, P]
 }
 
 // TODO: Remove methods that are not useful anymore and move less-useful methods to a separate object
 trait ExprDsl extends WrapExprSyntax with WrapEachExprSyntax {
 
-  def eval[R, P](facts: FactTable)(query: RootExpr[R, P]): ExprResult[Id, FactTable, R, P] = {
+  def eval[R, P](facts: FactTable)(query: RootExpr[R, P]): ExprResult[FactTable, R, P] = {
     InterpretExprAsResultFn(query)(ExprInput.fromFactTable(facts))
   }
 
@@ -40,7 +40,7 @@ trait ExprDsl extends WrapExprSyntax with WrapEachExprSyntax {
     evidence: Evidence = Evidence.none,
   )(implicit
     capture: CaptureRootExpr[R, P],
-  ): Expr.ConstOutput[Id, FactTable, R, P] =
+  ): Expr.ConstOutput[FactTable, R, P] =
     Expr.ConstOutput(value, evidence, capture)
 
   /**
@@ -50,70 +50,70 @@ trait ExprDsl extends WrapExprSyntax with WrapEachExprSyntax {
     typedFact: TypedFact[R],
   )(implicit
     capture: CaptureRootExpr[R, P],
-  ): Expr.ConstOutput[Id, FactTable, R, P] =
+  ): Expr.ConstOutput[FactTable, R, P] =
     const(typedFact.value, Evidence(typedFact))
 
-  def input[F[_], V, P](
+  def input[V, P](
     implicit
-    capture: CaptureP[F, V, F[V], P],
-  ): Expr.ReturnInput[F, V, P] =
+    capture: CaptureP[V, V, P],
+  ): Expr.ReturnInput[V, P] =
     Expr.ReturnInput(capture)
 
   def define[T](factType: FactType[T]): DefinitionExprBuilder[T] = new DefinitionExprBuilder(factType)
 
-  def usingDefinitions[F[_], V, R, P](
+  def usingDefinitions[V, R, P](
     definitions: Expr.Definition[P]*,
   )(
-    subExpr: Expr[F, V, R, P],
+    subExpr: Expr[V, R, P],
   )(implicit
-    captureResult: CaptureP[F, V, R, P],
-  ): Expr.UsingDefinitions[F, V, R, P] =
+    captureResult: CaptureP[V, R, P],
+  ): Expr.UsingDefinitions[V, R, P] =
     Expr.UsingDefinitions(definitions.toVector, subExpr, captureResult)
 
-  def embed[F[_], V, R, P](
+  def embed[V, R, P](
     expr: RootExpr[R, P],
   )(implicit
-    captureResult: CaptureP[F, V, R, P],
-  ): Expr.Embed[F, V, R, P] =
+    captureResult: CaptureP[V, R, P],
+  ): Expr.Embed[V, R, P] =
     Expr.Embed(expr, captureResult)
 
-  def and[F[_], V, R : Conjunction : ExtractBoolean, P](
-    first: Expr[F, V, R, P],
-    second: Expr[F, V, R, P],
-    remaining: Expr[F, V, R, P]*,
+  def and[V, R : Conjunction : ExtractBoolean, P](
+    first: Expr[V, R, P],
+    second: Expr[V, R, P],
+    remaining: Expr[V, R, P]*,
   )(implicit
-    captureResult: CaptureP[F, V, R, P],
-  ): Expr.And[F, V, R, P] = {
+    captureResult: CaptureP[V, R, P],
+  ): Expr.And[V, R, P] = {
     val subExpressions = first :: NonEmptyList.of(second, remaining: _*)
     Expr.And(subExpressions, captureResult)
   }
 
-  def or[F[_], V, R : Disjunction : ExtractBoolean, P](
-    first: Expr[F, V, R, P],
-    second: Expr[F, V, R, P],
-    remaining: Expr[F, V, R, P]*,
+  def or[V, R : Disjunction : ExtractBoolean, P](
+    first: Expr[V, R, P],
+    second: Expr[V, R, P],
+    remaining: Expr[V, R, P]*,
   )(implicit
-    captureResult: CaptureP[F, V, R, P],
-  ): Expr.Or[F, V, R, P] = {
+    captureResult: CaptureP[V, R, P],
+  ): Expr.Or[V, R, P] = {
     val subExpressions = first :: NonEmptyList.of(second, remaining: _*)
     Expr.Or(subExpressions, captureResult)
   }
 
-  def not[F[_], V, R : Negation, P](
-    sub: Expr[F, V, R, P],
+  def not[V, R : Negation, P](
+    sub: Expr[V, R, P],
   )(implicit
-    captureResult: CaptureP[F, V, R, P],
-  ): Expr.Not[F, V, R, P] =
+    captureResult: CaptureP[V, R, P],
+  ): Expr.Not[V, R, P] =
     Expr.Not(sub, captureResult)
 
-  def when[F[_], V, R, P](condExpr: CondExpr[F, V, P]): WhenExprBuilder[F, V, P] = new WhenExprBuilder(condExpr)
+  def when[V, R, P](condExpr: CondExpr[V, P]): WhenExprBuilder[V, P] = new WhenExprBuilder(condExpr)
 
   def factsOfType[T, P](
     factTypeSet: FactTypeSet[T],
   )(implicit
     captureInput: CaptureFromFacts[T, P],
     captureAllResults: CaptureRootExpr[Seq[TypedFact[T]], P],
-  ): FoldableExprBuilder[Id, FactTable, Seq, TypedFact[T], P] =
+  ): FoldableExprBuilder[FactTable, Seq, TypedFact[T], P] =
     new FoldableExprBuilder(
       Expr.WithFactsOfType[T, Seq[TypedFact[T]], P](
         factTypeSet,
@@ -129,70 +129,70 @@ trait ExprDsl extends WrapExprSyntax with WrapEachExprSyntax {
   ): WithFactsOfTypeBuilder[T, P] =
     new WithFactsOfTypeBuilder(factTypeSet)
 
-  def collectSome[F[_], V, M[_] : Foldable, U, R : Monoid, P](
-    inputExpr: Expr[F, V, M[U], P],
+  def collectSome[V, M[_] : Foldable, U, R : Monoid, P](
+    inputExpr: Expr[V, M[U], P],
     collectExpr: ValExpr[U, Option[R], P],
   )(implicit
-    capture: CaptureP[F, V, R, P],
-  ): Expr.CollectFromOutput[F, V, M, U, R, P] =
+    capture: CaptureP[V, R, P],
+  ): Expr.CollectFromOutput[V, M, U, R, P] =
     Expr.CollectFromOutput(inputExpr, collectExpr, capture)
 
-  def selectFrom[F[_], V, S, R, P](
-    inputExpr: Expr[F, V, S, P],
+  def selectFrom[V, S, R, P](
+    inputExpr: Expr[V, S, P],
     lens: NamedLens[S, R],
   )(implicit
-    captureInput: CaptureP[F, V, R, P],
-  ): Expr.SelectFromOutput[F, V, S, R, P] =
+    captureInput: CaptureP[V, R, P],
+  ): Expr.SelectFromOutput[V, S, R, P] =
     Expr.SelectFromOutput(inputExpr, lens, captureInput)
 
-  def add[F[_], V, R : Addition, P](
-    lhs: Expr[F, V, R, P],
-    rhs: Expr[F, V, R, P],
+  def add[V, R : Addition, P](
+    lhs: Expr[V, R, P],
+    rhs: Expr[V, R, P],
   )(implicit
-    capture: CaptureP[F, V, R, P],
-  ): Expr.AddOutputs[F, V, R, P] =
+    capture: CaptureP[V, R, P],
+  ): Expr.AddOutputs[V, R, P] =
     Expr.AddOutputs(NonEmptyList.of(lhs, rhs), capture)
 
-  def subtract[F[_], V, R : Subtraction, P](
-    lhs: Expr[F, V, R, P],
-    rhs: Expr[F, V, R, P],
+  def subtract[V, R : Subtraction, P](
+    lhs: Expr[V, R, P],
+    rhs: Expr[V, R, P],
   )(implicit
-    capture: CaptureP[F, V, R, P],
-  ): Expr.SubtractOutputs[F, V, R, P] =
+    capture: CaptureP[V, R, P],
+  ): Expr.SubtractOutputs[V, R, P] =
     Expr.SubtractOutputs(NonEmptyList.of(lhs, rhs), capture)
 
-  def negative[F[_], V, R : Negative, P](
-    inputExpr: Expr[F, V, R, P],
+  def negative[V, R : Negative, P](
+    inputExpr: Expr[V, R, P],
   )(implicit
-    capture: CaptureP[F, V, R, P],
-  ): Expr.NegativeOutput[F, V, R, P] =
+    capture: CaptureP[V, R, P],
+  ): Expr.NegativeOutput[V, R, P] =
     Expr.NegativeOutput(inputExpr, capture)
 
-  def exists[F[_], V, M[_] : Foldable, U, P](
-    inputExpr: Expr[F, V, M[U], P],
+  def exists[V, M[_] : Foldable, U, P](
+    inputExpr: Expr[V, M[U], P],
     condExpr: ValCondExpr[U, P],
   )(implicit
-    capture: CaptureP[F, V, Boolean, P],
-  ): Expr.ExistsInOutput[F, V, M, U, P] =
+    capture: CaptureP[V, Boolean, P],
+  ): Expr.ExistsInOutput[V, M, U, P] =
     Expr.ExistsInOutput(inputExpr, condExpr, capture)
 
-  def returnInputFoldable[F[_], V, P](
+  def returnInputFoldable[V, P](
     implicit
-    capture: CaptureP[F, V, F[V], P],
-  ): Expr.ReturnInput[F, V, P] =
+    capture: CaptureP[V, V, P],
+  ): Expr.ReturnInput[V, P] =
     Expr.ReturnInput(capture)
 
   def returnInputValue[V, P](
     implicit
-    capture: CaptureP[Id, V, V, P],
-  ): Expr.ReturnInput[Id, V, P] =
-    Expr.ReturnInput[Id, V, P](capture)
+    capture: CaptureP[V, V, P],
+  ): Expr.ReturnInput[V, P] =
+    Expr.ReturnInput[V, P](capture)
 
-  def within[F[_], V, R, P](
-    inputExpr: Expr[F, V, R, P],
+  def within[V, R, P](
+    inputExpr: Expr[V, R, P],
     window: Window[R],
   )(implicit
-    capture: CaptureP[F, V, Boolean, P],
-  ): Expr.OutputWithinWindow[F, V, R, P] =
+    capture: CaptureP[V, Boolean, P],
+  ): Expr.OutputWithinWindow[V, R, P] =
     Expr.OutputWithinWindow(inputExpr, window, capture)
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/HListOperationWrapper.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/HListOperationWrapper.scala
@@ -4,21 +4,21 @@ import com.rallyhealth.vapors.core.algebra.{CaptureP, Expr, ExprConverter, NonEm
 import shapeless.ops.hlist.Tupler
 import shapeless.{Generic, HList}
 
-trait HListOperationWrapper[F[_], V, M[_], L <: HList, P] extends Any {
+trait HListOperationWrapper[V, M[_], L <: HList, P] extends Any {
 
-  type Op[R] <: Expr[F, V, M[R], P]
+  type Op[R] <: Expr[V, M[R], P]
 
-  protected def exprHList: NonEmptyExprHList[F, V, M, L, P]
+  protected def exprHList: NonEmptyExprHList[V, M, L, P]
 
   protected def buildOp[R](
     converter: ExprConverter[L, R],
-    captureResult: CaptureP[F, V, M[R], P],
+    captureResult: CaptureP[V, M[R], P],
   ): Op[R]
 
   final def asTuple[T](
     implicit
     tupler: Tupler.Aux[L, T],
-    captureResult: CaptureP[F, V, M[T], P],
+    captureResult: CaptureP[V, M[T], P],
   ): Op[T] =
     buildOp(
       ExprConverter.asTuple,
@@ -27,7 +27,7 @@ trait HListOperationWrapper[F[_], V, M[_], L <: HList, P] extends Any {
 
   final def asHList(
     implicit
-    captureResult: CaptureP[F, V, M[L], P],
+    captureResult: CaptureP[V, M[L], P],
   ): Op[L] =
     buildOp(
       ExprConverter.asHListIdentity,
@@ -37,7 +37,7 @@ trait HListOperationWrapper[F[_], V, M[_], L <: HList, P] extends Any {
   final def as[R](
     implicit
     gen: Generic.Aux[R, L],
-    captureResult: CaptureP[F, V, M[R], P],
+    captureResult: CaptureP[V, M[R], P],
   ): Op[R] =
     buildOp(
       ExprConverter.asProductType,

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WhenExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WhenExprBuilder.scala
@@ -3,29 +3,27 @@ package com.rallyhealth.vapors.core.dsl
 import cats.data.NonEmptyList
 import com.rallyhealth.vapors.core.algebra.{CaptureP, ConditionBranch, Expr}
 
-final class WhenExprBuilder[F[_], V, P](private val whenExpr: CondExpr[F, V, P]) extends AnyVal {
+final class WhenExprBuilder[V, P](private val whenExpr: CondExpr[V, P]) extends AnyVal {
 
-  def thenReturn[R](thenExpr: Expr[F, V, R, P]): WhenElseExprBuilder[F, V, R, P] =
+  def thenReturn[R](thenExpr: Expr[V, R, P]): WhenElseExprBuilder[V, R, P] =
     new WhenElseExprBuilder(NonEmptyList.of(ConditionBranch(whenExpr, thenExpr)))
 }
 
-final class WhenElifExprBuilder[F[_], V, R, P](
-  private val t: (CondExpr[F, V, P], NonEmptyList[ConditionBranch[F, V, R, P]]),
-) extends AnyVal {
+final class WhenElifExprBuilder[V, R, P](private val t: (CondExpr[V, P], NonEmptyList[ConditionBranch[V, R, P]]))
+  extends AnyVal {
 
-  def thenReturn(thenExpr: Expr[F, V, R, P]): WhenElseExprBuilder[F, V, R, P] =
+  def thenReturn(thenExpr: Expr[V, R, P]): WhenElseExprBuilder[V, R, P] =
     new WhenElseExprBuilder(ConditionBranch(t._1, thenExpr) :: t._2)
 }
 
-final class WhenElseExprBuilder[F[_], V, R, P](private val branches: NonEmptyList[ConditionBranch[F, V, R, P]])
-  extends AnyVal {
+final class WhenElseExprBuilder[V, R, P](private val branches: NonEmptyList[ConditionBranch[V, R, P]]) extends AnyVal {
 
   def elseReturn(
-    elseExpr: Expr[F, V, R, P],
+    elseExpr: Expr[V, R, P],
   )(implicit
-    captureResult: CaptureP[F, V, R, P],
-  ): Expr.When[F, V, R, P] =
+    captureResult: CaptureP[V, R, P],
+  ): Expr.When[V, R, P] =
     Expr.When(branches.reverse, elseExpr, captureResult)
 
-  def elif(elifExpr: CondExpr[F, V, P]): WhenElifExprBuilder[F, V, R, P] = new WhenElifExprBuilder((elifExpr, branches))
+  def elif(elifExpr: CondExpr[V, P]): WhenElifExprBuilder[V, R, P] = new WhenElifExprBuilder((elifExpr, branches))
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WithOutputSyntax.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WithOutputSyntax.scala
@@ -1,30 +1,27 @@
 package com.rallyhealth.vapors.core.dsl
 
-import cats.{Foldable, Id}
+import cats.Foldable
 import com.rallyhealth.vapors.core.algebra.Expr
 
 trait WithOutputSyntax {
 
-  implicit def thenChainValue[V, R, P](expr: Expr[Id, V, R, P]): WithOutputValueExprBuilder[V, R, P] =
+  implicit def thenChainValue[V, R, P](expr: Expr[V, R, P]): WithOutputValueExprBuilder[V, R, P] =
     new WithOutputValueExprBuilder(expr)
 
-  implicit def thenChainFoldable[F[_], V, M[_], R, P](
-    expr: Expr[F, V, M[R], P],
-  ): WithOutputFoldableExprBuilder[F, V, M, R, P] =
+  implicit def thenChainFoldable[V, M[_], R, P](expr: Expr[V, M[R], P]): WithOutputFoldableExprBuilder[V, M, R, P] =
     new WithOutputFoldableExprBuilder(expr)
 
 }
 
-final class WithOutputValueExprBuilder[V, R, P](private val expr: Expr[Id, V, R, P]) extends AnyVal {
+final class WithOutputValueExprBuilder[V, R, P](private val expr: Expr[V, R, P]) extends AnyVal {
 
   def withOutputValue: ValExprBuilder[V, R, P] = new ValExprBuilder(expr)
 }
 
-final class WithOutputFoldableExprBuilder[F[_], V, M[_], R, P](private val expr: Expr[F, V, M[R], P]) extends AnyVal {
+final class WithOutputFoldableExprBuilder[V, M[_], R, P](private val expr: Expr[V, M[R], P]) extends AnyVal {
 
   def withOutputFoldable(
     implicit
-    foldableF: Foldable[F],
     foldableM: Foldable[M],
-  ): FoldableExprBuilder[F, V, M, R, P] = new FoldableExprBuilder(expr)
+  ): FoldableExprBuilder[V, M, R, P] = new FoldableExprBuilder(expr)
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WrapEachExprSyntax.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WrapEachExprSyntax.scala
@@ -7,128 +7,127 @@ import shapeless.{::, Generic, HList, HNil}
 
 trait WrapEachExprSyntax {
 
-  def wrapEach[F[_], V, M[_], E1, E2, P](
-    e1: Expr[F, V, M[E1], P],
-    e2: Expr[F, V, M[E2], P],
-  ): WrapEachExprHListWrapper[F, V, M, E1 :: E2 :: HNil, P] =
+  def wrapEach[V, M[_], E1, E2, P](
+    e1: Expr[V, M[E1], P],
+    e2: Expr[V, M[E2], P],
+  ): WrapEachExprHListWrapper[V, M, E1 :: E2 :: HNil, P] =
     new WrapEachExprHListWrapper(e1 :: NonEmptyExprHList.tailK(e2))
 
-  def wrapEach[F[_], V, M[_], E1, E2, E3, P](
-    e1: Expr[F, V, M[E1], P],
-    e2: Expr[F, V, M[E2], P],
-    e3: Expr[F, V, M[E3], P],
-  ): WrapEachExprHListWrapper[F, V, M, E1 :: E2 :: E3 :: HNil, P] =
+  def wrapEach[V, M[_], E1, E2, E3, P](
+    e1: Expr[V, M[E1], P],
+    e2: Expr[V, M[E2], P],
+    e3: Expr[V, M[E3], P],
+  ): WrapEachExprHListWrapper[V, M, E1 :: E2 :: E3 :: HNil, P] =
     new WrapEachExprHListWrapper(e1 :: e2 :: NonEmptyExprHList.tailK(e3))
 
-  def wrapEach[F[_], V, M[_], E1, E2, E3, E4, P](
-    e1: Expr[F, V, M[E1], P],
-    e2: Expr[F, V, M[E2], P],
-    e3: Expr[F, V, M[E3], P],
-    e4: Expr[F, V, M[E4], P],
-  ): WrapEachExprHListWrapper[F, V, M, E1 :: E2 :: E3 :: E4 :: HNil, P] =
+  def wrapEach[V, M[_], E1, E2, E3, E4, P](
+    e1: Expr[V, M[E1], P],
+    e2: Expr[V, M[E2], P],
+    e3: Expr[V, M[E3], P],
+    e4: Expr[V, M[E4], P],
+  ): WrapEachExprHListWrapper[V, M, E1 :: E2 :: E3 :: E4 :: HNil, P] =
     new WrapEachExprHListWrapper(e1 :: e2 :: e3 :: NonEmptyExprHList.tailK(e4))
 
-  def wrapEach[F[_], V, M[_], E1, E2, E3, E4, E5, P](
-    e1: Expr[F, V, M[E1], P],
-    e2: Expr[F, V, M[E2], P],
-    e3: Expr[F, V, M[E3], P],
-    e4: Expr[F, V, M[E4], P],
-    e5: Expr[F, V, M[E5], P],
-  ): WrapEachExprHListWrapper[F, V, M, E1 :: E2 :: E3 :: E4 :: E5 :: HNil, P] =
+  def wrapEach[V, M[_], E1, E2, E3, E4, E5, P](
+    e1: Expr[V, M[E1], P],
+    e2: Expr[V, M[E2], P],
+    e3: Expr[V, M[E3], P],
+    e4: Expr[V, M[E4], P],
+    e5: Expr[V, M[E5], P],
+  ): WrapEachExprHListWrapper[V, M, E1 :: E2 :: E3 :: E4 :: E5 :: HNil, P] =
     new WrapEachExprHListWrapper(e1 :: e2 :: e3 :: e4 :: NonEmptyExprHList.tailK(e5))
 
-  def wrapEach[F[_], V, M[_], E1, E2, E3, E4, E5, E6, P](
-    e1: Expr[F, V, M[E1], P],
-    e2: Expr[F, V, M[E2], P],
-    e3: Expr[F, V, M[E3], P],
-    e4: Expr[F, V, M[E4], P],
-    e5: Expr[F, V, M[E5], P],
-    e6: Expr[F, V, M[E6], P],
-  ): WrapEachExprHListWrapper[F, V, M, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: HNil, P] =
+  def wrapEach[V, M[_], E1, E2, E3, E4, E5, E6, P](
+    e1: Expr[V, M[E1], P],
+    e2: Expr[V, M[E2], P],
+    e3: Expr[V, M[E3], P],
+    e4: Expr[V, M[E4], P],
+    e5: Expr[V, M[E5], P],
+    e6: Expr[V, M[E6], P],
+  ): WrapEachExprHListWrapper[V, M, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: HNil, P] =
     new WrapEachExprHListWrapper(e1 :: e2 :: e3 :: e4 :: e5 :: NonEmptyExprHList.tailK(e6))
 
-  def wrapEach[F[_], V, M[_], E1, E2, E3, E4, E5, E6, E7, P](
-    e1: Expr[F, V, M[E1], P],
-    e2: Expr[F, V, M[E2], P],
-    e3: Expr[F, V, M[E3], P],
-    e4: Expr[F, V, M[E4], P],
-    e5: Expr[F, V, M[E5], P],
-    e6: Expr[F, V, M[E6], P],
-    e7: Expr[F, V, M[E7], P],
-  ): WrapEachExprHListWrapper[F, V, M, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: HNil, P] =
+  def wrapEach[V, M[_], E1, E2, E3, E4, E5, E6, E7, P](
+    e1: Expr[V, M[E1], P],
+    e2: Expr[V, M[E2], P],
+    e3: Expr[V, M[E3], P],
+    e4: Expr[V, M[E4], P],
+    e5: Expr[V, M[E5], P],
+    e6: Expr[V, M[E6], P],
+    e7: Expr[V, M[E7], P],
+  ): WrapEachExprHListWrapper[V, M, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: HNil, P] =
     new WrapEachExprHListWrapper(e1 :: e2 :: e3 :: e4 :: e5 :: e6 :: NonEmptyExprHList.tailK(e7))
 
-  def wrapEach[F[_], V, M[_], E1, E2, E3, E4, E5, E6, E7, E8, P](
-    e1: Expr[F, V, M[E1], P],
-    e2: Expr[F, V, M[E2], P],
-    e3: Expr[F, V, M[E3], P],
-    e4: Expr[F, V, M[E4], P],
-    e5: Expr[F, V, M[E5], P],
-    e6: Expr[F, V, M[E6], P],
-    e7: Expr[F, V, M[E7], P],
-    e8: Expr[F, V, M[E8], P],
-  ): WrapEachExprHListWrapper[F, V, M, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: HNil, P] =
+  def wrapEach[V, M[_], E1, E2, E3, E4, E5, E6, E7, E8, P](
+    e1: Expr[V, M[E1], P],
+    e2: Expr[V, M[E2], P],
+    e3: Expr[V, M[E3], P],
+    e4: Expr[V, M[E4], P],
+    e5: Expr[V, M[E5], P],
+    e6: Expr[V, M[E6], P],
+    e7: Expr[V, M[E7], P],
+    e8: Expr[V, M[E8], P],
+  ): WrapEachExprHListWrapper[V, M, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: HNil, P] =
     new WrapEachExprHListWrapper(e1 :: e2 :: e3 :: e4 :: e5 :: e6 :: e7 :: NonEmptyExprHList.tailK(e8))
 
-  def wrapEach[F[_], V, M[_], E1, E2, E3, E4, E5, E6, E7, E8, E9, P](
-    e1: Expr[F, V, M[E1], P],
-    e2: Expr[F, V, M[E2], P],
-    e3: Expr[F, V, M[E3], P],
-    e4: Expr[F, V, M[E4], P],
-    e5: Expr[F, V, M[E5], P],
-    e6: Expr[F, V, M[E6], P],
-    e7: Expr[F, V, M[E7], P],
-    e8: Expr[F, V, M[E8], P],
-    e9: Expr[F, V, M[E9], P],
-  ): WrapEachExprHListWrapper[F, V, M, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: HNil, P] =
+  def wrapEach[V, M[_], E1, E2, E3, E4, E5, E6, E7, E8, E9, P](
+    e1: Expr[V, M[E1], P],
+    e2: Expr[V, M[E2], P],
+    e3: Expr[V, M[E3], P],
+    e4: Expr[V, M[E4], P],
+    e5: Expr[V, M[E5], P],
+    e6: Expr[V, M[E6], P],
+    e7: Expr[V, M[E7], P],
+    e8: Expr[V, M[E8], P],
+    e9: Expr[V, M[E9], P],
+  ): WrapEachExprHListWrapper[V, M, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: HNil, P] =
     new WrapEachExprHListWrapper(e1 :: e2 :: e3 :: e4 :: e5 :: e6 :: e7 :: e8 :: NonEmptyExprHList.tailK(e9))
 
-  def wrapEach[F[_], V, M[_], E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, P](
-    e1: Expr[F, V, M[E1], P],
-    e2: Expr[F, V, M[E2], P],
-    e3: Expr[F, V, M[E3], P],
-    e4: Expr[F, V, M[E4], P],
-    e5: Expr[F, V, M[E5], P],
-    e6: Expr[F, V, M[E6], P],
-    e7: Expr[F, V, M[E7], P],
-    e8: Expr[F, V, M[E8], P],
-    e9: Expr[F, V, M[E9], P],
-    e10: Expr[F, V, M[E10], P],
-  ): WrapEachExprHListWrapper[F, V, M, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: E10 :: HNil, P] =
+  def wrapEach[V, M[_], E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, P](
+    e1: Expr[V, M[E1], P],
+    e2: Expr[V, M[E2], P],
+    e3: Expr[V, M[E3], P],
+    e4: Expr[V, M[E4], P],
+    e5: Expr[V, M[E5], P],
+    e6: Expr[V, M[E6], P],
+    e7: Expr[V, M[E7], P],
+    e8: Expr[V, M[E8], P],
+    e9: Expr[V, M[E9], P],
+    e10: Expr[V, M[E10], P],
+  ): WrapEachExprHListWrapper[V, M, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: E10 :: HNil, P] =
     new WrapEachExprHListWrapper(e1 :: e2 :: e3 :: e4 :: e5 :: e6 :: e7 :: e8 :: e9 :: NonEmptyExprHList.tailK(e10))
 
-  def wrapEach[F[_], V, M[_], E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11, P](
-    e1: Expr[F, V, M[E1], P],
-    e2: Expr[F, V, M[E2], P],
-    e3: Expr[F, V, M[E3], P],
-    e4: Expr[F, V, M[E4], P],
-    e5: Expr[F, V, M[E5], P],
-    e6: Expr[F, V, M[E6], P],
-    e7: Expr[F, V, M[E7], P],
-    e8: Expr[F, V, M[E8], P],
-    e9: Expr[F, V, M[E9], P],
-    e10: Expr[F, V, M[E10], P],
-    e11: Expr[F, V, M[E11], P],
-  ): WrapEachExprHListWrapper[F, V, M, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: E10 :: E11 :: HNil, P] =
+  def wrapEach[V, M[_], E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11, P](
+    e1: Expr[V, M[E1], P],
+    e2: Expr[V, M[E2], P],
+    e3: Expr[V, M[E3], P],
+    e4: Expr[V, M[E4], P],
+    e5: Expr[V, M[E5], P],
+    e6: Expr[V, M[E6], P],
+    e7: Expr[V, M[E7], P],
+    e8: Expr[V, M[E8], P],
+    e9: Expr[V, M[E9], P],
+    e10: Expr[V, M[E10], P],
+    e11: Expr[V, M[E11], P],
+  ): WrapEachExprHListWrapper[V, M, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: E10 :: E11 :: HNil, P] =
     new WrapEachExprHListWrapper(
       e1 :: e2 :: e3 :: e4 :: e5 :: e6 :: e7 :: e8 :: e9 :: e10 :: NonEmptyExprHList.tailK(e11),
     )
 
-  def wrapEach[F[_], V, M[_], E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11, E12, P](
-    e1: Expr[F, V, M[E1], P],
-    e2: Expr[F, V, M[E2], P],
-    e3: Expr[F, V, M[E3], P],
-    e4: Expr[F, V, M[E4], P],
-    e5: Expr[F, V, M[E5], P],
-    e6: Expr[F, V, M[E6], P],
-    e7: Expr[F, V, M[E7], P],
-    e8: Expr[F, V, M[E8], P],
-    e9: Expr[F, V, M[E9], P],
-    e10: Expr[F, V, M[E10], P],
-    e11: Expr[F, V, M[E11], P],
-    e12: Expr[F, V, M[E12], P],
+  def wrapEach[V, M[_], E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11, E12, P](
+    e1: Expr[V, M[E1], P],
+    e2: Expr[V, M[E2], P],
+    e3: Expr[V, M[E3], P],
+    e4: Expr[V, M[E4], P],
+    e5: Expr[V, M[E5], P],
+    e6: Expr[V, M[E6], P],
+    e7: Expr[V, M[E7], P],
+    e8: Expr[V, M[E8], P],
+    e9: Expr[V, M[E9], P],
+    e10: Expr[V, M[E10], P],
+    e11: Expr[V, M[E11], P],
+    e12: Expr[V, M[E12], P],
   ): WrapEachExprHListWrapper[
-    F,
     V,
     M,
     E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: E10 :: E11 :: E12 :: HNil,
@@ -139,26 +138,25 @@ trait WrapEachExprSyntax {
     )
 }
 
-final class WrapEachExprHListWrapper[F[_], V, M[_], L <: HList, P](
-  private val exprHList: NonEmptyExprHList[F, V, M, L, P],
-) extends AnyVal {
+final class WrapEachExprHListWrapper[V, M[_], L <: HList, P](private val exprHList: NonEmptyExprHList[V, M, L, P])
+  extends AnyVal {
 
   def zippedToShortest(
     implicit
     alignM: Align[M],
     filterM: FunctorFilter[M],
-  ): ZippedToShortestExprWrapper[F, V, M, L, P] = new ZippedToShortestExprWrapper(exprHList)
+  ): ZippedToShortestExprWrapper[V, M, L, P] = new ZippedToShortestExprWrapper(exprHList)
 }
 
-final class ZippedToShortestExprWrapper[F[_], V, M[_] : Align : FunctorFilter, L <: HList, P](
-  override protected val exprHList: NonEmptyExprHList[F, V, M, L, P],
-) extends HListOperationWrapper[F, V, M, L, P] {
+final class ZippedToShortestExprWrapper[V, M[_] : Align : FunctorFilter, L <: HList, P](
+  override protected val exprHList: NonEmptyExprHList[V, M, L, P],
+) extends HListOperationWrapper[V, M, L, P] {
 
-  override type Op[R] = Expr.ZipOutput[F, V, M, L, R, P]
+  override type Op[R] = Expr.ZipOutput[V, M, L, R, P]
 
   override protected def buildOp[R](
     converter: ExprConverter[L, R],
-    captureResult: CaptureP[F, V, M[R], P],
-  ): Expr.ZipOutput[F, V, M, L, R, P] =
+    captureResult: CaptureP[V, M[R], P],
+  ): Expr.ZipOutput[V, M, L, R, P] =
     Expr.ZipOutput(exprHList, converter, captureResult)
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WrapExprSyntax.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WrapExprSyntax.scala
@@ -7,142 +7,141 @@ import shapeless.{::, Generic, HList, HNil}
 
 trait WrapExprSyntax {
 
-  def wrap[F[_], V, E1, E2, P](
-    e1: Expr[F, V, E1, P],
-    e2: Expr[F, V, E2, P],
-  ): ExprHListWrapper[F, V, E1 :: E2 :: HNil, P] =
+  def wrap[V, E1, E2, P](
+    e1: Expr[V, E1, P],
+    e2: Expr[V, E2, P],
+  ): ExprHListWrapper[V, E1 :: E2 :: HNil, P] =
     new ExprHListWrapper(e1 :: NonEmptyExprHList.tail(e2))
 
-  def wrap[F[_], V, E1, E2, E3, P](
-    e1: Expr[F, V, E1, P],
-    e2: Expr[F, V, E2, P],
-    e3: Expr[F, V, E3, P],
-  ): ExprHListWrapper[F, V, E1 :: E2 :: E3 :: HNil, P] =
+  def wrap[V, E1, E2, E3, P](
+    e1: Expr[V, E1, P],
+    e2: Expr[V, E2, P],
+    e3: Expr[V, E3, P],
+  ): ExprHListWrapper[V, E1 :: E2 :: E3 :: HNil, P] =
     new ExprHListWrapper(e1 :: e2 :: NonEmptyExprHList.tail(e3))
 
-  def wrap[F[_], V, E1, E2, E3, E4, P](
-    e1: Expr[F, V, E1, P],
-    e2: Expr[F, V, E2, P],
-    e3: Expr[F, V, E3, P],
-    e4: Expr[F, V, E4, P],
-  ): ExprHListWrapper[F, V, E1 :: E2 :: E3 :: E4 :: HNil, P] =
+  def wrap[V, E1, E2, E3, E4, P](
+    e1: Expr[V, E1, P],
+    e2: Expr[V, E2, P],
+    e3: Expr[V, E3, P],
+    e4: Expr[V, E4, P],
+  ): ExprHListWrapper[V, E1 :: E2 :: E3 :: E4 :: HNil, P] =
     new ExprHListWrapper(e1 :: e2 :: e3 :: NonEmptyExprHList.tail(e4))
 
-  def wrap[F[_], V, E1, E2, E3, E4, E5, P](
-    e1: Expr[F, V, E1, P],
-    e2: Expr[F, V, E2, P],
-    e3: Expr[F, V, E3, P],
-    e4: Expr[F, V, E4, P],
-    e5: Expr[F, V, E5, P],
-  ): ExprHListWrapper[F, V, E1 :: E2 :: E3 :: E4 :: E5 :: HNil, P] =
+  def wrap[V, E1, E2, E3, E4, E5, P](
+    e1: Expr[V, E1, P],
+    e2: Expr[V, E2, P],
+    e3: Expr[V, E3, P],
+    e4: Expr[V, E4, P],
+    e5: Expr[V, E5, P],
+  ): ExprHListWrapper[V, E1 :: E2 :: E3 :: E4 :: E5 :: HNil, P] =
     new ExprHListWrapper(e1 :: e2 :: e3 :: e4 :: NonEmptyExprHList.tail(e5))
 
-  def wrap[F[_], V, E1, E2, E3, E4, E5, E6, P](
-    e1: Expr[F, V, E1, P],
-    e2: Expr[F, V, E2, P],
-    e3: Expr[F, V, E3, P],
-    e4: Expr[F, V, E4, P],
-    e5: Expr[F, V, E5, P],
-    e6: Expr[F, V, E6, P],
-  ): ExprHListWrapper[F, V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: HNil, P] =
+  def wrap[V, E1, E2, E3, E4, E5, E6, P](
+    e1: Expr[V, E1, P],
+    e2: Expr[V, E2, P],
+    e3: Expr[V, E3, P],
+    e4: Expr[V, E4, P],
+    e5: Expr[V, E5, P],
+    e6: Expr[V, E6, P],
+  ): ExprHListWrapper[V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: HNil, P] =
     new ExprHListWrapper(e1 :: e2 :: e3 :: e4 :: e5 :: NonEmptyExprHList.tail(e6))
 
-  def wrap[F[_], V, E1, E2, E3, E4, E5, E6, E7, P](
-    e1: Expr[F, V, E1, P],
-    e2: Expr[F, V, E2, P],
-    e3: Expr[F, V, E3, P],
-    e4: Expr[F, V, E4, P],
-    e5: Expr[F, V, E5, P],
-    e6: Expr[F, V, E6, P],
-    e7: Expr[F, V, E7, P],
-  ): ExprHListWrapper[F, V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: HNil, P] =
+  def wrap[V, E1, E2, E3, E4, E5, E6, E7, P](
+    e1: Expr[V, E1, P],
+    e2: Expr[V, E2, P],
+    e3: Expr[V, E3, P],
+    e4: Expr[V, E4, P],
+    e5: Expr[V, E5, P],
+    e6: Expr[V, E6, P],
+    e7: Expr[V, E7, P],
+  ): ExprHListWrapper[V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: HNil, P] =
     new ExprHListWrapper(e1 :: e2 :: e3 :: e4 :: e5 :: e6 :: NonEmptyExprHList.tail(e7))
 
-  def wrap[F[_], V, E1, E2, E3, E4, E5, E6, E7, E8, P](
-    e1: Expr[F, V, E1, P],
-    e2: Expr[F, V, E2, P],
-    e3: Expr[F, V, E3, P],
-    e4: Expr[F, V, E4, P],
-    e5: Expr[F, V, E5, P],
-    e6: Expr[F, V, E6, P],
-    e7: Expr[F, V, E7, P],
-    e8: Expr[F, V, E8, P],
-  ): ExprHListWrapper[F, V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: HNil, P] =
+  def wrap[V, E1, E2, E3, E4, E5, E6, E7, E8, P](
+    e1: Expr[V, E1, P],
+    e2: Expr[V, E2, P],
+    e3: Expr[V, E3, P],
+    e4: Expr[V, E4, P],
+    e5: Expr[V, E5, P],
+    e6: Expr[V, E6, P],
+    e7: Expr[V, E7, P],
+    e8: Expr[V, E8, P],
+  ): ExprHListWrapper[V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: HNil, P] =
     new ExprHListWrapper(e1 :: e2 :: e3 :: e4 :: e5 :: e6 :: e7 :: NonEmptyExprHList.tail(e8))
 
-  def wrap[F[_], V, E1, E2, E3, E4, E5, E6, E7, E8, E9, P](
-    e1: Expr[F, V, E1, P],
-    e2: Expr[F, V, E2, P],
-    e3: Expr[F, V, E3, P],
-    e4: Expr[F, V, E4, P],
-    e5: Expr[F, V, E5, P],
-    e6: Expr[F, V, E6, P],
-    e7: Expr[F, V, E7, P],
-    e8: Expr[F, V, E8, P],
-    e9: Expr[F, V, E9, P],
-  ): ExprHListWrapper[F, V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: HNil, P] =
+  def wrap[V, E1, E2, E3, E4, E5, E6, E7, E8, E9, P](
+    e1: Expr[V, E1, P],
+    e2: Expr[V, E2, P],
+    e3: Expr[V, E3, P],
+    e4: Expr[V, E4, P],
+    e5: Expr[V, E5, P],
+    e6: Expr[V, E6, P],
+    e7: Expr[V, E7, P],
+    e8: Expr[V, E8, P],
+    e9: Expr[V, E9, P],
+  ): ExprHListWrapper[V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: HNil, P] =
     new ExprHListWrapper(e1 :: e2 :: e3 :: e4 :: e5 :: e6 :: e7 :: e8 :: NonEmptyExprHList.tail(e9))
 
-  def wrap[F[_], V, E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, P](
-    e1: Expr[F, V, E1, P],
-    e2: Expr[F, V, E2, P],
-    e3: Expr[F, V, E3, P],
-    e4: Expr[F, V, E4, P],
-    e5: Expr[F, V, E5, P],
-    e6: Expr[F, V, E6, P],
-    e7: Expr[F, V, E7, P],
-    e8: Expr[F, V, E8, P],
-    e9: Expr[F, V, E9, P],
-    e10: Expr[F, V, E10, P],
-  ): ExprHListWrapper[F, V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: E10 :: HNil, P] =
+  def wrap[V, E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, P](
+    e1: Expr[V, E1, P],
+    e2: Expr[V, E2, P],
+    e3: Expr[V, E3, P],
+    e4: Expr[V, E4, P],
+    e5: Expr[V, E5, P],
+    e6: Expr[V, E6, P],
+    e7: Expr[V, E7, P],
+    e8: Expr[V, E8, P],
+    e9: Expr[V, E9, P],
+    e10: Expr[V, E10, P],
+  ): ExprHListWrapper[V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: E10 :: HNil, P] =
     new ExprHListWrapper(e1 :: e2 :: e3 :: e4 :: e5 :: e6 :: e7 :: e8 :: e9 :: NonEmptyExprHList.tail(e10))
 
-  def wrap[F[_], V, E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11, P](
-    e1: Expr[F, V, E1, P],
-    e2: Expr[F, V, E2, P],
-    e3: Expr[F, V, E3, P],
-    e4: Expr[F, V, E4, P],
-    e5: Expr[F, V, E5, P],
-    e6: Expr[F, V, E6, P],
-    e7: Expr[F, V, E7, P],
-    e8: Expr[F, V, E8, P],
-    e9: Expr[F, V, E9, P],
-    e10: Expr[F, V, E10, P],
-    e11: Expr[F, V, E11, P],
-  ): ExprHListWrapper[F, V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: E10 :: E11 :: HNil, P] =
+  def wrap[V, E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11, P](
+    e1: Expr[V, E1, P],
+    e2: Expr[V, E2, P],
+    e3: Expr[V, E3, P],
+    e4: Expr[V, E4, P],
+    e5: Expr[V, E5, P],
+    e6: Expr[V, E6, P],
+    e7: Expr[V, E7, P],
+    e8: Expr[V, E8, P],
+    e9: Expr[V, E9, P],
+    e10: Expr[V, E10, P],
+    e11: Expr[V, E11, P],
+  ): ExprHListWrapper[V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: E10 :: E11 :: HNil, P] =
     new ExprHListWrapper(e1 :: e2 :: e3 :: e4 :: e5 :: e6 :: e7 :: e8 :: e9 :: e10 :: NonEmptyExprHList.tail(e11))
 
-  def wrap[F[_], V, E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11, E12, P](
-    e1: Expr[F, V, E1, P],
-    e2: Expr[F, V, E2, P],
-    e3: Expr[F, V, E3, P],
-    e4: Expr[F, V, E4, P],
-    e5: Expr[F, V, E5, P],
-    e6: Expr[F, V, E6, P],
-    e7: Expr[F, V, E7, P],
-    e8: Expr[F, V, E8, P],
-    e9: Expr[F, V, E9, P],
-    e10: Expr[F, V, E10, P],
-    e11: Expr[F, V, E11, P],
-    e12: Expr[F, V, E12, P],
-  ): ExprHListWrapper[F, V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: E10 :: E11 :: E12 :: HNil, P] =
+  def wrap[V, E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11, E12, P](
+    e1: Expr[V, E1, P],
+    e2: Expr[V, E2, P],
+    e3: Expr[V, E3, P],
+    e4: Expr[V, E4, P],
+    e5: Expr[V, E5, P],
+    e6: Expr[V, E6, P],
+    e7: Expr[V, E7, P],
+    e8: Expr[V, E8, P],
+    e9: Expr[V, E9, P],
+    e10: Expr[V, E10, P],
+    e11: Expr[V, E11, P],
+    e12: Expr[V, E12, P],
+  ): ExprHListWrapper[V, E1 :: E2 :: E3 :: E4 :: E5 :: E6 :: E7 :: E8 :: E9 :: E10 :: E11 :: E12 :: HNil, P] =
     new ExprHListWrapper(
       e1 :: e2 :: e3 :: e4 :: e5 :: e6 :: e7 :: e8 :: e9 :: e10 :: e11 :: NonEmptyExprHList.tail(e12),
     )
 
 }
 
-final class ExprHListWrapper[F[_], V, L <: HList, P](
-  override protected val exprHList: NonEmptyExprHList[F, V, Id, L, P],
-) extends AnyVal
-  with HListOperationWrapper[F, V, Id, L, P] {
+final class ExprHListWrapper[V, L <: HList, P](override protected val exprHList: NonEmptyExprHList[V, Id, L, P])
+  extends AnyVal
+  with HListOperationWrapper[V, Id, L, P] {
 
-  override type Op[R] = Expr.WrapOutput[F, V, L, R, P]
+  override type Op[R] = Expr.WrapOutput[V, L, R, P]
 
   override protected def buildOp[R](
     converter: ExprConverter[L, R],
-    captureResult: CaptureP[F, V, Id[R], P],
-  ): Expr.WrapOutput[F, V, L, R, P] =
+    captureResult: CaptureP[V, Id[R], P],
+  ): Expr.WrapOutput[V, L, R, P] =
     Expr.WrapOutput(exprHList, converter, captureResult)
 }
 

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/package.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/package.scala
@@ -1,18 +1,17 @@
 package com.rallyhealth.vapors.core
 
-import cats.Id
 import com.rallyhealth.vapors.core.algebra.{CaptureP, Expr}
 import com.rallyhealth.vapors.core.data.{FactTable, TypedFact}
 
 package object dsl extends ExprDsl with ExprBuilderSyntax with WithOutputSyntax with ExprBuilderCatsInstances {
 
-  final type CondExpr[F[_], V, P] = Expr[F, V, Boolean, P]
+  final type CondExpr[V, P] = Expr[V, Boolean, P]
 
-  final type ValExpr[V, R, P] = Expr[Id, V, R, P]
+  final type ValExpr[V, R, P] = Expr[V, R, P]
   final type ValCondExpr[V, P] = ValExpr[V, Boolean, P]
 
-  final type RootExpr[R, P] = Expr[Id, FactTable, R, P]
+  final type RootExpr[R, P] = Expr[FactTable, R, P]
 
-  final type CaptureRootExpr[R, P] = CaptureP[Id, FactTable, R, P]
-  final type CaptureFromFacts[T, P] = CaptureP[Seq, TypedFact[T], Seq[TypedFact[T]], P]
+  final type CaptureRootExpr[R, P] = CaptureP[FactTable, R, P]
+  final type CaptureFromFacts[T, P] = CaptureP[Seq[TypedFact[T]], Seq[TypedFact[T]], P]
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/ExprInput.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/ExprInput.scala
@@ -8,7 +8,7 @@ final case class ExprInput[V](
   factTable: FactTable,
 ) {
 
-  // TODO: Remove
+  @deprecated("Use withValue instead.", "0.10.0")
   @inline def withFoldableValue[G[_], U](
     value: G[U],
     evidence: Evidence = this.evidence,

--- a/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/ExprInput.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/ExprInput.scala
@@ -1,42 +1,42 @@
 package com.rallyhealth.vapors.core.interpreter
 
-import cats.Id
 import com.rallyhealth.vapors.core.data.{Evidence, FactTable}
 
-final case class ExprInput[F[_], V](
-  value: F[V],
+final case class ExprInput[V](
+  value: V,
   evidence: Evidence,
   factTable: FactTable,
 ) {
 
+  // TODO: Remove
   @inline def withFoldableValue[G[_], U](
     value: G[U],
     evidence: Evidence = this.evidence,
-  ): ExprInput[G, U] = copy(value = value, evidence = evidence)
+  ): ExprInput[G[U]] = copy(value = value, evidence = evidence)
 
   @inline def withValue[U](
     value: U,
     evidence: Evidence = this.evidence,
-  ): ExprInput[Id, U] = copy[Id, U](value = value, evidence = evidence)
+  ): ExprInput[U] = copy(value = value, evidence = evidence)
 }
 
 object ExprInput {
 
-  type Init = ExprInput[Id, FactTable]
+  type Init = ExprInput[FactTable]
 
   @inline def fromFactTable(factTable: FactTable): Init =
-    ExprInput[Id, FactTable](factTable, Evidence.none, factTable)
+    ExprInput(factTable, Evidence.none, factTable)
 
   @inline def fromValue[V](
     value: V,
     evidence: Evidence,
     factTable: FactTable,
-  ): ExprInput[Id, V] =
-    ExprInput[Id, V](value, evidence, factTable)
+  ): ExprInput[V] =
+    ExprInput(value, evidence, factTable)
 
   @inline def fromValue[V](
     value: V,
     evidence: Evidence = Evidence.none,
-  ): ExprInput[Id, V] =
+  ): ExprInput[V] =
     fromValue(value, evidence, FactTable(evidence.factSet))
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/InterpretExprAsResultFn.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/InterpretExprAsResultFn.scala
@@ -380,7 +380,7 @@ final class InterpretExprAsResultFn[V, P] extends Expr.Visitor[V, P, Lambda[r =>
     val withMatchingFactsFn = expr.subExpr.visit(InterpretExprAsResultFn())
     val matchingFacts = input.factTable.getSortedSeq(expr.factTypeSet)
     // facts will always be added as their own evidence when used, so we do not need to add them to the evidence here
-    val subInput = input.withFoldableValue[Seq, TypedFact[T]](matchingFacts)
+    val subInput = input.withValue[Seq[TypedFact[T]]](matchingFacts)
     val subResult = withMatchingFactsFn(subInput)
     val postParam = expr.capture.foldToParam(expr, inputFactTable, subResult.output, subResult.param :: Nil)
     ExprResult.WithFactsOfType(
@@ -426,8 +426,6 @@ final class InterpretExprAsResultFn[V, P] extends Expr.Visitor[V, P, Lambda[r =>
     buildResult(expr, ExprResult.Context(input, output, param))
   }
 
-  // This takes a higher-kinded parameter G[_] because there isn't a good way to use a wild-card
-  // See https://github.com/scala/bug/issues/8039 for more details
   @inline private def resultOfSingleSubExpr[R](
     expr: Expr[V, R, P],
     input: ExprInput[V],

--- a/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/VisitGenericExprWithProxyFn.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/VisitGenericExprWithProxyFn.scala
@@ -16,99 +16,98 @@ import shapeless.HList
   * need to take into account any specific method signatures or expression node types. It is useful for defining
   * behavior that only relies on the common methods and values of [[Expr]] and [[ExprInput]].
   */
-abstract class VisitGenericExprWithProxyFn[F[_] : Foldable, V, P, G[_]]
-  extends Expr.Visitor[F, V, P, Lambda[r => ExprInput[F, V] => G[r]]] {
+abstract class VisitGenericExprWithProxyFn[V, P, G[_]] extends Expr.Visitor[V, P, Lambda[r => ExprInput[V] => G[r]]] {
 
-  protected def visitGeneric[M[_] : Foldable, U, R](
-    expr: Expr[M, U, R, P],
-    input: ExprInput[M, U],
+  protected def visitGeneric[U, R](
+    expr: Expr[U, R, P],
+    input: ExprInput[U],
   ): G[R]
 
-  override def visitAddOutputs[R : Addition](expr: Expr.AddOutputs[F, V, R, P]): ExprInput[F, V] => G[R] =
+  override def visitAddOutputs[R : Addition](expr: Expr.AddOutputs[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
-  override def visitAnd[R : Conjunction : ExtractBoolean](expr: Expr.And[F, V, R, P]): ExprInput[F, V] => G[R] =
+  override def visitAnd[R : Conjunction : ExtractBoolean](expr: Expr.And[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
   override def visitCollectSomeOutput[M[_] : Foldable, U, R : Monoid](
-    expr: Expr.CollectFromOutput[F, V, M, U, R, P],
-  ): ExprInput[F, V] => G[R] = visitGeneric(expr, _)
+    expr: Expr.CollectFromOutput[V, M, U, R, P],
+  ): ExprInput[V] => G[R] = visitGeneric(expr, _)
 
-  override def visitConstOutput[R](expr: Expr.ConstOutput[F, V, R, P]): ExprInput[F, V] => G[R] =
+  override def visitConstOutput[R](expr: Expr.ConstOutput[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
-  override def visitDefine[M[_] : Foldable, T](expr: Expr.Define[M, T, P]): ExprInput[F, V] => G[FactSet] = { input =>
+  override def visitDefine[M[_] : Foldable, T](expr: Expr.Define[M, T, P]): ExprInput[V] => G[FactSet] = { input =>
     visitGeneric(expr, input.withValue(input.factTable))
   }
 
-  override def visitEmbed[R](expr: Expr.Embed[F, V, R, P]): ExprInput[F, V] => G[R] =
+  override def visitEmbed[R](expr: Expr.Embed[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
   override def visitExistsInOutput[M[_] : Foldable, U](
-    expr: Expr.ExistsInOutput[F, V, M, U, P],
-  ): ExprInput[F, V] => G[Boolean] = visitGeneric(expr, _)
+    expr: Expr.ExistsInOutput[V, M, U, P],
+  ): ExprInput[V] => G[Boolean] = visitGeneric(expr, _)
 
   override def visitFilterOutput[M[_] : Foldable : FunctorFilter, R](
-    expr: Expr.FilterOutput[F, V, M, R, P],
-  ): ExprInput[F, V] => G[M[R]] = visitGeneric(expr, _)
+    expr: Expr.FilterOutput[V, M, R, P],
+  ): ExprInput[V] => G[M[R]] = visitGeneric(expr, _)
 
   override def visitFlatMapOutput[M[_] : Foldable : FlatMap, U, X](
-    expr: Expr.FlatMapOutput[F, V, M, U, X, P],
-  ): ExprInput[F, V] => G[M[X]] = visitGeneric(expr, _)
+    expr: Expr.FlatMapOutput[V, M, U, X, P],
+  ): ExprInput[V] => G[M[X]] = visitGeneric(expr, _)
 
   override def visitMapOutput[M[_] : Foldable : Functor, U, R](
-    expr: Expr.MapOutput[F, V, M, U, R, P],
-  ): ExprInput[F, V] => G[M[R]] = visitGeneric(expr, _)
+    expr: Expr.MapOutput[V, M, U, R, P],
+  ): ExprInput[V] => G[M[R]] = visitGeneric(expr, _)
 
-  override def visitNegativeOutput[R : Negative](expr: Expr.NegativeOutput[F, V, R, P]): ExprInput[F, V] => G[R] =
+  override def visitNegativeOutput[R : Negative](expr: Expr.NegativeOutput[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
-  override def visitNot[R : Negation](expr: Expr.Not[F, V, R, P]): ExprInput[F, V] => G[R] =
+  override def visitNot[R : Negation](expr: Expr.Not[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
-  override def visitOr[R : Disjunction : ExtractBoolean](expr: Expr.Or[F, V, R, P]): ExprInput[F, V] => G[R] =
+  override def visitOr[R : Disjunction : ExtractBoolean](expr: Expr.Or[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
   override def visitOutputIsEmpty[M[_] : Foldable, R](
-    expr: Expr.OutputIsEmpty[F, V, M, R, P],
-  ): ExprInput[F, V] => G[Boolean] = visitGeneric(expr, _)
+    expr: Expr.OutputIsEmpty[V, M, R, P],
+  ): ExprInput[V] => G[Boolean] = visitGeneric(expr, _)
 
-  override def visitOutputWithinSet[R](expr: Expr.OutputWithinSet[F, V, R, P]): ExprInput[F, V] => G[Boolean] =
+  override def visitOutputWithinSet[R](expr: Expr.OutputWithinSet[V, R, P]): ExprInput[V] => G[Boolean] =
     visitGeneric(expr, _)
 
-  override def visitOutputWithinWindow[R](expr: Expr.OutputWithinWindow[F, V, R, P]): ExprInput[F, V] => G[Boolean] =
+  override def visitOutputWithinWindow[R](expr: Expr.OutputWithinWindow[V, R, P]): ExprInput[V] => G[Boolean] =
     visitGeneric(expr, _)
 
-  override def visitReturnInput(expr: Expr.ReturnInput[F, V, P]): ExprInput[F, V] => G[F[V]] =
+  override def visitReturnInput(expr: Expr.ReturnInput[V, P]): ExprInput[V] => G[V] =
     visitGeneric(expr, _)
 
-  override def visitSelectFromOutput[S, R](expr: Expr.SelectFromOutput[F, V, S, R, P]): ExprInput[F, V] => G[R] =
+  override def visitSelectFromOutput[S, R](expr: Expr.SelectFromOutput[V, S, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
-  override def visitSortOutput[M[_], R](expr: Expr.SortOutput[F, V, M, R, P]): ExprInput[F, V] => G[M[R]] =
+  override def visitSortOutput[M[_], R](expr: Expr.SortOutput[V, M, R, P]): ExprInput[V] => G[M[R]] =
     visitGeneric(expr, _)
 
-  override def visitSubtractOutputs[R : Subtraction](expr: Expr.SubtractOutputs[F, V, R, P]): ExprInput[F, V] => G[R] =
+  override def visitSubtractOutputs[R : Subtraction](expr: Expr.SubtractOutputs[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
   override def visitTakeFromOutput[M[_] : Traverse : TraverseFilter, R](
-    expr: Expr.TakeFromOutput[F, V, M, R, P],
-  ): ExprInput[F, V] => G[M[R]] = visitGeneric(expr, _)
+    expr: Expr.TakeFromOutput[V, M, R, P],
+  ): ExprInput[V] => G[M[R]] = visitGeneric(expr, _)
 
-  override def visitUsingDefinitions[R](expr: Expr.UsingDefinitions[F, V, R, P]): ExprInput[F, V] => G[R] =
+  override def visitUsingDefinitions[R](expr: Expr.UsingDefinitions[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
-  override def visitWhen[R](expr: Expr.When[F, V, R, P]): ExprInput[F, V] => G[R] =
+  override def visitWhen[R](expr: Expr.When[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
-  override def visitWithFactsOfType[T, R](expr: Expr.WithFactsOfType[T, R, P]): ExprInput[F, V] => G[R] = { input =>
+  override def visitWithFactsOfType[T, R](expr: Expr.WithFactsOfType[T, R, P]): ExprInput[V] => G[R] = { input =>
     visitGeneric(expr, input.withValue(input.factTable))
   }
 
-  override def visitWrapOutput[T <: HList, R](expr: Expr.WrapOutput[F, V, T, R, P]): ExprInput[F, V] => G[R] =
+  override def visitWrapOutput[T <: HList, R](expr: Expr.WrapOutput[V, T, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
   override def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](
-    expr: Expr.ZipOutput[F, V, M, L, R, P],
-  ): ExprInput[F, V] => G[M[R]] = visitGeneric(expr, _)
+    expr: Expr.ZipOutput[V, M, L, R, P],
+  ): ExprInput[V] => G[M[R]] = visitGeneric(expr, _)
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/package.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/dsl/package.scala
@@ -6,13 +6,13 @@ import com.rallyhealth.vapors.core.dsl
 package object dsl {
 
   @deprecated("Use com.rallyhealth.vapors.core.algebra.CaptureP instead.", "0.8.0")
-  final type CaptureP[F[_], V, R, P] = algebra.CaptureP[F, V, R, P]
+  final type CaptureP[F[_], V, R, P] = algebra.CaptureP[V, R, P]
 
   @deprecated("Use com.rallyhealth.vapors.core.algebra.CaptureP instead.", "0.8.0")
   final val CaptureP = algebra.CaptureP
 
   @deprecated("Use com.rallyhealth.vapors.core.dsl.ExprBuilder instead.", "0.8.0")
-  final type ExprBuilder[F[_], V, M[_], U, P] = dsl.ExprBuilder[F, V, M, U, P]
+  final type ExprBuilder[F[_], V, M[_], U, P] = dsl.ExprBuilder[V, M, U, P]
 
   @deprecated("Use com.rallyhealth.vapors.core.dsl.ExprBuilder instead.", "0.8.0")
   final val ExprBuilder = dsl.ExprBuilder

--- a/core/src/main/scala/com/rallyhealth/vapors/factfilter/evaluator/package.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/factfilter/evaluator/package.scala
@@ -5,7 +5,7 @@ import com.rallyhealth.vapors.core.interpreter
 package object evaluator {
 
   @deprecated("Use com.rallyhealth.vapors.core.interpreter.ExprInput instead.", "0.8.0")
-  final type ExprInput[F[_], V] = interpreter.ExprInput[F, V]
+  final type ExprInput[F[_], V] = interpreter.ExprInput[V]
 
   @deprecated("Use com.rallyhealth.vapors.core.interpreter.ExprInput instead.", "0.8.0")
   final val ExprInput = interpreter.ExprInput
@@ -17,13 +17,13 @@ package object evaluator {
   final val ExprOutput = interpreter.ExprOutput
 
   @deprecated("Use com.rallyhealth.vapors.core.interpreter.InterpretExprAsResultFn instead.", "0.8.0")
-  final type InterpretExprAsResultFn[F[_], V, P] = interpreter.InterpretExprAsResultFn[F, V, P]
+  final type InterpretExprAsResultFn[F[_], V, P] = interpreter.InterpretExprAsResultFn[V, P]
 
   @deprecated("Use com.rallyhealth.vapors.core.interpreter.InterpretExprAsResultFn instead.", "0.8.0")
   final val InterpretExprAsResultFn = interpreter.InterpretExprAsResultFn
 
   @deprecated("Use com.rallyhealth.vapors.core.interpreter.InterpretExprAsResultFn instead.", "0.8.0")
-  final type InterpretExprAsSimpleOutputFn[F[_], V, P] = interpreter.InterpretExprAsSimpleOutputFn[F, V, P]
+  final type InterpretExprAsSimpleOutputFn[F[_], V, P] = interpreter.InterpretExprAsSimpleOutputFn[V, P]
 
   @deprecated("Use com.rallyhealth.vapors.core.interpreter.InterpretExprAsResultFn instead.", "0.8.0")
   final val InterpretExprAsSimpleOutputFn = interpreter.InterpretExprAsSimpleOutputFn

--- a/core/src/test/scala/com/rallyhealth/vapors/core/example/CaptureTimeRange.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/example/CaptureTimeRange.scala
@@ -13,8 +13,8 @@ object CaptureTimeRange extends CaptureP.AsMonoidCompanion[TimeRange] {
     new CaptureP.AsMonoidFromFactsOfType[T, R, TimeRange] {
 
       override protected def foldWithParentParam(
-        expr: Expr[Seq, TypedFact[T], R, TimeRange],
-        input: ExprInput[Seq, TypedFact[T]],
+        expr: Expr[Seq[TypedFact[T]], R, TimeRange],
+        input: ExprInput[Seq[TypedFact[T]]],
         output: ExprOutput[R],
         processedChildren: TimeRange,
       ): Eval[TimeRange] = {

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/LogicalExprSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/LogicalExprSpec.scala
@@ -1,6 +1,5 @@
 package com.rallyhealth.vapors.core.interpreter
 
-import cats.Id
 import com.rallyhealth.vapors.core.algebra.Expr
 import com.rallyhealth.vapors.core.data.{Evidence, ExtractBoolean, FactSet, FactTable}
 import com.rallyhealth.vapors.core.dsl._
@@ -11,7 +10,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class LogicalExprSpec extends AnyWordSpec {
 
-  private type LogicExpr[R] = Expr[Id, Unit, R, Unit]
+  private type LogicExpr[R] = Expr[Unit, R, Unit]
 
   private type LogicOpBuilder[R] =
     (LogicExpr[R], LogicExpr[R], Seq[LogicExpr[R]]) => LogicExpr[R]
@@ -19,7 +18,7 @@ class LogicalExprSpec extends AnyWordSpec {
   private type UnaryLogicOpBuilder[R] = LogicExpr[R] => LogicExpr[R]
 
   private def evalUnit[R](facts: FactSet)(expr: LogicExpr[R]): ExprOutput[R] = {
-    InterpretExprAsResultFn(expr)(ExprInput[Id, Unit]((), Evidence(facts), FactTable(facts))).output
+    InterpretExprAsResultFn(expr)(ExprInput((), Evidence(facts), FactTable(facts))).output
   }
 
   private def validLogicalOperators[R](


### PR DESCRIPTION
I had an epiphany about the `Expr`. If every `Expr` node takes an `inputExpr`, then there is really no benefit to constraining the input type. You can always pass the `Expr.ReturnInput` to move a higher-kinded parameter from the input side to the output side, where you can constrain the output with an implicit. This vastly simplifies the code without reducing expressiveness. It might also resolve some issues with implicit resolution when the type parameter was `Id[V]`

**Dependencies**

- [x] https://github.com/jeffmay/vapors/pull/40