### PR TITLE
Add Expr.GroupBy

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
@@ -1,13 +1,15 @@
 package com.rallyhealth.vapors.core.algebra
 
-import cats.data.NonEmptyList
 import cats._
+import cats.data.NonEmptyList
 import com.rallyhealth.vapors.core.data._
 import com.rallyhealth.vapors.core.interpreter.{ExprOutput, InterpretExprAsResultFn}
 import com.rallyhealth.vapors.core.lens.NamedLens
 import com.rallyhealth.vapors.core.logic.{Conjunction, Disjunction, Negation}
 import com.rallyhealth.vapors.core.math.{Addition, Negative, Subtraction}
 import shapeless.HList
+
+import scala.collection.MapView
 
 /**
   * The core expression algebra.
@@ -49,6 +51,7 @@ object Expr {
     def visitExistsInOutput[M[_] : Foldable, U](expr: ExistsInOutput[V, M, U, P]): G[Boolean]
     def visitFilterOutput[M[_] : Foldable : FunctorFilter, R](expr: FilterOutput[V, M, R, P]): G[M[R]]
     def visitFlatMapOutput[M[_] : Foldable : FlatMap, U, X](expr: FlatMapOutput[V, M, U, X, P]): G[M[X]]
+    def visitGroupOutput[M[_] : Foldable, U : Order, K](expr: GroupOutput[V, M, U, K, P]): G[MapView[K, Seq[U]]]
     def visitMapOutput[M[_] : Foldable : Functor, U, R](expr: MapOutput[V, M, U, R, P]): G[M[R]]
     def visitNegativeOutput[R : Negative](expr: NegativeOutput[V, R, P]): G[R]
     def visitNot[R : Negation](expr: Not[V, R, P]): G[R]
@@ -304,6 +307,19 @@ object Expr {
     capture: CaptureP[V, M[R], P],
   ) extends Expr[V, M[R], P] {
     override def visit[G[_]](v: Visitor[V, P, G]): G[M[R]] = v.visitMapOutput(this)
+  }
+
+  /**
+    * Group the output of a given expression into a Map of some hashable key type.
+    *
+    * @note this uses the default (_: K).## method for hashing because it uses the standard Scala Map collection.
+    */
+  final case class GroupOutput[V, M[_] : Foldable, U : Order, K, P](
+    inputExpr: Expr[V, M[U], P],
+    groupByLens: NamedLens[U, K],
+    capture: CaptureP[V, MapView[K, Seq[U]], P],
+  ) extends Expr[V, MapView[K, Seq[U]], P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[MapView[K, Seq[U]]] = v.visitGroupOutput(this)
   }
 
   /**

--- a/core/src/main/scala/com/rallyhealth/vapors/core/data/FactType.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/data/FactType.scala
@@ -9,7 +9,7 @@ import scala.reflect.runtime.universe.TypeTag
 /**
   * Type information required to construct a [[Fact]].
   */
-trait FactType[T] {
+trait FactType[T] extends (T => TypedFact[T]) {
 
   /**
     * The unique name for this fact type.
@@ -37,7 +37,7 @@ trait FactType[T] {
     * If you need the specific type of fact for some reason, you can use the standard [[TypedFact]]
     * factory method and supply this fact type as the first parameter.
     */
-  def apply(value: T): TypedFact[T] = TypedFact(this, value)
+  override def apply(value: T): TypedFact[T] = TypedFact(this, value)
 
   def unapply(value: Fact): Option[TypedFact[T]] = cast(value)
 

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprBuilderCatsInstances.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprBuilderCatsInstances.scala
@@ -1,6 +1,10 @@
 package com.rallyhealth.vapors.core.dsl
 
-import cats.{Monad, Traverse, TraverseFilter}
+import cats._
+import cats.data.Ior
+import cats.syntax.all._
+
+import scala.collection.{MapView, View}
 
 trait ExprBuilderCatsInstances {
 
@@ -13,4 +17,234 @@ trait ExprBuilderCatsInstances {
   implicit def traverseMap[K]: Traverse[Map[K, *]] = alleycats.std.map.alleycatsStdInstancesForMap
 
   implicit def traverseFilterMap[K]: TraverseFilter[Map[K, *]] = alleycats.std.map.alleycatsStdMapTraverseFilter
+
+  implicit def traverseMapView[K]: Traverse[MapView[K, *]] = new Traverse[MapView[K, *]] {
+
+    override final def traverse[G[_], A, B](
+      fa: MapView[K, A],
+    )(
+      f: A => G[B],
+    )(implicit
+      G: Applicative[G],
+    ): G[MapView[K, B]] =
+      traverseMap.traverse(fa.toMap)(f).map(_.view)
+
+    override final def map[A, B](fa: MapView[K, A])(f: A => B): MapView[K, B] = fa.mapValues(f)
+
+    override final def foldLeft[A, B](
+      fa: MapView[K, A],
+      b: B,
+    )(
+      f: (B, A) => B,
+    ): B =
+      fa.foldLeft(b) { case (x, (_, a)) => f(x, a) }
+
+    override final def foldRight[A, B](
+      fa: MapView[K, A],
+      lb: Eval[B],
+    )(
+      f: (A, Eval[B]) => Eval[B],
+    ): Eval[B] =
+      Foldable.iterateRight(fa.values, lb)(f)
+
+    override final def size[A](fa: MapView[K, A]): Long = fa.size.toLong
+
+    override final def get[A](fa: MapView[K, A])(idx: Long): Option[A] = {
+      if (idx < 0L || Int.MaxValue < idx) None
+      else {
+        val n = idx.toInt
+        if (n >= fa.size) None
+        else Some(fa.valuesIterator.drop(n).next())
+      }
+    }
+
+    override final def isEmpty[A](fa: MapView[K, A]): Boolean = fa.isEmpty
+
+    override final def fold[A](fa: MapView[K, A])(implicit A: Monoid[A]): A = A.combineAll(fa.values)
+
+    override final def toList[A](fa: MapView[K, A]): List[A] = fa.values.toList
+
+    override final def collectFirst[A, B](fa: MapView[K, A])(pf: PartialFunction[A, B]): Option[B] =
+      fa.collectFirst(new PartialFunction[(K, A), B] {
+        override final def isDefinedAt(x: (K, A)): Boolean = pf.isDefinedAt(x._2)
+        override final def apply(v1: (K, A)): B = pf(v1._2)
+      })
+
+    override final def collectFirstSome[A, B](fa: MapView[K, A])(f: A => Option[B]): Option[B] =
+      collectFirst(fa)(Function.unlift(f))
+  }
+
+  implicit def traverseFilterMapView[K]: TraverseFilter[MapView[K, *]] = new TraverseFilter[MapView[K, *]] {
+    override final def traverse: Traverse[MapView[K, *]] = traverseMapView
+    override final def traverseFilter[G[_], A, B](
+      fa: MapView[K, A],
+    )(
+      f: A => G[Option[B]],
+    )(implicit
+      G: Applicative[G],
+    ): G[MapView[K, B]] = {
+      import cats.syntax.functor._
+      traverseFilterMap.traverseFilter(fa.toMap)(f).map(_.view)
+    }
+  }
+
+  implicit val vaporsInstancesForView: Traverse[View]
+    with TraverseFilter[View]
+    with Alternative[View]
+    with Monad[View]
+    with CoflatMap[View]
+    with Align[View] =
+    new Traverse[View] with TraverseFilter[View] with Alternative[View] with Monad[View] with CoflatMap[View]
+    with Align[View] {
+
+      override final def traverse: Traverse[View] = this
+
+      override final def empty[A]: View[A] = View.empty
+
+      override final def combineK[A](
+        x: View[A],
+        y: View[A],
+      ): View[A] = x ++ y
+
+      override final def pure[A](x: A): View[A] = View(x)
+
+      override final def map[A, B](fa: View[A])(f: A => B): View[B] =
+        fa.map(f)
+
+      override final def flatMap[A, B](fa: View[A])(f: A => View[B]): View[B] =
+        fa.flatMap(f)
+
+      override final def map2[A, B, Z](
+        fa: View[A],
+        fb: View[B],
+      )(
+        f: (A, B) => Z,
+      ): View[Z] =
+        if (fb.isEmpty) View.empty // do O(1) work if fb is empty
+        else fa.flatMap(a => fb.map(b => f(a, b))) // already O(1) if fa is empty
+
+      override final def map2Eval[A, B, Z](
+        fa: View[A],
+        fb: Eval[View[B]],
+      )(
+        f: (A, B) => Z,
+      ): Eval[View[Z]] =
+        if (fa.isEmpty) Eval.now(View.empty) // no need to evaluate fb
+        else fb.map(fb => map2(fa, fb)(f))
+
+      override final def coflatMap[A, B](fa: View[A])(f: View[A] => B): View[B] =
+        fa.tails.to(View).init.map(f)
+
+      override final def foldLeft[A, B](
+        fa: View[A],
+        b: B,
+      )(
+        f: (B, A) => B,
+      ): B =
+        fa.foldLeft(b)(f)
+
+      override final def foldRight[A, B](
+        fa: View[A],
+        lb: Eval[B],
+      )(
+        f: (A, Eval[B]) => Eval[B],
+      ): Eval[B] =
+        Now(fa).flatMap { s =>
+          // Note that we don't use pattern matching, since that may needlessly force the tail.
+          if (s.isEmpty) lb else f(s.head, Eval.defer(foldRight(s.tail, lb)(f)))
+        }
+
+      override final def foldMap[A, B](fa: View[A])(f: A => B)(implicit B: Monoid[B]): B =
+        B.combineAll(fa.iterator.map(f))
+
+      override final def traverse[G[_], A, B](fa: View[A])(f: A => G[B])(implicit G: Applicative[G]): G[View[B]] =
+        Traverse[LazyList].traverse(fa.to[LazyList[A]](LazyList))(f).map(_.to(View))
+
+      override final def mapWithIndex[A, B](fa: View[A])(f: (A, Int) => B): View[B] =
+        fa.zipWithIndex.map(ai => f(ai._1, ai._2))
+
+      override final def zipWithIndex[A](fa: View[A]): View[(A, Int)] =
+        fa.zipWithIndex
+
+      override final def tailRecM[A, B](a: A)(fn: A => View[Either[A, B]]): View[B] =
+        FlatMap[LazyList]
+          .tailRecM(a) {
+            fn.andThen(_.to[LazyList[Either[A, B]]](LazyList))
+          }
+          .to(View)
+
+      override final def exists[A](fa: View[A])(p: A => Boolean): Boolean =
+        fa.exists(p)
+
+      override final def forall[A](fa: View[A])(p: A => Boolean): Boolean =
+        fa.forall(p)
+
+      override final def get[A](fa: View[A])(idx: Long): Option[A] =
+        Traverse[LazyList].get(fa.to[LazyList[A]](LazyList))(idx)
+
+      override final def isEmpty[A](fa: View[A]): Boolean = fa.isEmpty
+
+      override final def foldM[G[_], A, B](
+        fa: View[A],
+        z: B,
+      )(
+        f: (B, A) => G[B],
+      )(implicit
+        G: Monad[G],
+      ): G[B] =
+        Traverse[LazyList].foldM(fa.to[LazyList[A]](LazyList), z)(f)
+
+      override final def fold[A](fa: View[A])(implicit A: Monoid[A]): A = A.combineAll(fa)
+
+      override final def toList[A](fa: View[A]): List[A] = fa.toList
+
+      override final def toIterable[A](fa: View[A]): Iterable[A] = fa
+
+      override def reduceLeftOption[A](fa: View[A])(f: (A, A) => A): Option[A] =
+        fa.reduceLeftOption(f)
+
+      override final def find[A](fa: View[A])(f: A => Boolean): Option[A] = fa.find(f)
+
+      override final def algebra[A]: Monoid[View[A]] = new Monoid[View[A]] {
+        override final def empty: View[A] = View.empty
+        override final def combine(
+          x: View[A],
+          y: View[A],
+        ): View[A] = x ++ y
+      }
+
+      override final def collectFirst[A, B](fa: View[A])(pf: PartialFunction[A, B]): Option[B] = fa.collectFirst(pf)
+
+      override final def collectFirstSome[A, B](fa: View[A])(f: A => Option[B]): Option[B] =
+        fa.collectFirst(Function.unlift(f))
+
+      override final def align[A, B](
+        fa: View[A],
+        fb: View[B],
+      ): View[Ior[A, B]] =
+        alignWith(fa, fb)(identity)
+
+      override final def alignWith[A, B, C](
+        fa: View[A],
+        fb: View[B],
+      )(
+        f: Ior[A, B] => C,
+      ): View[C] =
+        Align[LazyList].alignWith(fa.to[LazyList[A]](LazyList), fb.to[LazyList[B]](LazyList))(f).to(View)
+
+      override final def traverseFilter[G[_], A, B](
+        fa: View[A],
+      )(
+        f: A => G[Option[B]],
+      )(implicit
+        G: Applicative[G],
+      ): G[View[B]] =
+        TraverseFilter[LazyList].traverseFilter(fa.to[LazyList[A]](LazyList))(f).map(_.to(View))
+
+      override def filterA[G[_], A](fa: View[A])(f: A => G[Boolean])(implicit G: Applicative[G]): G[View[A]] =
+        TraverseFilter[LazyList].filterA(fa.to[LazyList[A]](LazyList))(f).map(_.to(View))
+
+      override def mapFilter[A, B](fa: View[A])(f: A => Option[B]): View[B] =
+        fa.collect(Function.unlift(f))
+    }
 }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/MapViewExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/MapViewExprBuilder.scala
@@ -1,0 +1,78 @@
+package com.rallyhealth.vapors.core.dsl
+
+import cats.Id
+import com.rallyhealth.vapors.core.algebra.{CaptureP, Expr}
+import com.rallyhealth.vapors.core.lens.{DataPath, NamedLens}
+import shapeless.Nat
+
+import scala.collection.{MapView, View}
+
+final class MapViewExprBuilder[V, K, U, P](private val inputExpr: Expr[V, MapView[K, U], P]) extends AnyVal {
+
+  def mapValues[R](
+    buildExpr: ValExprBuilder[(K, U), U, P] => ExprBuilder[(K, U), Id, R, P],
+  )(implicit
+    captureView: CaptureP[V, View[(K, U)], P],
+    captureEachTuple: CaptureP[(K, U), (K, U), P],
+    captureEachTupleKey: CaptureP[(K, U), K, P],
+    captureEachTupleValue: CaptureP[(K, U), U, P],
+    captureEachResultTuple: CaptureP[(K, U), (K, R), P],
+    captureViewResult: CaptureP[V, View[(K, R)], P],
+    captureMapViewResult: CaptureP[V, MapView[K, R], P],
+  ): MapViewExprBuilder[V, K, R, P] =
+    MapViewExprBuilder
+      .asFoldableBuilder(this)
+      .map { kv =>
+        val selectKeyFromTuple = kv.get(_.copy(path = DataPath.empty.atKey(Nat._1), get = _._1))
+        val selectValueFromTuple = kv.get(_.copy(path = DataPath.empty.atKey(Nat._2), get = _._2))
+        val mappedValue = buildExpr(new ValExprBuilder(selectValueFromTuple))
+        wrap(
+          selectKeyFromTuple.returnOutput,
+          mappedValue.returnOutput,
+        ).asTuple[(K, R)]
+      }
+      .toMap
+
+  def values(
+    implicit
+    captureView: CaptureP[V, View[(K, U)], P],
+    captureEachTuple: CaptureP[(K, U), (K, U), P],
+    captureEachTupleValue: CaptureP[(K, U), U, P],
+    captureResult: CaptureP[V, View[U], P],
+  ): FoldableExprBuilder[V, View, U, P] = {
+    new FoldableExprBuilder(
+      Expr.MapOutput(
+        Expr.SelectFromOutput(
+          inputExpr,
+          NamedLens.id[MapView[K, U]].asIterable.to(View),
+          captureView,
+        ),
+        Expr.SelectFromOutput(
+          Expr.ReturnInput(captureEachTuple),
+          NamedLens[(K, U), U](DataPath.empty.atKey(Nat._2), _._2),
+          captureEachTupleValue,
+        ),
+        captureResult,
+      ),
+    )
+  }
+}
+
+object MapViewExprBuilder {
+
+  implicit def asExpr[V, K, U, P](builder: MapViewExprBuilder[V, K, U, P]): Expr[V, MapView[K, U], P] =
+    builder.inputExpr
+
+  implicit def asFoldableBuilder[V, K, U, P](
+    builder: MapViewExprBuilder[V, K, U, P],
+  )(implicit
+    captureView: CaptureP[V, View[(K, U)], P],
+  ): FoldableExprBuilder[V, View, (K, U), P] =
+    new FoldableExprBuilder(
+      Expr.SelectFromOutput(
+        builder.inputExpr,
+        NamedLens.id[MapView[K, U]].asIterable.to(View),
+        captureView,
+      ),
+    )
+}

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WithOutputSyntax.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WithOutputSyntax.scala
@@ -13,6 +13,7 @@ trait WithOutputSyntax {
 
 }
 
+// TODO: These classes would not be needed if everything returned builders
 final class WithOutputValueExprBuilder[V, R, P](private val expr: Expr[V, R, P]) extends AnyVal {
 
   def withOutputValue: ValExprBuilder[V, R, P] = new ValExprBuilder(expr)

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WrapExprSyntax.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WrapExprSyntax.scala
@@ -2,7 +2,6 @@ package com.rallyhealth.vapors.core.dsl
 
 import cats.Id
 import com.rallyhealth.vapors.core.algebra.{CaptureP, Expr, ExprConverter, NonEmptyExprHList}
-import shapeless.ops.hlist.Tupler
 import shapeless.{::, Generic, HList, HNil}
 
 trait WrapExprSyntax {

--- a/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/VisitGenericExprWithProxyFn.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/VisitGenericExprWithProxyFn.scala
@@ -8,6 +8,8 @@ import com.rallyhealth.vapors.core.logic.{Conjunction, Disjunction, Negation}
 import com.rallyhealth.vapors.core.math.{Addition, Negative, Subtraction}
 import shapeless.HList
 
+import scala.collection.MapView
+
 /**
   * A function interpreter from [[ExprInput]] to any output type constructor that passes all expressions nodes into
   * a single common [[visitGeneric]] function.
@@ -57,6 +59,10 @@ abstract class VisitGenericExprWithProxyFn[V, P, G[_]] extends Expr.Visitor[V, P
   override def visitFlatMapOutput[M[_] : Foldable : FlatMap, U, X](
     expr: Expr.FlatMapOutput[V, M, U, X, P],
   ): ExprInput[V] => G[M[X]] = visitGeneric(expr, _)
+
+  override def visitGroupOutput[M[_] : Foldable, U : Order, K](
+    expr: Expr.GroupOutput[V, M, U, K, P],
+  ): ExprInput[V] => G[MapView[K, Seq[U]]] = visitGeneric(expr, _)
 
   override def visitMapOutput[M[_] : Foldable : Functor, U, R](
     expr: Expr.MapOutput[V, M, U, R, P],

--- a/core/src/main/scala/com/rallyhealth/vapors/core/lens/Indexed.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/lens/Indexed.scala
@@ -1,6 +1,8 @@
 package com.rallyhealth.vapors.core.lens
 
 import cats.Foldable
+import shapeless.{HList, Nat}
+import shapeless.ops.{hlist, tuple}
 
 /**
   * Defines how to get an instance of [[V]] from a collection [[C]], keyed by [[K]].
@@ -25,6 +27,18 @@ object Indexed extends LowPriorityIndexed {
   implicit def indexedMap[K, V]: Indexed[Map[K, V], K, Option[V]] = {
     new Indexed[Map[K, V], K, Option[V]] {
       override def get(container: Map[K, V])(key: K): Option[V] = container.get(key)
+    }
+  }
+
+  implicit def indexedHList[L <: HList, N <: Nat, V](implicit at: hlist.At.Aux[L, N, V]): Indexed[L, N, V] = {
+    new Indexed[L, N, V] {
+      override def get(container: L)(key: N): V = at(container)
+    }
+  }
+
+  implicit def indexedTuple[T <: Product, N <: Nat, V](implicit at: tuple.At.Aux[T, N, V]): Indexed[T, N, V] = {
+    new Indexed[T, N, V] {
+      override def get(container: T)(key: N): V = at(container)
     }
   }
 

--- a/core/src/main/scala/com/rallyhealth/vapors/core/lens/ValidDataPathKey.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/lens/ValidDataPathKey.scala
@@ -1,6 +1,8 @@
 package com.rallyhealth.vapors.core.lens
 
 import cats.Contravariant
+import shapeless.Nat
+import shapeless.ops.nat.ToInt
 
 /**
   * Defines a type that can be used as the key in a [[Map]].
@@ -23,6 +25,10 @@ object ValidDataPathKey {
     override def contramap[A, B](fa: ValidDataPathKey[A])(f: B => A): ValidDataPathKey[B] = { key =>
       fa.stringify(f(key))
     }
+  }
+
+  implicit def atNatIdx[N <: Nat : ToInt]: ValidDataPathKey[N] = { _ =>
+    ToInt[N].apply().toString
   }
 
   implicit val string: ValidDataPathKey[String] = identity[String]

--- a/core/src/test/scala/com/rallyhealth/vapors/core/example/GeneratedUser.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/example/GeneratedUser.scala
@@ -1,0 +1,22 @@
+package com.rallyhealth.vapors.core.example
+
+import com.rallyhealth.vapors.core.data.FactTable
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+
+abstract class GeneratedUser {
+
+  val name: String = getClass.getSimpleName.filterNot(Set('$'))
+
+  val seed: Seed = Seed(name.##)
+
+  lazy val factTable: FactTable =
+    FactTable(Generators.genFact.pureApply(GeneratedUser.scalaCheckParams, seed))
+}
+
+object GeneratedUser {
+
+  val scalaCheckParams: Gen.Parameters = Gen.Parameters.default
+    .withInitialSeed(7)
+    .withSize(7)
+}

--- a/core/src/test/scala/com/rallyhealth/vapors/core/example/Generators.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/example/Generators.scala
@@ -1,0 +1,37 @@
+package com.rallyhealth.vapors.core.example
+
+import com.rallyhealth.vapors.core.data.Fact
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.ops._
+
+import java.time.Instant
+
+object Generators {
+
+  lazy val genSmallId: Gen[String] = for {
+    chars <- Gen.stringOfN(1, Gen.alphaUpperChar)
+    nums <- Gen.stringOfN(2, Gen.numChar)
+  } yield chars + nums
+
+  lazy val genMusicalNote: Gen[Char] = Gen.choose('A', 'G')
+
+  lazy val genMusicalNoteOrEmpty: Gen[String] = Gen.option(Gen.stringOfN(1, genMusicalNote)).map(_.getOrElse(""))
+
+  lazy val genTimestampWithin90Days: Gen[Instant] = Gen.javaInstant.beforeNowWithin(java.time.Duration.ofDays(90))
+
+  def genTagsSource: Gen[String] = genMusicalNoteOrEmpty
+
+  lazy val genTags: Gen[Set[String]] = Gen.setOf(genSmallId)
+
+  lazy val genTagsUpdate: Gen[TagsUpdate] = for {
+    source <- genTagsSource
+    tags <- genTags
+    timestamp <- genTimestampWithin90Days
+  } yield TagsUpdate(
+    source,
+    tags,
+    timestamp,
+  )
+
+  lazy val genFact: Gen[Fact] = genTagsUpdate.map(FactTypes.TagsUpdate)
+}

--- a/core/src/test/scala/com/rallyhealth/vapors/core/example/users.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/example/users.scala
@@ -1,0 +1,11 @@
+package com.rallyhealth.vapors.core.example
+
+// Some sample users to compare for testing that generate the same facts every time
+// this should hopefully make it easier to spot when something is awry with the sample user.
+// Unlike JoeSchmoe, you cannot make any assumptions about the presence of facts so you should
+// verify that your test user has the necessary pre-conditions. If not, you should pick a
+// different generated user.
+
+case object User1 extends GeneratedUser
+case object User2 extends GeneratedUser
+case object User3 extends GeneratedUser

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/GroupOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/GroupOutputSpec.scala
@@ -1,0 +1,23 @@
+package com.rallyhealth.vapors.core.interpreter
+
+import com.rallyhealth.vapors.core.dsl._
+import com.rallyhealth.vapors.core.example.{FactTypes, User1}
+import org.scalatest.freespec.AnyFreeSpec
+
+class GroupOutputSpec extends AnyFreeSpec {
+
+  "groupBy should" - {
+
+    "create a map from a list using groupBy and mapValues" in {
+      val query = factsOfType(FactTypes.TagsUpdate)
+        .groupBy(_.select(_.value.source))
+        // TODO: This is very verbose and doesn't easily support the common case of mapping over collection values
+        .mapValues(_.returnOutput.withOutputFoldable.map(_.value).returnOutput)
+      val expected = User1.factTable.getSortedSeq(FactTypes.TagsUpdate).groupMap(_.value.source)(_.value)
+      val result = eval(User1.factTable)(query)
+      assertResult(expected) {
+        result.output.value.toMap
+      }
+    }
+  }
+}

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/SelectFromOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/SelectFromOutputSpec.scala
@@ -1,0 +1,50 @@
+package com.rallyhealth.vapors.core.interpreter
+
+import cats.instances.order._
+import com.rallyhealth.vapors.core.dsl._
+import com.rallyhealth.vapors.core.example._
+import org.scalatest.freespec.AnyFreeSpec
+import shapeless.Nat
+
+import scala.collection.View
+
+class SelectFromOutputSpec extends AnyFreeSpec {
+
+  "create a map from a converting a list of facts to tuples" in {
+    val query = factsOfType(FactTypes.TagsUpdate).map { fact =>
+      val update = fact.value
+      wrap(
+        update.get(_.select(_.source)).returnOutput,
+        update.get(_.select(_.tags)).returnOutput,
+      ).asTuple.withOutputValue
+    }.toMap
+    val expected = User1.factTable
+      .getSortedSeq(FactTypes.TagsUpdate)
+      .map { fact =>
+        (fact.value.source, fact.value.tags)
+      }
+      .toMap
+    val result = eval(User1.factTable)(query)
+    assertResult(expected) {
+      result.output.value.toMap
+    }
+  }
+
+  "create a set from a list using groupBy, flatMap, sorted, and headOption" in {
+    val query = factsOfType(FactTypes.TagsUpdate)
+      .groupBy(_.select(_.value.source))
+      .flatMap { sourceAndFacts =>
+        val facts = sourceAndFacts.getFoldable(_.atKey(Nat._1))
+        val latestFactTags = facts.sorted.headOption.toSet.flatMap(_.getFoldable(_.select(_.value.tags)))
+        latestFactTags.to(View)
+      }
+    val expected = User1.factTable.getSortedSeq(FactTypes.TagsUpdate).groupBy(_.value.source).view.flatMap {
+      case (_, facts) =>
+        facts.map(_.value).sorted.headOption.toList.flatMap(_.tags)
+    }
+    val result = eval(User1.factTable)(query)
+    assertResult(expected.toVector) {
+      result.output.value.toVector
+    }
+  }
+}


### PR DESCRIPTION
**Summary**

- Add cats instances for MapView and View
- Cleanup ExprBuilder methods
  - use IterableOnce instead of Iterable for lower bound
  - override higher kinded type returnOutput in FoldableExprBuilder
- Add support for accessing tuple elements via NamedLens
  - Use shapeless for NamedLens tuples
  - Add a .toMap method for lens
- Convert FactType to extend function
- Add Expr.GroupOutput and unit tests
  - Added Expr.GroupOutput and associated groupBy builder
  - Added a MapViewExprBuilder for special operations on maps
  - Added GeneratedUsers for testing with ScalaCheck