### PR TITLE
Add Expr.WrapOutputSeq and associated dsl.seq() operator

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
@@ -63,7 +63,7 @@ object Expr {
     def visitTakeFromOutput[M[_] : Traverse : TraverseFilter, R](expr: TakeFromOutput[V, M, R, P]): G[M[R]]
     def visitUsingDefinitions[R](expr: UsingDefinitions[V, R, P]): G[R]
     def visitWhen[R](expr: When[V, R, P]): G[R]
-    def visitWrapOutput[T <: HList, R](expr: WrapOutput[V, T, R, P]): G[R]
+    def visitWrapOutputHList[T <: HList, R](expr: WrapOutputHList[V, T, R, P]): G[R]
     def visitWithFactsOfType[T, R](expr: WithFactsOfType[T, R, P]): G[R]
     def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](expr: ZipOutput[V, M, L, R, P]): G[M[R]]
   }
@@ -339,12 +339,12 @@ object Expr {
     * anything other than a single instance of the expected type, so you don't need any type-classes for the
     * return type.
     */
-  final case class WrapOutput[V, L <: HList, R, P](
+  final case class WrapOutputHList[V, L <: HList, R, P](
     inputExprHList: NonEmptyExprHList[V, Id, L, P],
     converter: ExprConverter[L, R],
     capture: CaptureP[V, R, P],
   ) extends Expr[V, R, P] {
-    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitWrapOutput(this)
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitWrapOutputHList(this)
   }
 
   /**

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
@@ -64,6 +64,7 @@ object Expr {
     def visitUsingDefinitions[R](expr: UsingDefinitions[V, R, P]): G[R]
     def visitWhen[R](expr: When[V, R, P]): G[R]
     def visitWrapOutputHList[T <: HList, R](expr: WrapOutputHList[V, T, R, P]): G[R]
+    def visitWrapOutputSeq[R](expr: WrapOutputSeq[V, R, P]): G[Seq[R]]
     def visitWithFactsOfType[T, R](expr: WithFactsOfType[T, R, P]): G[R]
     def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](expr: ZipOutput[V, M, L, R, P]): G[M[R]]
   }
@@ -330,6 +331,17 @@ object Expr {
     capture: CaptureP[V, M[R], P],
   ) extends Expr[V, M[R], P] {
     override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitConcatOutput(this)
+  }
+
+  /**
+    * Wrap a sequence of expressions into a single expression of a lazy sequence that evaluates only the
+    * expressions needed to produce the values used in subsequent expression nodes.
+    */
+  final case class WrapOutputSeq[V, R, P](
+    inputExprList: Seq[Expr[V, R, P]],
+    capture: CaptureP[V, Seq[R], P],
+  ) extends Expr[V, Seq[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[Seq[R]] = v.visitWrapOutputSeq(this)
   }
 
   /**

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
@@ -63,6 +63,7 @@ object ExprResult {
     def visitUsingDefinitions[R](result: UsingDefinitions[V, R, P]): G[R]
     def visitWhen[R](result: When[V, R, P]): G[R]
     def visitWrapOutputHList[T <: HList, R](result: WrapOutputHList[V, T, R, P]): G[R]
+    def visitWrapOutputSeq[R](result: WrapOutputSeq[V, R, P]): G[Seq[R]]
     def visitWithFactsOfType[T, R](result: WithFactsOfType[V, T, R, P]): G[R]
     def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](result: ZipOutput[V, M, L, R, P]): G[M[R]]
   }
@@ -259,6 +260,14 @@ object ExprResult {
     subResultList: List[ExprResult[V, R, P]],
   ) extends ExprResult[V, R, P] {
     override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitSubtractOutputs(this)
+  }
+
+  final case class WrapOutputSeq[V, R, P](
+    expr: Expr.WrapOutputSeq[V, R, P],
+    context: Context[V, Seq[R], P],
+    inputResultList: Seq[ExprResult[V, R, P]],
+  ) extends ExprResult[V, Seq[R], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[Seq[R]] = v.visitWrapOutputSeq(this)
   }
 
   final case class WrapOutputHList[V, T <: HList, R, P](

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
@@ -62,7 +62,7 @@ object ExprResult {
     def visitTakeFromOutput[M[_] : Traverse : TraverseFilter, R](result: TakeFromOutput[V, M, R, P]): G[M[R]]
     def visitUsingDefinitions[R](result: UsingDefinitions[V, R, P]): G[R]
     def visitWhen[R](result: When[V, R, P]): G[R]
-    def visitWrapOutput[T <: HList, R](result: WrapOutput[V, T, R, P]): G[R]
+    def visitWrapOutputHList[T <: HList, R](result: WrapOutputHList[V, T, R, P]): G[R]
     def visitWithFactsOfType[T, R](result: WithFactsOfType[V, T, R, P]): G[R]
     def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](result: ZipOutput[V, M, L, R, P]): G[M[R]]
   }
@@ -261,11 +261,11 @@ object ExprResult {
     override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitSubtractOutputs(this)
   }
 
-  final case class WrapOutput[V, T <: HList, R, P](
-    expr: Expr.WrapOutput[V, T, R, P],
+  final case class WrapOutputHList[V, T <: HList, R, P](
+    expr: Expr.WrapOutputHList[V, T, R, P],
     context: Context[V, R, P],
   ) extends ExprResult[V, R, P] {
-    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitWrapOutput(this)
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitWrapOutputHList(this)
   }
 
   final case class ZipOutput[V, M[_] : Align : FunctorFilter, L <: HList, R, P](

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprDsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprDsl.scala
@@ -125,6 +125,31 @@ trait ExprDsl extends WrapExprSyntax with WrapEachExprSyntax {
       ),
     )
 
+  /**
+    * Takes a sequence of expressions and produces an expression of sequence of all the items.
+    *
+    * @see [[wrapSeq]] for varargs syntactic sugar.
+    *
+    *      If you would like to put the results into a heterogeneous sequence, then you should use the [[wrap]] method.
+    */
+  def sequence[V, R, P](
+    expressions: Seq[Expr[V, R, P]],
+  )(implicit
+    captureResult: CaptureP[V, Seq[R], P],
+  ): Expr.WrapOutputSeq[V, R, P] = Expr.WrapOutputSeq(expressions, captureResult)
+
+  /**
+    * Syntactic sugar for [[sequence]].
+    *
+    * You should use this method over [[sequence]] when you are writing your expression in the embedded DSL.
+    * If you are abstracting over a sequence of expressions, then you should use [[sequence]].
+    */
+  @inline final def wrapSeq[V, R, P](
+    expressions: Expr[V, R, P]*,
+  )(implicit
+    captureResult: CaptureP[V, Seq[R], P],
+  ): Expr.WrapOutputSeq[V, R, P] = sequence(expressions)
+
   def withFactsOfType[T, P](
     factTypeSet: FactTypeSet[T],
   )(implicit

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/HListOperationWrapper.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/HListOperationWrapper.scala
@@ -1,7 +1,7 @@
 package com.rallyhealth.vapors.core.dsl
 
 import com.rallyhealth.vapors.core.algebra.{CaptureP, Expr, ExprConverter, NonEmptyExprHList}
-import shapeless.ops.hlist.Tupler
+import shapeless.ops.hlist.{ToTraversable, Tupler}
 import shapeless.{Generic, HList}
 
 trait HListOperationWrapper[V, M[_], L <: HList, P] extends Any {

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WrapExprSyntax.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WrapExprSyntax.scala
@@ -136,13 +136,13 @@ final class ExprHListWrapper[V, L <: HList, P](override protected val exprHList:
   extends AnyVal
   with HListOperationWrapper[V, Id, L, P] {
 
-  override type Op[R] = Expr.WrapOutput[V, L, R, P]
+  override type Op[R] = Expr.WrapOutputHList[V, L, R, P]
 
   override protected def buildOp[R](
     converter: ExprConverter[L, R],
     captureResult: CaptureP[V, Id[R], P],
-  ): Expr.WrapOutput[V, L, R, P] =
-    Expr.WrapOutput(exprHList, converter, captureResult)
+  ): Expr.WrapOutputHList[V, L, R, P] =
+    Expr.WrapOutputHList(exprHList, converter, captureResult)
 }
 
 final class GenericIdentity[R] extends Generic[R] {

--- a/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/InterpretExprAsResultFn.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/InterpretExprAsResultFn.scala
@@ -330,6 +330,17 @@ final class InterpretExprAsResultFn[V, P] extends Expr.Visitor[V, P, Lambda[r =>
     }
   }
 
+  override def visitWrapOutputSeq[R](expr: Expr.WrapOutputSeq[V, R, P]): ExprInput[V] => ExprResult[V, Seq[R], P] = {
+    input =>
+      val inputResultList = expr.inputExprList.to(LazyList).map(_.visit(this)(input))
+      val allEvidence = inputResultList.foldMap(_.output.evidence)
+      val allParams = inputResultList.foldMap(_.param :: Nil)
+      val outputValues = inputResultList.map(_.output.value)
+      resultOfManySubExpr(expr, input, outputValues, allEvidence, allParams) {
+        ExprResult.WrapOutputSeq(_, _, inputResultList)
+      }
+  }
+
   override def visitWrapOutputHList[T <: HList, R](
     expr: Expr.WrapOutputHList[V, T, R, P],
   ): ExprInput[V] => ExprResult[V, R, P] = { input =>

--- a/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/InterpretExprAsResultFn.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/InterpretExprAsResultFn.scala
@@ -330,13 +330,13 @@ final class InterpretExprAsResultFn[V, P] extends Expr.Visitor[V, P, Lambda[r =>
     }
   }
 
-  override def visitWrapOutput[T <: HList, R](
-    expr: Expr.WrapOutput[V, T, R, P],
+  override def visitWrapOutputHList[T <: HList, R](
+    expr: Expr.WrapOutputHList[V, T, R, P],
   ): ExprInput[V] => ExprResult[V, R, P] = { input =>
     val (tupleOutput, allParams) = visitHListOfScalarExprAndCombineOutput(expr.inputExprHList, input)
     val value = expr.converter(tupleOutput.value)
     resultOfManySubExpr(expr, input, value, tupleOutput.evidence, allParams) {
-      ExprResult.WrapOutput(_, _)
+      ExprResult.WrapOutputHList(_, _)
     }
   }
 

--- a/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/VisitGenericExprWithProxyFn.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/VisitGenericExprWithProxyFn.scala
@@ -107,7 +107,7 @@ abstract class VisitGenericExprWithProxyFn[V, P, G[_]] extends Expr.Visitor[V, P
     visitGeneric(expr, input.withValue(input.factTable))
   }
 
-  override def visitWrapOutput[T <: HList, R](expr: Expr.WrapOutput[V, T, R, P]): ExprInput[V] => G[R] =
+  override def visitWrapOutputHList[T <: HList, R](expr: Expr.WrapOutputHList[V, T, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
   override def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](

--- a/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/VisitGenericExprWithProxyFn.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/VisitGenericExprWithProxyFn.scala
@@ -97,6 +97,9 @@ abstract class VisitGenericExprWithProxyFn[V, P, G[_]] extends Expr.Visitor[V, P
     expr: Expr.TakeFromOutput[V, M, R, P],
   ): ExprInput[V] => G[M[R]] = visitGeneric(expr, _)
 
+  override def visitWrapOutputSeq[R](expr: Expr.WrapOutputSeq[V, R, P]): ExprInput[V] => G[Seq[R]] =
+    visitGeneric(expr, _)
+
   override def visitUsingDefinitions[R](expr: Expr.UsingDefinitions[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/WrapOutputHListSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/WrapOutputHListSpec.scala
@@ -6,7 +6,7 @@ import com.rallyhealth.vapors.core.example.{ColorCoding, FactTypes, JoeSchmoe, T
 import org.scalatest.freespec.AnyFreeSpec
 import shapeless.HNil
 
-class WrapOutputSpec extends AnyFreeSpec {
+class WrapOutputHListSpec extends AnyFreeSpec {
 
   import com.rallyhealth.vapors.core.example.SimpleTagUpdates._
 

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/WrapOutputSeqSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/WrapOutputSeqSpec.scala
@@ -1,0 +1,61 @@
+package com.rallyhealth.vapors.core.interpreter
+
+import com.rallyhealth.vapors.core.data.{Evidence, FactTable, FactType}
+import com.rallyhealth.vapors.core.dsl._
+import com.rallyhealth.vapors.core.example.{FactTypes, HasTimestamp, JoeSchmoe}
+import org.scalatest.Inside.inside
+import org.scalatest.freespec.AnyFreeSpec
+
+class WrapOutputSeqSpec extends AnyFreeSpec {
+
+  "wrapSeq / sequence should" - {
+
+    "wrap a list of constant expressions into an expression of a list of the values" in {
+      val query = wrapSeq(
+        const(1),
+        const(2),
+        const(3),
+      )
+      val result = eval(FactTable.empty)(query)
+      assertResult(Seq(1, 2, 3)) {
+        result.output.value
+      }
+    }
+
+    "not force the resulting lazy list" in {
+      val query = wrapSeq(
+        const(1),
+        const(2),
+        const(3),
+      )
+      val result = eval(FactTable.empty)(query)
+      inside(result.output.value) {
+        case values: LazyList[_] =>
+          // confirm that the collection does not start with a definite size because it was unforced
+          assert(!values.hasDefiniteSize)
+          // confirm that forcing the collection causes it to have a definite size
+          assert(values.force.hasDefiniteSize)
+      }
+    }
+
+    "wrap a list of expressions and combine the evidence from all of them" in {
+      val factTypes = List[FactType[_ <: HasTimestamp]](
+        FactTypes.BloodPressureMeasurement,
+        FactTypes.WeightSelfReported,
+        FactTypes.TagsUpdate,
+      )
+      val subExpressions =
+        factTypes.map(t => factsOfType(t).map(_.value.get(_.select(_.timestamp))).returnOutput)
+      val query = sequence(subExpressions)
+      val factsPerType = factTypes.map(JoeSchmoe.factTable.getSortedSeq(_))
+      val expectedValues = factsPerType.map(_.map(_.value.timestamp))
+      val result = eval(JoeSchmoe.factTable)(query)
+      assertResult(expectedValues) {
+        result.output.value
+      }
+      assertResult(Evidence(factsPerType.flatten)) {
+        result.output.evidence
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Rename `WrapOutput` to `WrapOutputHList` for clarity
- Add `Expr.WrapOutputSeq` node for converting a `Seq[Expr[R]]` into an `Expr[Seq[R]]`
- Add `seq(expr*)` method for building the wrap output expression
- Add unit tests to verify that the collection is not forced