### PR TITLE
Add Expr.MultiplyOutputs operator and builder methods

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/Expr.scala
@@ -6,9 +6,7 @@ import com.rallyhealth.vapors.core.data._
 import com.rallyhealth.vapors.core.interpreter.{ExprOutput, InterpretExprAsResultFn}
 import com.rallyhealth.vapors.core.lens.NamedLens
 import com.rallyhealth.vapors.core.logic.{Conjunction, Disjunction, Negation}
-import com.rallyhealth.vapors.core.math.{Addition, Division, Negative, Subtraction}
-import shapeless.HList
-import com.rallyhealth.vapors.core.math.{Addition, Negative, Subtraction}
+import com.rallyhealth.vapors.core.math._
 import shapeless.{HList, Typeable}
 
 import scala.collection.MapView
@@ -57,6 +55,7 @@ object Expr {
     def visitFlatMapOutput[M[_] : Foldable : FlatMap, U, X](expr: FlatMapOutput[V, M, U, X, P]): G[M[X]]
     def visitGroupOutput[M[_] : Foldable, U : Order, K](expr: GroupOutput[V, M, U, K, P]): G[MapView[K, Seq[U]]]
     def visitMapOutput[M[_] : Foldable : Functor, U, R](expr: MapOutput[V, M, U, R, P]): G[M[R]]
+    def visitMultiplyOutputs[R : Multiplication](expr: MultiplyOutputs[V, R, P]): G[R]
     def visitNegativeOutput[R : Negative](expr: NegativeOutput[V, R, P]): G[R]
     def visitNot[R : Negation](expr: Not[V, R, P]): G[R]
     def visitOr[R : Disjunction : ExtractBoolean](expr: Or[V, R, P]): G[R]
@@ -484,6 +483,16 @@ object Expr {
     capture: CaptureP[V, R, P],
   ) extends Expr[V, R, P] {
     override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitSubtractOutputs(this)
+  }
+
+  /**
+    * Multiply the results of all expressions in [[inputExprList]] using the provided definition for [[Addition]].
+    */
+  final case class MultiplyOutputs[V, R : Multiplication, P](
+    inputExprList: NonEmptyList[Expr[V, R, P]],
+    capture: CaptureP[V, R, P],
+  ) extends Expr[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitMultiplyOutputs(this)
   }
 
   /**

--- a/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/algebra/ExprResult.scala
@@ -54,6 +54,7 @@ object ExprResult {
     def visitFlatMapOutput[M[_], U, R](result: FlatMapOutput[V, M, U, R, P]): G[M[R]]
     def visitGroupOutput[M[_] : Foldable, U : Order, K](result: GroupOutput[V, M, U, K, P]): G[MapView[K, Seq[U]]]
     def visitMapOutput[M[_], U, R](result: MapOutput[V, M, U, R, P]): G[M[R]]
+    def visitMultiplyOutputs[R](result: MultiplyOutputs[V, R, P]): G[R]
     def visitNegativeOutput[R](result: NegativeOutput[V, R, P]): G[R]
     def visitNot[R](result: Not[V, R, P]): G[R]
     def visitOr[R](result: Or[V, R, P]): G[R]
@@ -290,6 +291,14 @@ object ExprResult {
     subResultList: List[ExprResult[V, R, P]],
   ) extends ExprResult[V, R, P] {
     override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitSubtractOutputs(this)
+  }
+
+  final case class MultiplyOutputs[V, R, P](
+    expr: Expr.MultiplyOutputs[V, R, P],
+    context: Context[V, R, P],
+    subResultList: List[ExprResult[V, R, P]],
+  ) extends ExprResult[V, R, P] {
+    override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitMultiplyOutputs(this)
   }
 
   final case class DivideOutputs[V, R, P](

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprBuilder.scala
@@ -4,9 +4,7 @@ import cats._
 import com.rallyhealth.vapors.core.algebra.{CaptureP, Expr, ExprSorter}
 import com.rallyhealth.vapors.core.data.{Evidence, TypedFact, Window}
 import com.rallyhealth.vapors.core.lens.NamedLens
-import com.rallyhealth.vapors.core.math.{Addition, Division, Negative, Subtraction}
-import shapeless.{::, HNil}
-import com.rallyhealth.vapors.core.math.{Addition, Negative, Subtraction}
+import com.rallyhealth.vapors.core.math._
 
 import scala.collection.{Factory, MapView, View}
 import scala.reflect.runtime.universe.TypeTag
@@ -110,6 +108,17 @@ final class SubtractBuilderOps[R : Subtraction](number: R) {
     captureResult: builder.CaptureResult[R],
   ): ValExprBuilder[V, R, P] = {
     builder.subtractFrom(number)
+  }
+}
+
+final class MultiplicationBuilderOps[R : Multiplication](number: R) {
+
+  def *[V, P](
+    builder: ValExprBuilder[V, R, P],
+  )(implicit
+    captureResult: builder.CaptureResult[R],
+  ): ValExprBuilder[V, R, P] = {
+    builder.multiply(number)
   }
 }
 
@@ -384,6 +393,46 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
     captureResult: CaptureResult[R],
   ): ValExprBuilder[V, R, P] =
     new ValExprBuilder(ExprDsl.add(Expr.ConstOutput(lhs, Evidence.none, captureResult), returnOutput))
+
+  def *(
+    rhs: Expr[V, R, P],
+  )(implicit
+    R: Multiplication[R],
+    captureResult: CaptureResult[R],
+  ): ValExprBuilder[V, R, P] =
+    new ValExprBuilder(ExprDsl.multiply(returnOutput, rhs))
+
+  def *(
+    rhs: R,
+  )(implicit
+    R: Multiplication[R],
+    captureResult: CaptureResult[R],
+  ): ValExprBuilder[V, R, P] =
+    new ValExprBuilder(ExprDsl.multiply(returnOutput, Expr.ConstOutput(rhs, Evidence.none, captureResult)))
+
+  def multiply(
+    rhs: Expr[V, R, P],
+  )(implicit
+    R: Multiplication[R],
+    captureResult: CaptureResult[R],
+  ): ValExprBuilder[V, R, P] =
+    this * rhs
+
+  def multiply(
+    rhs: R,
+  )(implicit
+    R: Multiplication[R],
+    captureResult: CaptureResult[R],
+  ): ValExprBuilder[V, R, P] =
+    this * rhs
+
+  def multiplyTo(
+    lhs: R,
+  )(implicit
+    R: Multiplication[R],
+    captureResult: CaptureResult[R],
+  ): ValExprBuilder[V, R, P] =
+    new ValExprBuilder(ExprDsl.multiply(Expr.ConstOutput(lhs, Evidence.none, captureResult), returnOutput))
 
   def subtract(
     rhs: R,

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprBuilder.scala
@@ -458,13 +458,13 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, R, P] =
     new ValExprBuilder(ExprDsl.subtract(Expr.ConstOutput(lhs, Evidence.none, captureResult), returnOutput))
 
-  def divide(
-    rhs: R,
+  def /(
+    rhs: Expr[V, R, P],
   )(implicit
     R: Division[R],
     captureResult: CaptureResult[R],
   ): ValExprBuilder[V, R, P] =
-    this / rhs
+    new ValExprBuilder(ExprDsl.divide(returnOutput, rhs))
 
   def /(
     rhs: R,
@@ -473,6 +473,22 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
     captureResult: CaptureResult[R],
   ): ValExprBuilder[V, R, P] =
     new ValExprBuilder(ExprDsl.divide(returnOutput, Expr.ConstOutput(rhs, Evidence.none, captureResult)))
+
+  def divide(
+    rhs: Expr[V, R, P],
+  )(implicit
+    R: Division[R],
+    captureResult: CaptureResult[R],
+  ): ValExprBuilder[V, R, P] =
+    this / rhs
+
+  def divide(
+    rhs: R,
+  )(implicit
+    R: Division[R],
+    captureResult: CaptureResult[R],
+  ): ValExprBuilder[V, R, P] =
+    this / rhs
 
   def divideFrom(
     lhs: R,

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprDsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprDsl.scala
@@ -1,14 +1,14 @@
 package com.rallyhealth.vapors.core.dsl
 
 import cats.data.NonEmptyList
-import cats.{Foldable, Id, Monoid}
-import com.rallyhealth.vapors.core.algebra.{CaptureP, ConditionBranch, Expr, ExprResult}
+import cats.{Foldable, Monoid}
+import com.rallyhealth.vapors.core.algebra.{CaptureP, Expr, ExprResult}
 import com.rallyhealth.vapors.core.data._
 import com.rallyhealth.vapors.core.dsl
 import com.rallyhealth.vapors.core.interpreter.{ExprInput, InterpretExprAsResultFn}
 import com.rallyhealth.vapors.core.lens.NamedLens
 import com.rallyhealth.vapors.core.logic.{Conjunction, Disjunction, Negation}
-import com.rallyhealth.vapors.core.math.{Addition, Division, Negative, Subtraction}
+import com.rallyhealth.vapors.core.math._
 
 object ExprDsl extends ExprDsl {
 
@@ -180,6 +180,14 @@ trait ExprDsl extends TimeFunctions with WrapExprSyntax with WrapEachExprSyntax 
     capture: CaptureP[V, R, P],
   ): Expr.AddOutputs[V, R, P] =
     Expr.AddOutputs(NonEmptyList.of(lhs, rhs), capture)
+
+  def multiply[V, R : Multiplication, P](
+    lhs: Expr[V, R, P],
+    rhs: Expr[V, R, P],
+  )(implicit
+    capture: CaptureP[V, R, P],
+  ): Expr.MultiplyOutputs[V, R, P] =
+    Expr.MultiplyOutputs(NonEmptyList.of(lhs, rhs), capture)
 
   def subtract[V, R : Subtraction, P](
     lhs: Expr[V, R, P],

--- a/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/VisitGenericExprWithProxyFn.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/interpreter/VisitGenericExprWithProxyFn.scala
@@ -1,11 +1,11 @@
 package com.rallyhealth.vapors.core.interpreter
 
-import cats.kernel.Monoid
 import cats._
+import cats.kernel.Monoid
 import com.rallyhealth.vapors.core.algebra.Expr
 import com.rallyhealth.vapors.core.data.{ExtractBoolean, FactSet}
 import com.rallyhealth.vapors.core.logic.{Conjunction, Disjunction, Negation}
-import com.rallyhealth.vapors.core.math.{Addition, Division, Negative, Subtraction}
+import com.rallyhealth.vapors.core.math._
 import shapeless.HList
 
 import scala.collection.MapView
@@ -73,6 +73,9 @@ abstract class VisitGenericExprWithProxyFn[V, P, G[_]] extends Expr.Visitor[V, P
   override def visitMapOutput[M[_] : Foldable : Functor, U, R](
     expr: Expr.MapOutput[V, M, U, R, P],
   ): ExprInput[V] => G[M[R]] = visitGeneric(expr, _)
+
+  override def visitMultiplyOutputs[R : Multiplication](expr: Expr.MultiplyOutputs[V, R, P]): ExprInput[V] => G[R] =
+    visitGeneric(expr, _)
 
   override def visitNegativeOutput[R : Negative](expr: Expr.NegativeOutput[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)

--- a/core/src/main/scala/com/rallyhealth/vapors/core/math/Multiplication.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/math/Multiplication.scala
@@ -1,0 +1,16 @@
+package com.rallyhealth.vapors.core.math
+
+/**
+  * Defines multiplication for a specific type.
+  */
+trait Multiplication[A] {
+
+  def multiply(
+    lhs: A,
+    rhs: A,
+  ): A
+}
+
+object Multiplication extends NumericalImplicits {
+  def apply[A](implicit A: Multiplication[A]): Multiplication[A] = A
+}

--- a/core/src/main/scala/com/rallyhealth/vapors/core/math/NumericalImplicits.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/math/NumericalImplicits.scala
@@ -9,7 +9,14 @@ private[math] trait NumericalImplicits {
   implicit def fractional[A : Fractional]: FromFractional[A] = new FromFractional[A]
 }
 
-abstract class FromNumeric[A : Numeric] extends Addition[A] with Subtraction[A] with Negative[A] {
+/**
+  * Defines all arithmetic type-classes from Scala's [[Numeric]] definition.
+  */
+abstract class FromNumeric[A : Numeric]
+  extends Addition[A]
+  with Subtraction[A]
+  with Negative[A]
+  with Multiplication[A] {
   import Numeric.Implicits._
 
   override def add(
@@ -23,6 +30,11 @@ abstract class FromNumeric[A : Numeric] extends Addition[A] with Subtraction[A] 
   ): A = lhs - rhs
 
   override def negative(value: A): A = -value
+
+  override def multiply(
+    lhs: A,
+    rhs: A,
+  ): A = lhs * rhs
 }
 
 /**

--- a/core/src/main/scala/com/rallyhealth/vapors/core/syntax/MathSyntax.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/syntax/MathSyntax.scala
@@ -1,6 +1,6 @@
 package com.rallyhealth.vapors.core.syntax
 
-import com.rallyhealth.vapors.core.math.{Addition, Division, Negative, Subtraction}
+import com.rallyhealth.vapors.core.math._
 
 trait MathSyntax {
 
@@ -14,6 +14,8 @@ final class MathOps[A](private val lhs: A) extends AnyVal {
   def -(rhs: A)(implicit A: Subtraction[A]): A = A.subtract(lhs, rhs)
 
   def unary_-(implicit A: Negative[A]): A = A.negative(lhs)
+
+  def *(rhs: A)(implicit A: Multiplication[A]): A = A.multiply(lhs, rhs)
 
   def /(rhs: A)(implicit A: Division[A]): A = A.quot(lhs, rhs)
 }

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/DivideOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/DivideOutputSpec.scala
@@ -5,83 +5,125 @@ import com.rallyhealth.vapors.core.data.FactTable
 import com.rallyhealth.vapors.core.dsl
 import com.rallyhealth.vapors.core.dsl._
 import com.rallyhealth.vapors.core.example.FactTypes
-import com.rallyhealth.vapors.core.math.Division
-import org.scalatest.matchers.should.Matchers._
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class DivideOutputSpec extends AnyWordSpec {
+class DivideOutputSpec extends AnyFreeSpec {
 
-  s"${classOf[Division[Int]].getSimpleName}[Int]" should {
+  "Expr.DivideOutput" - {
 
-    lazy val humanAgeFromDogYears: Expr.WithFactsOfType[Int, Seq[Int], Unit] = {
-      withFactsOfType(FactTypes.Age).where { facts =>
-        facts.map { fact =>
-          fact.get(_.select(_.value)) / 7
+    "Int" - {
+
+      "expression divided by an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          _ / _,
+          const(_) / const(_),
+        )
+      }
+
+      "expression divided by a value" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          _ / _,
+          const(_) / _,
+        )
+      }
+
+      "value divided from an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          (a, b) => b / a,
+          const(_).divideFrom(_),
+        )
+      }
+
+      lazy val humanAgeFromDogYears: Expr.WithFactsOfType[Int, Seq[Int], Unit] = {
+        withFactsOfType(FactTypes.Age).where { facts =>
+          facts.map { fact =>
+            fact.get(_.select(_.value)) / 7
+          }
         }
+      }
+
+      "48 dog years is 6 human years" in {
+        val result = eval(FactTable(FactTypes.Age(48))) {
+          humanAgeFromDogYears.withOutputFoldable.exists {
+            _ === 6
+          }
+        }
+        assert(result.output.value)
+      }
+
+      "49 dog years is 7 human years" in {
+        val result = eval(FactTable(FactTypes.Age(49))) {
+          humanAgeFromDogYears.withOutputFoldable.exists {
+            _ === 7
+          }
+        }
+        assert(result.output.value)
+      }
+
+      "50 dog years is 7 human years" in {
+        val result = eval(FactTable(FactTypes.Age(50))) {
+          humanAgeFromDogYears.withOutputFoldable.exists {
+            _ === 7
+          }
+        }
+        assert(result.output.value)
       }
     }
 
-    "How old is 48 dog years in Human years" in {
-      val result = eval(FactTable(FactTypes.Age(48))) {
-        humanAgeFromDogYears.withOutputFoldable.exists {
-          _ === 6
+    "Double" - {
+
+      "expression divided by an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+          _ / _,
+          const(_) / const(_),
+        )
+      }
+
+      "expression divided by a value" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+          _ / _,
+          const(_) / _,
+        )
+      }
+
+      "value divided from an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+          (a, b) => b / a,
+          const(_).divideFrom(_),
+        )
+      }
+
+      lazy val celciusFromFahrenheit: Expr.WithFactsOfType[Double, Seq[Double], Unit] = {
+        withFactsOfType(FactTypes.TempFahrenheit).where { facts =>
+          facts.map { fact =>
+            (fact.get(_.select(_.value)) - 32.0) / 1.8
+          }
         }
       }
-      assert(result.output.value)
-    }
 
-    "How old is 49 dog years in Human years" in {
-      val result = eval(FactTable(FactTypes.Age(49))) {
-        humanAgeFromDogYears.withOutputFoldable.exists {
-          _ === 7
+      "is 32F === 0C (shorter form)" in {
+        val result = eval(FactTable(FactTypes.TempFahrenheit(32.0))) {
+          celciusFromFahrenheit.withOutputFoldable.exists { v =>
+            // TODO Support tolerance here
+            // === 0.0 works here, too
+            val matchVal = 0.0
+            dsl.not(and(v > matchVal, v < matchVal))
+          }
         }
+        assert(result.output.value)
       }
-      assert(result.output.value)
-    }
 
-    "How old is 50 dog years in Human years" in {
-      val result = eval(FactTable(FactTypes.Age(50))) {
-        humanAgeFromDogYears.withOutputFoldable.exists {
-          _ === 7
+      "is 50F === 10C (shorter form)" in {
+        val result = eval(FactTable(FactTypes.TempFahrenheit(50.0))) {
+          celciusFromFahrenheit.withOutputFoldable.exists { v =>
+            // TODO support tolerance here
+            // === 10.0 works here, too
+            val matchVal = 10.0
+            dsl.not(and(v > matchVal, v < matchVal))
+          }
         }
-      }
-      assert(result.output.value)
-    }
-  }
-
-  s"${classOf[Division[Double]].getSimpleName}[Double]" should {
-
-    lazy val celciusFromFahrenheit: Expr.WithFactsOfType[Double, Seq[Double], Unit] = {
-      withFactsOfType(FactTypes.TempFahrenheit).where { facts =>
-        facts.map { fact =>
-          (fact.get(_.select(_.value)) - 32.0) / 1.8
-        }
+        assert(result.output.value)
       }
     }
-
-    "is 32F === 0C (shorter form)" in {
-      val result = eval(FactTable(FactTypes.TempFahrenheit(32.0))) {
-        celciusFromFahrenheit.withOutputFoldable.exists { v =>
-          // TODO Support tolerance here
-          // === 0.0 works here, too
-          val matchVal = 0.0
-          dsl.not(and(v > matchVal, v < matchVal))
-        }
-      }
-      assert(result.output.value)
-    }
-
-    "is 50F === 10C (shorter form)" in {
-      val result = eval(FactTable(FactTypes.TempFahrenheit(50.0))) {
-        celciusFromFahrenheit.withOutputFoldable.exists { v =>
-          // TODO support tolerance here
-          // === 10.0 works here, too
-          val matchVal = 10.0
-          dsl.not(and(v > matchVal, v < matchVal))
-        }
-      }
-      assert(result.output.value)
-    }
-
   }
 }

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/MultiplyOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/MultiplyOutputSpec.scala
@@ -1,0 +1,58 @@
+package com.rallyhealth.vapors.core.interpreter
+
+import com.rallyhealth.vapors.core.dsl._
+import org.scalatest.freespec.AnyFreeSpec
+
+class MultiplyOutputSpec extends AnyFreeSpec {
+
+  "Expr.MultiplyOutput" - {
+
+    "Int" - {
+
+      "expression multiplied by an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          _ * _,
+          const(_) * const(_),
+        )
+      }
+
+      "expression multiplied by a value" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          _ * _,
+          const(_) * _,
+        )
+      }
+
+      "value multiplied to an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          _ * _,
+          const(_).multiplyTo(_),
+        )
+      }
+    }
+
+    "Double" - {
+
+      "expression multiplied by an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+          _ * _,
+          const(_) * const(_),
+        )
+      }
+
+      "expression multiplied by a value" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          _ * _,
+          const(_) * _,
+        )
+      }
+
+      "value multiplied to an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          _ * _,
+          const(_).multiplyTo(_),
+        )
+      }
+    }
+  }
+}

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/TimeFunctionsSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/TimeFunctionsSpec.scala
@@ -1,57 +1,27 @@
 package com.rallyhealth.vapors.core.interpreter
 
-import com.rallyhealth.vapors.core.algebra.Expr
 import com.rallyhealth.vapors.core.data.FactTable
 import com.rallyhealth.vapors.core.dsl._
 import com.rallyhealth.vapors.core.example.{FactTypes, Snippets}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.ops._
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.Assertion
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks._
 
-import java.time.temporal.{ChronoUnit, Temporal, TemporalAmount}
 import java.time._
-import scala.util.Try
+import java.time.temporal.ChronoUnit
 
 class TimeFunctionsSpec extends AnyFreeSpec {
   import TimeFunctionsSpec._
-
-  private def testProducesTheSameResult[T <: Temporal : Arbitrary, D <: TemporalAmount : Arbitrary](
-    evaluateDirectly: (T, D) => T,
-    buildQuery: (RootExpr[T, Unit], RootExpr[D, Unit]) => RootExpr[T, Unit],
-  ): Assertion = {
-    forAll { (temporal: T, amount: D) =>
-      val query = buildQuery(const(temporal), const(amount))
-      Try(evaluateDirectly(temporal, amount)).fold(
-        expectedErr => {
-          val err = intercept[DateTimeException] {
-            eval(FactTable.empty)(query)
-          }
-          assertResult(expectedErr.getMessage) {
-            err.getMessage
-          }
-        },
-        expectedValue => {
-          val result = eval(FactTable.empty)(query)
-          assertResult(expectedValue) {
-            result.output.value
-          }
-        },
-      )
-    }
-  }
 
   "dateAdd" - {
 
     "Instant with" - {
 
       "Duration works the same as .plus" in {
-        testProducesTheSameResult[Instant, Duration](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Instant, Duration, Instant, DateTimeException](
           _.plus(_),
-          dateAdd(_, _),
+          (t, d) => dateAdd(const(t), const(d)),
         )
       }
 
@@ -81,9 +51,9 @@ class TimeFunctionsSpec extends AnyFreeSpec {
       }
 
       "Period works the same as .plus" in {
-        testProducesTheSameResult[LocalDate, Period](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[LocalDate, Period, LocalDate, DateTimeException](
           _.plus(_),
-          dateAdd(_, _),
+          (t, d) => dateAdd(const(t), const(d)),
         )
       }
     }
@@ -91,34 +61,38 @@ class TimeFunctionsSpec extends AnyFreeSpec {
     "LocalDateTime with" - {
 
       "Duration works the same as .plus" in {
-        testProducesTheSameResult[LocalDateTime, Duration](
-          _.plus(_),
-          dateAdd(_, _),
-        )
+        VaporsEvalTestHelpers
+          .producesTheSameResultOrException[LocalDateTime, Duration, LocalDateTime, DateTimeException](
+            _.plus(_),
+            (t, d) => dateAdd(const(t), const(d)),
+          )
       }
 
       "Period works the same as .plus" in {
-        testProducesTheSameResult[LocalDateTime, Period](
-          _.plus(_),
-          dateAdd(_, _),
-        )
+        VaporsEvalTestHelpers
+          .producesTheSameResultOrException[LocalDateTime, Period, LocalDateTime, DateTimeException](
+            _.plus(_),
+            (t, d) => dateAdd(const(t), const(d)),
+          )
       }
     }
 
     "ZonedDateTime with" - {
 
       "Duration works the same as .plus" in {
-        testProducesTheSameResult[ZonedDateTime, Duration](
-          _.plus(_),
-          dateAdd(_, _),
-        )
+        VaporsEvalTestHelpers
+          .producesTheSameResultOrException[ZonedDateTime, Duration, ZonedDateTime, DateTimeException](
+            _.plus(_),
+            (t, d) => dateAdd(const(t), const(d)),
+          )
       }
 
       "Period works the same as .plus" in {
-        testProducesTheSameResult[ZonedDateTime, Period](
-          _.plus(_),
-          dateAdd(_, _),
-        )
+        VaporsEvalTestHelpers
+          .producesTheSameResultOrException[ZonedDateTime, Period, ZonedDateTime, DateTimeException](
+            _.plus(_),
+            (t, d) => dateAdd(const(t), const(d)),
+          )
       }
     }
   }

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/VaporsEvalTestHelpers.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/VaporsEvalTestHelpers.scala
@@ -1,0 +1,104 @@
+package com.rallyhealth.vapors.core.interpreter
+
+import com.rallyhealth.vapors.core.data.FactTable
+import com.rallyhealth.vapors.core.dsl.{eval, RootExpr}
+import org.scalacheck.Arbitrary
+import org.scalactic.Tolerance._
+import org.scalactic.TripleEqualsSupport._
+import org.scalactic.source.Position
+import org.scalatest.Assertion
+import org.scalatest.Assertions._
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks._
+
+import scala.Fractional.Implicits._
+import scala.reflect.ClassTag
+import scala.util.Try
+
+object VaporsEvalTestHelpers {
+
+  trait CompareEquality[E, A] {
+
+    def assertEqual(
+      expected: E,
+      actual: A,
+    )(implicit
+      pos: Position,
+    ): Assertion
+  }
+
+  object CompareEquality extends LowPriorityDefaultTolerance {
+
+    def apply[E, A](build: Position => (E, A) => Assertion): CompareEquality[E, A] = new CompareEquality[E, A] {
+      override def assertEqual(
+        expected: E,
+        actual: A,
+      )(implicit
+        pos: Position,
+      ): Assertion = build(pos)(expected, actual)
+    }
+
+    implicit def tolerantFractional[A : Fractional : DefaultTolerance]: CompareEquality[A, A] = CompareEquality {
+      implicit pos => (expected, actual) =>
+        assert(DefaultTolerance[A].toSpread(expected) === actual)
+    }
+
+    implicit def tolerantIntegral[A : Integral : DefaultTolerance]: CompareEquality[A, A] = CompareEquality {
+      implicit pos => (expected, actual) =>
+        assert(DefaultTolerance[A].toSpread(expected) === actual)
+    }
+  }
+
+  trait LowPriorityDefaultTolerance {
+
+    implicit def zeroToleranceIntegral[A : Integral]: CompareEquality[A, A] = CompareEquality {
+      implicit pos => (expected, actual) =>
+        assert(expected == actual)
+    }
+  }
+
+  trait DefaultTolerance[A] {
+    def toSpread(value: A): Spread[A]
+  }
+
+  object DefaultTolerance {
+
+    @inline def apply[A : DefaultTolerance]: DefaultTolerance[A] = implicitly
+
+    implicit def onePercentFractionalTolerance[A : Fractional]: DefaultTolerance[A] = {
+      val F = Fractional[A]
+      val onePercent = F.one / F.fromInt(100)
+      value => {
+        val onePercentOfValue = value * onePercent
+        value +- onePercentOfValue
+      }
+    }
+  }
+
+  def producesTheSameResultOrException[A : Arbitrary, B : Arbitrary, R, E <: Throwable : ClassTag](
+    evaluate: (A, B) => R,
+    buildExpr: (A, B) => RootExpr[R, Unit],
+  ): Assertion = {
+    forAll { (a: A, b: B) =>
+      val query = buildExpr(a, b)
+      Try(evaluate(a, b)).fold(
+        {
+          case expectedExc: E =>
+            val exc = intercept[E] {
+              eval(FactTable.empty)(query)
+            }
+            assertResult(expectedExc.getMessage) {
+              exc.getMessage
+            }
+          case unexpected =>
+            fail("Unexpected exception", unexpected)
+        },
+        expectedValue => {
+          val result = eval(FactTable.empty)(query)
+          assertResult(expectedValue) {
+            result.output.value
+          }
+        },
+      )
+    }
+  }
+}


### PR DESCRIPTION
- Add Expr.MultiplyOutputs operator and builder methods
- Add VaporsEvalTestHelpers.producesTheSameResultOrException for testing with scalacheck
- Updated Expr.DivideOutputs to use the same builder patterns and unit testing methods as multiplication