### PR TITLE
Improve NamedLens macros and use better data structure for DataPath

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/lens/NamedLens.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/lens/NamedLens.scala
@@ -26,7 +26,6 @@ object NamedLens {
   }
 
   implicit final class Selector[A, B](val lens: NamedLens[A, B]) extends AnyVal {
-    // TODO: Rename downField?
     def select[C](getter: B => C): NamedLens[A, C] = macro NamedLensMacros.selectImpl[A, B, C]
   }
 

--- a/core/src/main/scala/com/rallyhealth/vapors/core/lens/NamedLens.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/lens/NamedLens.scala
@@ -11,7 +11,7 @@ import scala.collection.Factory
 object NamedLens {
 
   type Id[A] = NamedLens[A, A]
-  val Id: NamedLens[Any, Any] = NamedLens(DataPath(Nil), identity[Any])
+  val Id: NamedLens[Any, Any] = NamedLens(DataPath.empty, identity[Any])
   def id[A]: NamedLens[A, A] = Id.asInstanceOf[Id[A]]
 
   type Fn[A, B] = NamedLens.Id[A] => NamedLens[A, B]
@@ -57,7 +57,7 @@ final case class NamedLens[A, B](
 
   def andThen[C](lens: NamedLens[B, C]): NamedLens[A, C] = {
     copy(
-      path = this.path ::: lens.path,
+      path = this.path ++ lens.path,
       get = get.andThen(lens.get),
     )
   }

--- a/core/src/test/scala/com/rallyhealth/vapors/core/example/FactTypes.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/example/FactTypes.scala
@@ -14,6 +14,7 @@ object FactTypes {
   val Role = FactType[Role]("role")
   val BirthYear = FactType[Int]("year_of_birth")
   val DateOfBirth = FactType[LocalDate]("date_of_birth")
+  val AddressUpdate = FactType[AddressUpdate]("address_update")
   val GenericMeasurement = FactType[GenericMeasurement]("generic_measurement")
   val WeightMeasurement = FactType[WeightMeasurementLbs]("weight_measurement")
   val WeightSelfReported = FactType[WeightMeasurementLbs]("weight_self_reported")

--- a/core/src/test/scala/com/rallyhealth/vapors/core/example/JoeSchmoe.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/example/JoeSchmoe.scala
@@ -2,7 +2,7 @@ package com.rallyhealth.vapors.core.example
 
 import com.rallyhealth.vapors.core.data.{FactSet, FactTable}
 
-import java.time.{LocalDate, ZoneOffset}
+import java.time.{Instant, LocalDate, ZoneOffset}
 
 object JoeSchmoe {
   val name = FactTypes.Name("Joe Schmoe")
@@ -10,6 +10,13 @@ object JoeSchmoe {
   val userRole = FactTypes.Role(Role.User)
   val adminRole = FactTypes.Role(Role.Admin)
   val dateOfBirth = FactTypes.DateOfBirth(LocalDate.of(1987, 1, 1))
+
+  val lastAddressUpdate = FactTypes.AddressUpdate(
+    AddressUpdate(
+      Address("123 elm", "", "Springfield", "CO", "81073"),
+      Instant.from(LocalDate.of(2018, 3, 12).atStartOfDay(ZoneOffset.UTC)),
+    ),
+  )
 
   val weight = FactTypes.WeightMeasurement(
     WeightMeasurementLbs(250.0, LocalDate.of(2020, 5, 1).atStartOfDay().toInstant(ZoneOffset.UTC)),

--- a/core/src/test/scala/com/rallyhealth/vapors/core/example/models.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/example/models.scala
@@ -43,14 +43,11 @@ trait HasTimestamp {
 
 object HasTimestamp {
   implicit val extractTimestamp: ExtractInstant[HasTimestamp] = _.timestamp
+  implicit def orderByTimestampLatestFirst[T <: HasTimestamp]: Order[T] = Order.by(_.timestamp)
 }
 
 sealed trait Measurement extends HasTimestamp {
   def name: String
-}
-
-object Measurement {
-  implicit def orderByLatestTimestamp[M <: Measurement]: Order[M] = Order.by(_.timestamp)
 }
 
 sealed trait NumericMeasurement extends Measurement {
@@ -87,6 +84,15 @@ final case class TagsUpdate(
   timestamp: Instant,
 ) extends HasTimestamp
 
-object TagsUpdate {
-  implicit val orderByLatestTimestamp: Order[TagsUpdate] = Order.by(_.timestamp)
-}
+final case class Address(
+  street1: String,
+  street2: String,
+  city: String,
+  state: String,
+  zip: String,
+)
+
+final case class AddressUpdate(
+  address: Address,
+  timestamp: Instant,
+) extends HasTimestamp

--- a/core/src/test/scala/com/rallyhealth/vapors/core/lens/NamedLensSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/lens/NamedLensSpec.scala
@@ -1,5 +1,6 @@
 package com.rallyhealth.vapors.core.lens
 
+import cats.data.Chain
 import com.rallyhealth.vapors.core.example.{BloodPressure, JoeSchmoe}
 import org.scalatest.wordspec.AnyWordSpec
 import shapeless.{::, HNil, Nat}
@@ -29,7 +30,7 @@ class NamedLensSpec extends AnyWordSpec {
 
     "select a case class field" in {
       val lens = NamedLens.id[BloodPressure].select(_.diastolic)
-      assertResult(DataPath(List(DataPath.Field("diastolic"))))(lens.path)
+      assertResult(DataPath(Chain(DataPath.Field("diastolic"))))(lens.path)
       assertResult(JoeSchmoe.bloodPressure.value.diastolic) {
         lens.get(JoeSchmoe.bloodPressure.value)
       }
@@ -38,7 +39,7 @@ class NamedLensSpec extends AnyWordSpec {
     "select a Java bean style getter method" in {
       val lens = NamedLens.id[LocalDate].select(_.getYear)
       // TODO: Should this remove the "get" and lowercase the first letter?
-      assertResult(DataPath(List(DataPath.Field("getYear"))))(lens.path)
+      assertResult(DataPath(Chain(DataPath.Field("getYear"))))(lens.path)
       assertResult(JoeSchmoe.dateOfBirth.value.getYear) {
         lens.get(JoeSchmoe.dateOfBirth.value)
       }


### PR DESCRIPTION
- Switch DataPath to use Chain instead of List
- Define a cats `Compose` instance for `NamedLens`
- Update the `NamedLensMacros` to support multiple chained select operations
- Add a better compiler error message for unsupported select expressions
- Unbeanify Java-style getter methods