### PR TITLE
Cleanup arithmetic operators, add unit tests, remove deprecated method

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprBuilder.scala
@@ -22,12 +22,6 @@ sealed class ExprBuilder[V, M[_], U, P](val returnOutput: Expr[V, M[U], P]) {
 
   def returnInput(implicit captureResult: CaptureResult[V]): Expr[V, V, P] = Expr.ReturnInput(captureResult)
 
-  @deprecated(
-    "Use embedExpr, embedConst, or embedFoldableConst. This does not work properly and will be removed",
-    "0.13.2",
-  )
-  def embed[R](expr: Expr[M[U], R, P]): ExprBuilder[M[U], Id, R, P] = new ExprBuilder[M[U], Id, R, P](expr)
-
   /**
     * Embed the result of an expression with the input of the current builder.
     */

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprBuilder.scala
@@ -118,7 +118,7 @@ final class MultiplicationBuilderOps[R : Multiplication](number: R) {
   )(implicit
     captureResult: builder.CaptureResult[R],
   ): ValExprBuilder[V, R, P] = {
-    builder.multiply(number)
+    builder.multiplyTo(number)
   }
 }
 
@@ -370,13 +370,13 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   def in(accepted: Set[R])(implicit captureCond: CaptureCondResult): ValExprBuilder[V, Boolean, P] =
     new ValExprBuilder(Expr.OutputWithinSet(returnOutput, accepted, captureCond))
 
-  def add(
-    rhs: R,
+  def +(
+    rhs: Expr[V, R, P],
   )(implicit
     R: Addition[R],
     captureResult: CaptureResult[R],
   ): ValExprBuilder[V, R, P] =
-    this + rhs
+    new ValExprBuilder(ExprDsl.add(returnOutput, rhs))
 
   def +(
     rhs: R,
@@ -410,22 +410,6 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, R, P] =
     new ValExprBuilder(ExprDsl.multiply(returnOutput, Expr.ConstOutput(rhs, Evidence.none, captureResult)))
 
-  def multiply(
-    rhs: Expr[V, R, P],
-  )(implicit
-    R: Multiplication[R],
-    captureResult: CaptureResult[R],
-  ): ValExprBuilder[V, R, P] =
-    this * rhs
-
-  def multiply(
-    rhs: R,
-  )(implicit
-    R: Multiplication[R],
-    captureResult: CaptureResult[R],
-  ): ValExprBuilder[V, R, P] =
-    this * rhs
-
   def multiplyTo(
     lhs: R,
   )(implicit
@@ -434,13 +418,13 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, R, P] =
     new ValExprBuilder(ExprDsl.multiply(Expr.ConstOutput(lhs, Evidence.none, captureResult), returnOutput))
 
-  def subtract(
-    rhs: R,
+  def -(
+    rhs: Expr[V, R, P],
   )(implicit
     R: Subtraction[R],
     captureResult: CaptureResult[R],
   ): ValExprBuilder[V, R, P] =
-    this - rhs
+    new ValExprBuilder(ExprDsl.subtract(returnOutput, rhs))
 
   def -(
     rhs: R,
@@ -473,22 +457,6 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
     captureResult: CaptureResult[R],
   ): ValExprBuilder[V, R, P] =
     new ValExprBuilder(ExprDsl.divide(returnOutput, Expr.ConstOutput(rhs, Evidence.none, captureResult)))
-
-  def divide(
-    rhs: Expr[V, R, P],
-  )(implicit
-    R: Division[R],
-    captureResult: CaptureResult[R],
-  ): ValExprBuilder[V, R, P] =
-    this / rhs
-
-  def divide(
-    rhs: R,
-  )(implicit
-    R: Division[R],
-    captureResult: CaptureResult[R],
-  ): ValExprBuilder[V, R, P] =
-    this / rhs
 
   def divideFrom(
     lhs: R,

--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WrapExprSyntax.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/WrapExprSyntax.scala
@@ -6,6 +6,9 @@ import shapeless.{::, Generic, HList, HNil}
 
 trait WrapExprSyntax {
 
+  def wrap[V, E1, P](e1: Expr[V, E1, P]): ExprHListWrapper[V, E1 :: HNil, P] =
+    new ExprHListWrapper(NonEmptyExprHList.tail(e1))
+
   def wrap[V, E1, E2, P](
     e1: Expr[V, E1, P],
     e2: Expr[V, E2, P],

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/AddOutputsSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/AddOutputsSpec.scala
@@ -1,0 +1,58 @@
+package com.rallyhealth.vapors.core.interpreter
+
+import com.rallyhealth.vapors.core.dsl._
+import org.scalatest.freespec.AnyFreeSpec
+
+class AddOutputsSpec extends AnyFreeSpec {
+
+  "Expr.AddOutputs" - {
+
+    "Int" - {
+
+      "expression added to an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          _ + _,
+          const(_) + const(_),
+        )
+      }
+
+      "value added to an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          _ + _,
+          const(_) + _,
+        )
+      }
+
+      "expression added to a value" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          _ + _,
+          const(_).addTo(_),
+        )
+      }
+    }
+
+    "Double" - {
+
+      "expression added to an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+          _ + _,
+          const(_) + const(_),
+        )
+      }
+
+      "value added to an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+          _ + _,
+          const(_) + _,
+        )
+      }
+
+      "expression added to a value" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+          _ + _,
+          const(_).addTo(_),
+        )
+      }
+    }
+  }
+}

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/DivideOutputsSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/DivideOutputsSpec.scala
@@ -7,9 +7,9 @@ import com.rallyhealth.vapors.core.dsl._
 import com.rallyhealth.vapors.core.example.FactTypes
 import org.scalatest.freespec.AnyFreeSpec
 
-class DivideOutputSpec extends AnyFreeSpec {
+class DivideOutputsSpec extends AnyFreeSpec {
 
-  "Expr.DivideOutput" - {
+  "Expr.DivideOutputs" - {
 
     "Int" - {
 

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/EmbedExprSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/EmbedExprSpec.scala
@@ -18,8 +18,8 @@ class EmbedExprSpec extends AnyWordSpec {
               _.select(_.value).select(_.scores).atKey("weightloss").to(List)
             }
           }
-          .exists {
-            _.embed(cond)
+          .exists { _ =>
+            cond
           }
       }
     }

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/MultiplyOutputsSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/MultiplyOutputsSpec.scala
@@ -3,9 +3,9 @@ package com.rallyhealth.vapors.core.interpreter
 import com.rallyhealth.vapors.core.dsl._
 import org.scalatest.freespec.AnyFreeSpec
 
-class MultiplyOutputSpec extends AnyFreeSpec {
+class MultiplyOutputsSpec extends AnyFreeSpec {
 
-  "Expr.MultiplyOutput" - {
+  "Expr.MultiplyOutputs" - {
 
     "Int" - {
 

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/SubtractOutputsSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/SubtractOutputsSpec.scala
@@ -1,0 +1,58 @@
+package com.rallyhealth.vapors.core.interpreter
+
+import com.rallyhealth.vapors.core.dsl._
+import org.scalatest.freespec.AnyFreeSpec
+
+class SubtractOutputsSpec extends AnyFreeSpec {
+
+  "Expr.SubtractOutputs" - {
+
+    "Int" - {
+
+      "expression subtracted by an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          _ - _,
+          const(_) - const(_),
+        )
+      }
+
+      "expression subtracted by a value" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          _ - _,
+          const(_) - _,
+        )
+      }
+
+      "value subtracted by an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+          (a, b) => b - a,
+          const(_).subtractFrom(_),
+        )
+      }
+    }
+
+    "Double" - {
+
+      "expression subtracted by an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+          _ - _,
+          const(_) - const(_),
+        )
+      }
+
+      "expression subtracted by a value" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+          _ - _,
+          const(_) - _,
+        )
+      }
+
+      "value subtracted by an expression" in {
+        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+          (a, b) => b - a,
+          const(_).subtractFrom(_),
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is some cleanup to make the interface more uniform for math operators

- Removes deprecated `embed` method
- Adds unit tests for addition and subtraction
- Adds support for single argument `wrap` method (for wrapping a single value with a class)