### PR TITLE
Add Expr.CustomFunction and datetime functions

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/CaptureP.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/CaptureP.scala
@@ -8,15 +8,17 @@ import scala.annotation.implicitNotFound
 
 @implicitNotFound(
   """
-Missing implicit CaptureP[${V}, ${R}, P] (where P is some arbitrary type of parameter).
+Missing implicit CaptureP[${V}, ${R}, P] (where P is a custom parameter type that you choose via implicit).
+Currently, P is inferred as ${P}.
 
-If you do not plan to do post-processing, you can import CaptureP.unit._
+Expression builders rely on the implicit CaptureP in scope to determine the concrete type of P.
+CaptureP.unit will be used by default unless another implicit is in scope and P will be inferred as Unit.
+However, if the compiler has trouble inferring other arguments, such as V or R, then it may also fail to infer P.
 
-Alternatively, you can import or define a CaptureP that matches the type of this expression node and extracts some type parameter P.
-If you decide to define it, remember to define one implicit where all of the types, aside from P, are abstract use a low priority implicit trait.
-It will need to combine, return, or ignore the parameters from its child nodes. If P is a Monoid, you can just define it using CaptureP.AsMonoid.
+Is the compiler is unable to infer either V (${V}) or R (${R})?
+If so, you may need to check the types of your expression and make sure they match.
 
-The expression node that failed to find a post processor is:
+Failed to find a CaptureP for the following expression:
 """,
 )
 trait CaptureP[V, R, P] {

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
@@ -45,6 +45,7 @@ object ExprResult {
     def visitCollectFromOutput[M[_] : Foldable, U, R : Monoid](result: CollectFromOutput[V, M, U, R, P]): G[R]
     def visitConcatOutput[M[_] : MonoidK, R](result: ConcatOutput[V, M, R, P]): G[M[R]]
     def visitConstOutput[R](result: ConstOutput[V, R, P]): G[R]
+    def visitCustomFunction[A, R](result: CustomFunction[V, A, R, P]): G[R]
     def visitDeclare[M[_], T](result: Define[V, M, T, P]): G[FactSet]
     def visitEmbed[R](result: Embed[V, R, P]): G[R]
     def visitExistsInOutput[M[_] : Foldable, U](result: ExistsInOutput[V, M, U, P]): G[Boolean]
@@ -105,6 +106,14 @@ object ExprResult {
     embeddedResult: ExprResult[FactTable, R, P],
   ) extends ExprResult[V, R, P] {
     override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitEmbed(this)
+  }
+
+  final case class CustomFunction[V, A, R, P](
+    expr: Expr.CustomFunction[V, A, R, P],
+    context: Context[V, R, P],
+    argResult: ExprResult[V, A, P],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitCustomFunction(this)
   }
 
   final case class WithFactsOfType[V, T, R, P](

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprDsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprDsl.scala
@@ -26,7 +26,7 @@ object ExprDsl extends ExprDsl {
 }
 
 // TODO: Remove methods that are not useful anymore and move less-useful methods to a separate object
-trait ExprDsl extends WrapExprSyntax with WrapEachExprSyntax {
+trait ExprDsl extends TimeFunctions with WrapExprSyntax with WrapEachExprSyntax {
 
   def eval[R, P](facts: FactTable)(query: RootExpr[R, P]): ExprResult[FactTable, R, P] = {
     InterpretExprAsResultFn(query)(ExprInput.fromFactTable(facts))

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/TimeFunctions.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/TimeFunctions.scala
@@ -1,0 +1,82 @@
+package com.rallyhealth.vapors.core.dsl
+
+import com.rallyhealth.vapors.core.algebra.{CaptureP, Expr}
+import com.rallyhealth.vapors.core.data.FactTable
+import com.rallyhealth.vapors.core.time.{CountTime, ModifyTime}
+import shapeless._
+
+import java.time.{Clock, Instant, LocalDate}
+
+trait TimeFunctions {
+
+  // TODO: Can this be converted to Addition[T] if we make the second argument a different type? Maybe AddLeft[T, D]?
+  final def dateAdd[V, T, D, P](
+    lhs: Expr[V, T, P],
+    rhs: Expr[V, D, P],
+  )(implicit
+    modTime: ModifyTime[T, D],
+    argTypeInfo: Typeable[T :: D :: HNil],
+    captureArgResult: CaptureP[V, T :: D :: HNil, P],
+    captureResult: CaptureP[V, T, P],
+  ): Expr[V, T, P] = {
+    val argExpr = wrap(lhs, rhs).asHList.returnOutput
+    val fn: T :: D :: HNil => T = {
+      case lhs :: rhs :: HNil =>
+        ModifyTime.addTo(lhs, rhs)
+    }
+    Expr.CustomFunction(argExpr, "date_add", fn, captureResult)
+  }
+
+  final def dateDiff[V, T, U, P](
+    lhsExpr: Expr[V, T, P],
+    rhsExpr: Expr[V, T, P],
+    roundToUnitExpr: Expr[V, U, P],
+  )(implicit
+    countTime: CountTime[T, U],
+    argTypeInfo: Typeable[T :: T :: U :: HNil],
+    captureArgResult: CaptureP[V, T :: T :: U :: HNil, P],
+    captureResult: CaptureP[V, Long, P],
+  ): Expr[V, Long, P] = {
+    val argExpr = wrap(lhsExpr, rhsExpr, roundToUnitExpr).asHList.returnOutput
+    val fn: T :: T :: U :: HNil => Long = {
+      case lhs :: rhs :: unit :: HNil =>
+        CountTime.between(lhs, rhs, unit)
+    }
+    Expr.CustomFunction(argExpr, "date_diff", fn, captureResult)
+  }
+
+  final def today[V, P](
+    implicit
+    captureClock: CaptureP[FactTable, Clock, P],
+    captureEmbed: CaptureP[V, Clock, P],
+    captureResult: CaptureP[V, LocalDate, P],
+  ): Expr[V, LocalDate, P] =
+    today(Clock.systemDefaultZone())
+
+  final def today[V, P](
+    clock: Clock,
+  )(implicit
+    captureClock: CaptureP[FactTable, Clock, P],
+    captureEmbed: CaptureP[V, Clock, P],
+    captureResult: CaptureP[V, LocalDate, P],
+  ): Expr[V, LocalDate, P] =
+    Expr.CustomFunction[V, Clock, LocalDate, P](embed(const(clock)), "today", LocalDate.now, captureResult)
+
+  final def now[V, P](
+    implicit
+    captureClock: CaptureP[FactTable, Clock, P],
+    captureEmbed: CaptureP[V, Clock, P],
+    captureResult: CaptureP[V, Instant, P],
+  ): Expr[V, Instant, P] =
+    now(Clock.systemUTC())
+
+  final def now[V, P](
+    clock: Clock,
+  )(implicit
+    captureClock: CaptureP[FactTable, Clock, P],
+    captureEmbed: CaptureP[V, Clock, P],
+    captureResult: CaptureP[V, Instant, P],
+  ): Expr[V, Instant, P] =
+    Expr.CustomFunction[V, Clock, Instant, P](embed(const(clock)), "now", Instant.now, captureResult)
+
+}

--- a/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/InterpretExprAsResultFn.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/InterpretExprAsResultFn.scala
@@ -88,6 +88,16 @@ final class InterpretExprAsResultFn[V, P] extends Expr.Visitor[V, P, Lambda[r =>
     }
   }
 
+  override def visitCustomFunction[A, R](
+    expr: Expr.CustomFunction[V, A, R, P],
+  ): ExprInput[V] => ExprResult[V, R, P] = { input =>
+    val argResult = InterpretExprAsResultFn(expr.inputExpr)(input)
+    val value = expr.evaluate(argResult.output.value)
+    resultOfPureExpr(expr, input, value, argResult.output.evidence) {
+      ExprResult.CustomFunction(_, _, argResult)
+    }
+  }
+
   override def visitDefine[M[_] : Foldable, T](
     expr: Expr.Define[M, T, P],
   ): ExprInput[V] => ExprResult[V, FactSet, P] = { input =>

--- a/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/VisitGenericExprWithProxyFn.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/VisitGenericExprWithProxyFn.scala
@@ -41,6 +41,9 @@ abstract class VisitGenericExprWithProxyFn[V, P, G[_]] extends Expr.Visitor[V, P
   override def visitConstOutput[R](expr: Expr.ConstOutput[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)
 
+  override def visitCustomFunction[A, R](expr: Expr.CustomFunction[V, A, R, P]): ExprInput[V] => G[R] =
+    visitGeneric(expr, _)
+
   override def visitDefine[M[_] : Foldable, T](expr: Expr.Define[M, T, P]): ExprInput[V] => G[FactSet] = { input =>
     visitGeneric(expr, input.withValue(input.factTable))
   }

--- a/core/src/main/scala/com/rallyhealth/vapors/core/time/CountTime.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/time/CountTime.scala
@@ -1,0 +1,44 @@
+package com.rallyhealth.vapors.core.time
+
+import java.time.temporal.{ChronoUnit, Temporal, TemporalUnit}
+
+trait CountTime[-T, -U] {
+
+  /**
+    * Count the whole number of complete time units between the start and end.
+    *
+    * @param start the start of the time range (inclusive)
+    * @param end the end of the time range (inclusive)
+    * @param truncateToUnit the unit to round down to
+    * @return the whole number of units between the start up to, but not including, the end
+    */
+  def between(
+    start: T,
+    end: T,
+    truncateToUnit: U,
+  ): Long
+}
+
+object CountTime {
+
+  def between[T, U](
+    start: T,
+    end: T,
+    roundDownToUnit: U,
+  )(implicit
+    diffTime: CountTime[T, U],
+  ): Long = diffTime.between(start, end, roundDownToUnit)
+
+  private final class OfTemporal[-T <: Temporal] extends CountTime[T, TemporalUnit] {
+    override def between(
+      start: T,
+      end: T,
+      unit: TemporalUnit,
+    ): Long = start.until(end, unit)
+  }
+
+  @inline private def temporal[T <: Temporal]: CountTime[T, ChronoUnit] = new OfTemporal[T]
+
+  // TODO: Restrict invalid units by type
+  implicit val ofTemporal: CountTime[Temporal, ChronoUnit] = temporal
+}

--- a/core/src/main/scala/com/rallyhealth/vapors/core/time/ModifyTime.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/time/ModifyTime.scala
@@ -1,0 +1,36 @@
+package com.rallyhealth.vapors.core.time
+
+import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period, ZonedDateTime}
+import java.time.temporal.{Temporal, TemporalAmount}
+
+trait ModifyTime[T, -D] {
+
+  def addTo(
+    temporal: T,
+    amount: D,
+  ): T
+}
+
+object ModifyTime {
+
+  def addTo[T, D](
+    temporal: T,
+    amount: D,
+  )(implicit
+    modifier: ModifyTime[T, D],
+  ): T = modifier.addTo(temporal, amount)
+
+  private final class OfTemporal[T <: Temporal, -D <: TemporalAmount] extends ModifyTime[T, D] {
+    override def addTo(
+      temporal: T,
+      amount: D,
+    ): T = amount.addTo(temporal).asInstanceOf[T]
+  }
+
+  @inline private def temporal[T <: Temporal, D <: TemporalAmount]: ModifyTime[T, D] = new OfTemporal[T, D]
+
+  implicit val ofInstant: ModifyTime[Instant, Duration] = temporal
+  implicit val ofLocalDate: ModifyTime[LocalDate, Period] = temporal
+  implicit val ofLocalDateTime: ModifyTime[LocalDateTime, TemporalAmount] = temporal
+  implicit val ofZonedDateTime: ModifyTime[ZonedDateTime, TemporalAmount] = temporal
+}

--- a/core/src/main/scala/com/rallyhealth/vapors/core/time/ModifyTime.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/time/ModifyTime.scala
@@ -3,8 +3,14 @@ package com.rallyhealth.vapors.core.time
 import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period, ZonedDateTime}
 import java.time.temporal.{Temporal, TemporalAmount}
 
+/**
+  * Defines the capability of adding or subtracting an amount of time to a temporal moment.
+  */
 trait ModifyTime[T, -D] {
 
+  /**
+    * Add a positive or negative temporal amount to a temporal moment.
+    */
   def addTo(
     temporal: T,
     amount: D,
@@ -29,8 +35,31 @@ object ModifyTime {
 
   @inline private def temporal[T <: Temporal, D <: TemporalAmount]: ModifyTime[T, D] = new OfTemporal[T, D]
 
+  /**
+    * Allows adding a [[Duration]] to a [[Instant]].
+    *
+    * An [[Instant]] does not support adding or subtracting year, month, or day [[Period]]s.
+    */
   implicit val ofInstant: ModifyTime[Instant, Duration] = temporal
+
+  /**
+    * Allows adding a [[Period]] to a [[LocalDate]].
+    *
+    * A [[LocalDate]] does not support adding or subtracting nanosecond, minute, hour, etc [[Duration]]s.
+    */
   implicit val ofLocalDate: ModifyTime[LocalDate, Period] = temporal
+
+  /**
+    * Allows adding any [[TemporalAmount]] to a [[LocalDateTime]].
+    *
+    * A [[LocalDateTime]] supports adding or subtracting time [[Duration]]s as well as date [[Period]]s.
+    */
   implicit val ofLocalDateTime: ModifyTime[LocalDateTime, TemporalAmount] = temporal
+
+  /**
+    * Allows adding any [[TemporalAmount]] to a [[ZonedDateTime]].
+    *
+    * A [[ZonedDateTime]] supports adding or subtracting time [[Duration]]s as well as date [[Period]]s.
+    */
   implicit val ofZonedDateTime: ModifyTime[ZonedDateTime, TemporalAmount] = temporal
 }

--- a/core/src/test/scala/com/rallyhealth/vapors/core/example/JoeSchmoe.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/example/JoeSchmoe.scala
@@ -9,7 +9,7 @@ object JoeSchmoe {
   val age = FactTypes.Age(32)
   val userRole = FactTypes.Role(Role.User)
   val adminRole = FactTypes.Role(Role.Admin)
-  val dateOfBirth = FactTypes.DateOfBirth(LocalDate.of(1987, 1, 1))
+  val dateOfBirth = FactTypes.DateOfBirth(LocalDate.of(1988, 8, 8))
 
   val lastAddressUpdate = FactTypes.AddressUpdate(
     AddressUpdate(

--- a/core/src/test/scala/com/rallyhealth/vapors/core/example/Snippets.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/example/Snippets.scala
@@ -1,0 +1,57 @@
+package com.rallyhealth.vapors.core.example
+
+import cats.Id
+import com.rallyhealth.vapors.core.algebra.Expr
+import com.rallyhealth.vapors.core.data.{FactTable, FactType}
+import com.rallyhealth.vapors.core.dsl._
+
+import java.time.temporal.ChronoUnit
+import java.time._
+
+class Snippets(val clock: Clock) {
+
+  def this(fixedInstant: Instant) = this(Clock.fixed(fixedInstant, ZoneOffset.UTC))
+
+  def this(fixedLocalDate: LocalDate) =
+    this(Clock.fixed(fixedLocalDate.atStartOfDay(ZoneId.systemDefault()).toInstant, ZoneId.systemDefault()))
+
+  val ageFromDateOfBirth: Expr[FactTable, Seq[Int], Unit] = {
+    factsOfType(FactTypes.DateOfBirth).map { fact =>
+      val ageInYears = dateDiff(
+        fact.get(_.select(_.value)),
+        fact.embedResult(today(clock)),
+        fact.embedConst(ChronoUnit.YEARS),
+      )
+      ageInYears.withOutputValue.get(_.select(_.toInt))
+    }
+  }
+
+  val ageFromDateOfBirthDef: Expr.Definition[Unit] = {
+    define(FactTypes.Age).fromEvery {
+      ageFromDateOfBirth
+    }
+  }
+
+  val isOver18: RootExpr[Boolean, Unit] = {
+    usingDefinitions(ageFromDateOfBirthDef) {
+      factsOfType(FactTypes.Age).exists {
+        _.get(_.select(_.value)) >= 18
+      }
+    }
+  }
+
+  lazy val isUser: RootExpr[Boolean, Unit] = {
+    withFactsOfType(FactTypes.Role).where {
+      _.exists {
+        _.get(_.select(_.value)) >= Role.User
+      }
+    }
+  }
+
+  val isEligible: RootExpr[Boolean, Unit] = and(isOver18, isUser)
+
+  val isEligibleDef: Expr.Define[Id, Boolean, Unit] =
+    define(FactType[Boolean]("is_eligible")).from(isEligible)
+}
+
+object Snippets extends Snippets(Clock.systemDefaultZone())

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/TimeFunctionsSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/TimeFunctionsSpec.scala
@@ -1,0 +1,253 @@
+package com.rallyhealth.vapors.core.interpreter
+
+import com.rallyhealth.vapors.core.algebra.Expr
+import com.rallyhealth.vapors.core.data.FactTable
+import com.rallyhealth.vapors.core.dsl._
+import com.rallyhealth.vapors.core.example.{FactTypes, Snippets}
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.ops._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.Assertion
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks._
+
+import java.time.temporal.{ChronoUnit, Temporal, TemporalAmount}
+import java.time._
+import scala.util.Try
+
+class TimeFunctionsSpec extends AnyFreeSpec {
+  import TimeFunctionsSpec._
+
+  private def testProducesTheSameResult[T <: Temporal : Arbitrary, D <: TemporalAmount : Arbitrary](
+    evaluateDirectly: (T, D) => T,
+    buildQuery: (RootExpr[T, Unit], RootExpr[D, Unit]) => RootExpr[T, Unit],
+  ): Assertion = {
+    forAll { (temporal: T, amount: D) =>
+      val query = buildQuery(const(temporal), const(amount))
+      Try(evaluateDirectly(temporal, amount)).fold(
+        expectedErr => {
+          val err = intercept[DateTimeException] {
+            eval(FactTable.empty)(query)
+          }
+          assertResult(expectedErr.getMessage) {
+            err.getMessage
+          }
+        },
+        expectedValue => {
+          val result = eval(FactTable.empty)(query)
+          assertResult(expectedValue) {
+            result.output.value
+          }
+        },
+      )
+    }
+  }
+
+  "dateAdd" - {
+
+    "Instant with" - {
+
+      "Duration works the same as .plus" in {
+        testProducesTheSameResult[Instant, Duration](
+          _.plus(_),
+          dateAdd(_, _),
+        )
+      }
+
+      "Period fails to compile" in {
+        val now = Instant.now()
+        val period = Period.ofYears(1)
+        assertDoesNotCompile {
+          "dateAdd(const(now), const(period))"
+        }
+        assertThrows[DateTimeException] {
+          now.plus(period)
+        }
+      }
+    }
+
+    "LocalDate with" - {
+
+      "Duration fails to compile" in {
+        val today = LocalDate.now()
+        val duration = Duration.ofSeconds(10)
+        assertDoesNotCompile {
+          "dateAdd(const(today), const(duration))"
+        }
+        assertThrows[DateTimeException] {
+          today.plus(duration)
+        }
+      }
+
+      "Period works the same as .plus" in {
+        testProducesTheSameResult[LocalDate, Period](
+          _.plus(_),
+          dateAdd(_, _),
+        )
+      }
+    }
+
+    "LocalDateTime with" - {
+
+      "Duration works the same as .plus" in {
+        testProducesTheSameResult[LocalDateTime, Duration](
+          _.plus(_),
+          dateAdd(_, _),
+        )
+      }
+
+      "Period works the same as .plus" in {
+        testProducesTheSameResult[LocalDateTime, Period](
+          _.plus(_),
+          dateAdd(_, _),
+        )
+      }
+    }
+
+    "ZonedDateTime with" - {
+
+      "Duration works the same as .plus" in {
+        testProducesTheSameResult[ZonedDateTime, Duration](
+          _.plus(_),
+          dateAdd(_, _),
+        )
+      }
+
+      "Period works the same as .plus" in {
+        testProducesTheSameResult[ZonedDateTime, Period](
+          _.plus(_),
+          dateAdd(_, _),
+        )
+      }
+    }
+  }
+
+  "dateDiff" - {
+
+    "computing Age from DateOfBirth" - {
+
+      val feb28Year2021 = LocalDate.of(2021, 2, 28)
+      val onFeb28Year2021 = new Snippets(feb28Year2021)
+
+      // leap year
+      val feb29Year2020 = LocalDate.of(2020, 2, 29)
+      val onFeb29Year2020 = new Snippets(feb29Year2020)
+
+      "rounds the year down" in {
+        val feb1Minus20Years = LocalDate.of(feb28Year2021.getYear - 20, 2, 1)
+        // validate that it works outside of vapors
+        assertResult(20) {
+          feb1Minus20Years.until(feb28Year2021, ChronoUnit.YEARS)
+        }
+        // validate that it works inside of vapors
+        val result = eval(FactTable(FactTypes.DateOfBirth(feb1Minus20Years))) {
+          onFeb28Year2021.ageFromDateOfBirth
+        }
+        assertResult(Seq(20)) { // Just turned 20 this month
+          result.output.value
+        }
+      }
+
+      "rounds the year down, even when close" in {
+        val feb29Year2000 = feb28Year2021.minusYears(21).plusDays(1)
+        // validate that it works outside of vapors
+        assertResult(20) {
+          feb29Year2000.until(feb28Year2021, ChronoUnit.YEARS)
+        }
+        // validate that it works inside of vapors
+        val result = eval(FactTable(FactTypes.DateOfBirth(feb29Year2000))) {
+          onFeb28Year2021.ageFromDateOfBirth
+        }
+        assertResult(Seq(20)) { // Sorry, birthday is tomorrow
+          result.output.value
+        }
+      }
+
+      "counts the current year on their birthday" in {
+        val feb28Year2000 = feb28Year2021.minusYears(21)
+        // validate that it works outside of vapors
+        assertResult(21) {
+          feb28Year2000.until(feb28Year2021, ChronoUnit.YEARS)
+        }
+        // validate that it works inside of vapors
+        val result = eval(FactTable(FactTypes.DateOfBirth(feb28Year2000))) {
+          onFeb28Year2021.ageFromDateOfBirth
+        }
+        assertResult(Seq(21)) { // 🎉 happy birthday! 🍻
+          result.output.value
+        }
+      }
+
+      "returns the correct number of years between leap years" in {
+        val feb29Year2000 = LocalDate.of(2000, 2, 29)
+        // validate that it works outside of vapors
+        assertResult(20) {
+          feb29Year2000.until(feb29Year2020, ChronoUnit.YEARS)
+        }
+        // validate that it works inside of vapors
+        val result = eval(FactTable(FactTypes.DateOfBirth(feb29Year2000))) {
+          new Snippets(feb29Year2020).ageFromDateOfBirth
+        }
+        assertResult(Seq(20)) { // leap years work as expected
+          result.output.value
+        }
+      }
+
+      "returns the correct number of years on a leap year" in {
+        val mar1Year1999 = LocalDate.of(1999, 3, 1)
+        // validate that it works outside of vapors
+        assertResult(20) {
+          mar1Year1999.until(feb29Year2020, ChronoUnit.YEARS)
+        }
+        // validate that it works inside of vapors
+        val result = eval(FactTable(FactTypes.DateOfBirth(mar1Year1999))) {
+          onFeb29Year2020.ageFromDateOfBirth
+        }
+        assertResult(Seq(20)) {
+          result.output.value
+        }
+      }
+
+      "returns the correct number of years from a leap year birthday" in {
+        val feb29Year2000 = LocalDate.of(2000, 2, 29)
+        // validate that it works outside of vapors
+        assertResult(20) {
+          feb29Year2000.until(feb28Year2021, ChronoUnit.YEARS)
+        }
+        // validate that it works inside of vapors
+        val result = eval(FactTable(FactTypes.DateOfBirth(feb29Year2000))) {
+          onFeb28Year2021.ageFromDateOfBirth
+        }
+        assertResult(Seq(20)) {
+          result.output.value
+        }
+      }
+    }
+  }
+}
+
+object TimeFunctionsSpec {
+
+  // TODO: Add to scalacheck-ops
+
+  // $COVERAGE-OFF$
+  implicit val arbChronoUnit: Arbitrary[ChronoUnit] = Arbitrary {
+    Gen.oneOf(ChronoUnit.values())
+  }
+
+  implicit val arbJDuration: Arbitrary[Duration] = Arbitrary {
+    for {
+      a <- arbitrary[Instant]
+      b <- arbitrary[Instant]
+    } yield Duration.between(a, b)
+  }
+
+  implicit val arbJPeriod: Arbitrary[Period] = Arbitrary {
+    for {
+      a <- arbitrary[LocalDate]
+      b <- arbitrary[LocalDate]
+    } yield Period.between(a, b)
+  }
+  // $COVERAGE-ON$
+}

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/UsingDefinitionsExprSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/UsingDefinitionsExprSpec.scala
@@ -1,9 +1,8 @@
 package com.rallyhealth.vapors.core.interpreter
 
-import com.rallyhealth.vapors.core.algebra.Expr
-import com.rallyhealth.vapors.core.data.{DerivedFactOfType, Evidence, FactTable, FactType}
+import com.rallyhealth.vapors.core.data.{DerivedFactOfType, Evidence, FactTable}
 import com.rallyhealth.vapors.core.dsl._
-import com.rallyhealth.vapors.core.example.{FactTypes, JoeSchmoe, Role}
+import com.rallyhealth.vapors.core.example.{FactTypes, JoeSchmoe, Role, Snippets}
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -13,50 +12,9 @@ class UsingDefinitionsExprSpec extends AnyWordSpec {
 
   "Expr.UsingDefinitions" should {
 
-    // TODO: Do the real computation here
-    // TODO: Make a named function to call out to "dateCompare()" (maybe a primitive algebra?)
-    //       Or just hack it for now.
-    // now.year - dob.year - (if (now.dayOfYear < (dob.dayOfYear + (if (dob.isLeapYear) 1 else 0)) 1 else 0)
-    lazy val ageFromDateOfBirth = {
-      val now = LocalDate.now()
-      withFactsOfType(FactTypes.DateOfBirth).where { facts =>
-        facts.map { fact =>
-          fact.get(_.select(_.value).select(_.getYear)).subtractFrom(now.getYear)
-        }
-      }
-    }
-
-    lazy val ageFromDateOfBirthDef: Expr.Definition[Unit] = {
-      define(FactTypes.Age).fromEvery {
-        ageFromDateOfBirth
-      }
-    }
-
-    lazy val isOver18: RootExpr[Boolean, Unit] = {
-      usingDefinitions(ageFromDateOfBirthDef) {
-        withFactsOfType(FactTypes.Age).where {
-          _.exists {
-            _.get(_.select(_.value)) >= 18
-          }
-        }
-      }
-    }
-
-    lazy val isUser: RootExpr[Boolean, Unit] = {
-      withFactsOfType(FactTypes.Role).where {
-        _.exists {
-          _.get(_.select(_.value)) >= Role.User
-        }
-      }
-    }
-
-    lazy val isEligible: RootExpr[Boolean, Unit] = and(isOver18, isUser)
-
-    lazy val isEligibleDef = define(FactType[Boolean]("is_eligible")).from(isEligible)
-
     "add the defined facts to the fact table" in {
       val result = eval(JoeSchmoe.factTable) {
-        usingDefinitions(ageFromDateOfBirthDef) {
+        usingDefinitions(Snippets.ageFromDateOfBirthDef) {
           withFactsOfType(FactTypes.Age).returnInput
         }
       }
@@ -69,7 +27,7 @@ class UsingDefinitionsExprSpec extends AnyWordSpec {
       val expiredAge = FactTypes.Age(17)
       val dob = FactTypes.DateOfBirth(LocalDate.of(yearWhen19, 1, 1))
       val facts = FactTable(expiredAge, dob)
-      val result = eval(facts)(isOver18)
+      val result = eval(facts)(Snippets.isOver18)
       assert(result.output.value)
       val ageFromYear = LocalDate.now().getYear - dob.value.getYear
       val expectedDerivedFact = DerivedFactOfType(FactTypes.Age, ageFromYear, Evidence(dob))
@@ -83,9 +41,10 @@ class UsingDefinitionsExprSpec extends AnyWordSpec {
       val expiredAge = FactTypes.Age(17)
       val dob = FactTypes.DateOfBirth(LocalDate.of(yearWhen19, 1, 1))
       val facts = FactTable(expiredAge, dob, userRole)
+      val definition = Snippets.isEligibleDef
       val result = eval(facts) {
-        usingDefinitions(isEligibleDef) {
-          withFactsOfType(isEligibleDef.factType).where {
+        usingDefinitions(definition) {
+          withFactsOfType(definition.factType).where {
             _.exists(_.get(_.select(_.value)))
           }
         }
@@ -93,7 +52,7 @@ class UsingDefinitionsExprSpec extends AnyWordSpec {
       assert(result.output.value)
       val correctAge = DerivedFactOfType(FactTypes.Age, 19, Evidence(dob))
       val evidenceOfEligibility = Evidence(
-        DerivedFactOfType(isEligibleDef.factType, true, Evidence(correctAge, userRole)),
+        DerivedFactOfType(definition.factType, true, Evidence(correctAge, userRole)),
       )
       assertResult(evidenceOfEligibility)(result.output.evidence)
       assertResult(Evidence(dob, userRole))(result.output.evidence.derivedFromSources)


### PR DESCRIPTION
- Add Expr.CustomFunction and datetime functions
- Add TimeFunctions to ExprDsl
- Improve unit tests for Age from DateOfBirth
- Add ModifyTime typeclass for adding or subtracting from times
- Add CountTime typeclass for counting the difference between times
- Add now and today methods for injecting the current time from a clock
- Deprecate builder.embed and add better alternatives
- Improve CaptureP implicitNotFound message