### PR TITLE
Deprecate withFactsOfType

### DIFF
--- a/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprDsl.scala
+++ b/core/src/main/scala/com/rallyhealth/vapors/core/dsl/ExprDsl.scala
@@ -150,6 +150,7 @@ trait ExprDsl extends TimeFunctions with WrapExprSyntax with WrapEachExprSyntax 
     captureResult: CaptureP[V, Seq[R], P],
   ): Expr.WrapOutputSeq[V, R, P] = sequence(expressions)
 
+  @deprecated("Use factsOfType() instead", "0.14.0")
   def withFactsOfType[T, P](
     factTypeSet: FactTypeSet[T],
   )(implicit

--- a/core/src/test/scala/com/rallyhealth/vapors/core/algebra/CapturePSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/algebra/CapturePSpec.scala
@@ -15,10 +15,8 @@ class CapturePSpec extends AnyWordSpec with TypeCheckedTripleEquals {
       import com.rallyhealth.vapors.core.example.CaptureTimeRange._
 
       "find a single fact from a query" in {
-        val q = withFactsOfType(FactTypes.WeightMeasurement).where {
-          _.exists {
-            _.get(_.select(_.value).select(_.value)) > 18
-          }
+        val q = factsOfType(FactTypes.WeightMeasurement).exists {
+          _.get(_.select(_.value).select(_.value)) > 18
         }
         val result = eval(JoeSchmoe.factTable)(q)
         assert(result.param.value === TimeRange(JoeSchmoe.weight.value.timestamp))

--- a/core/src/test/scala/com/rallyhealth/vapors/core/dsl/ExprBuilderSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/dsl/ExprBuilderSpec.scala
@@ -14,13 +14,11 @@ class ExprBuilderSpec extends AnyWordSpec {
   "ValExprBuilder" should {
 
     "combine lenses from chained .get() methods" in {
-      val q = withFactsOfType(FactTypes.GenericMeasurement).where {
-        _.exists {
-          _.get(_.select(_.value)).get(_.select(_.value)) > 0.0
-        }
-      }
+      val q = factsOfType(FactTypes.GenericMeasurement).exists {
+        _.get(_.select(_.value)).get(_.select(_.value)) > 0.0
+      }.returnOutput
       inside(q) {
-        case Expr.WithFactsOfType(_, Expr.ExistsInOutput(_, condExpr, _), _) =>
+        case Expr.ExistsInOutput(_, condExpr, _) =>
           inside(condExpr) {
             case Expr.OutputWithinWindow(Expr.SelectFromOutput(_, valueLens, _), _, _) =>
               assertResult(DataPath.empty.atField("value").atField("value")) {
@@ -35,13 +33,11 @@ class ExprBuilderSpec extends AnyWordSpec {
     }
 
     "combine lenses from .get() and .getFoldable() methods" in {
-      val q = withFactsOfType(FactTypes.ProbabilityToUse).where {
-        _.exists {
-          _.get(_.select(_.value)).getFoldable(_.select(_.scores)).isEmpty
-        }
-      }
+      val q = factsOfType(FactTypes.ProbabilityToUse).exists {
+        _.get(_.select(_.value)).getFoldable(_.select(_.scores)).isEmpty
+      }.returnOutput
       inside(q) {
-        case Expr.WithFactsOfType(_, Expr.ExistsInOutput(_, condExpr, _), _) =>
+        case Expr.ExistsInOutput(_, condExpr, _) =>
           inside(condExpr) {
             case Expr.OutputIsEmpty(Expr.SelectFromOutput(_, valueLens, _), _) =>
               assertResult(DataPath.empty.atField("value").atField("scores")) {

--- a/core/src/test/scala/com/rallyhealth/vapors/core/example/Snippets.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/example/Snippets.scala
@@ -41,10 +41,8 @@ class Snippets(val clock: Clock) {
   }
 
   lazy val isUser: RootExpr[Boolean, Unit] = {
-    withFactsOfType(FactTypes.Role).where {
-      _.exists {
-        _.get(_.select(_.value)) >= Role.User
-      }
+    factsOfType(FactTypes.Role).exists {
+      _.get(_.select(_.value)) >= Role.User
     }
   }
 

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/DivideOutputsSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/DivideOutputsSpec.scala
@@ -34,11 +34,9 @@ class DivideOutputsSpec extends AnyFreeSpec {
         )
       }
 
-      lazy val humanAgeFromDogYears: Expr.WithFactsOfType[Int, Seq[Int], Unit] = {
-        withFactsOfType(FactTypes.Age).where { facts =>
-          facts.map { fact =>
-            fact.get(_.select(_.value)) / 7
-          }
+      lazy val humanAgeFromDogYears: Expr[FactTable, Seq[Int], Unit] = {
+        factsOfType(FactTypes.Age).map { fact =>
+          fact.get(_.select(_.value)) / 7
         }
       }
 
@@ -93,11 +91,9 @@ class DivideOutputsSpec extends AnyFreeSpec {
         )
       }
 
-      lazy val celciusFromFahrenheit: Expr.WithFactsOfType[Double, Seq[Double], Unit] = {
-        withFactsOfType(FactTypes.TempFahrenheit).where { facts =>
-          facts.map { fact =>
-            (fact.get(_.select(_.value)) - 32.0) / 1.8
-          }
+      lazy val celciusFromFahrenheit: Expr[FactTable, Seq[Double], Unit] = {
+        factsOfType(FactTypes.TempFahrenheit).map { fact =>
+          (fact.get(_.select(_.value)) - 32.0) / 1.8
         }
       }
 

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/EmbedExprSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/EmbedExprSpec.scala
@@ -11,26 +11,22 @@ class EmbedExprSpec extends AnyWordSpec {
   "embedding an expression inside a logical operator inside a 'withFactsOfType'" when {
 
     def insideProbOfWeightloss(cond: ValCondExpr[Double, Unit]): RootExpr[Boolean, Unit] = {
-      withFactsOfType(FactTypes.ProbabilityToUse).where {
-        _.toList
-          .flatMap {
-            _.getFoldable {
-              _.select(_.value).select(_.scores).atKey("weightloss").to(List)
-            }
+      factsOfType(FactTypes.ProbabilityToUse)
+        .flatMap {
+          _.getFoldable {
+            _.select(_.value).select(_.scores).at("weightloss").to(Seq)
           }
-          .exists { _ =>
-            cond
-          }
-      }
+        }
+        .exists { _ =>
+          cond
+        }
     }
 
     def weightMeasuredWithin(window: Window[Int]): RootExpr[Boolean, Unit] = {
       import cats.syntax.invariant._
       val doubleWindow = window.imap(_.toDouble)(_.toInt)
-      withFactsOfType(FactTypes.WeightMeasurement).where {
-        _.exists {
-          _.get(_.select(_.value).select(_.value)).within(doubleWindow)
-        }
+      factsOfType(FactTypes.WeightMeasurement).exists {
+        _.get(_.select(_.value).select(_.value)).within(doubleWindow)
       }
     }
 
@@ -107,10 +103,8 @@ class EmbedExprSpec extends AnyWordSpec {
       }
 
       "disallows embedding an invalid return type" in {
-        val listOfNumberExpr = withFactsOfType(FactTypes.ProbabilityToUse).where {
-          _.toList.flatMap {
-            _.getFoldable(_.select(_.value).select(_.scores).atKey("weightloss").to(List))
-          }
+        val listOfNumberExpr = factsOfType(FactTypes.ProbabilityToUse).flatMap {
+          _.getFoldable(_.select(_.value).select(_.scores).at("weightloss").to(Seq))
         }
         assertDoesNotCompile {
           """insideProbOfWeightloss(or(trueLiteral, listOfNumberExpr))"""
@@ -177,10 +171,8 @@ class EmbedExprSpec extends AnyWordSpec {
       }
 
       "disallows embedding an invalid return type" in {
-        val listOfNumberExpr = withFactsOfType(FactTypes.ProbabilityToUse).where {
-          _.toList.flatMap {
-            _.getFoldable(_.select(_.value).select(_.scores).atKey("weightloss").asIterable.to(List))
-          }
+        val listOfNumberExpr = factsOfType(FactTypes.ProbabilityToUse).flatMap {
+          _.getFoldable(_.select(_.value).select(_.scores).at("weightloss").asIterable.to(Seq))
         }
         assertDoesNotCompile {
           """insideProbOfWeightloss(and(trueLiteral, listOfNumberExpr))"""

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/FilterOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/FilterOutputSpec.scala
@@ -16,8 +16,8 @@ class FilterOutputSpec extends AnyWordSpec {
       "comparing facts" should {
 
         "return all matching facts from a given subset" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.filter(_ in Set(Tags.asthma))
+          val q = factsOfType(FactTypes.Tag).filter {
+            _ in Set(Tags.asthma)
           }
           val res = eval(tagFacts)(q)
           res.output.value should contain theSameElementsAs Seq(Tags.asthma)
@@ -25,8 +25,8 @@ class FilterOutputSpec extends AnyWordSpec {
         }
 
         "return all matching facts from a given superset" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.filter(_ in Set(Tags.asthma, Tags.obeseBmi))
+          val q = factsOfType(FactTypes.Tag).filter {
+            _ in Set(Tags.asthma, Tags.obeseBmi)
           }
           val res = eval(tagFacts)(q)
           res.output.value should contain theSameElementsAs Seq(Tags.asthma)
@@ -34,8 +34,8 @@ class FilterOutputSpec extends AnyWordSpec {
         }
 
         "return an empty list of facts when given a set that contains no common elements" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.filter(_ in Set(Tags.obeseBmi))
+          val q = factsOfType(FactTypes.Tag).filter {
+            _ in Set(Tags.obeseBmi)
           }
           val res = eval(tagFacts)(q)
           assert(res.output.value.isEmpty)
@@ -46,16 +46,16 @@ class FilterOutputSpec extends AnyWordSpec {
       "comparing values" should {
 
         "return all matching values from a given subset" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.map(_.value).filter(_ in Set(Tags.asthma).map(_.value))
+          val q = factsOfType(FactTypes.Tag).map(_.value).filter {
+            _ in Set(Tags.asthma).map(_.value)
           }
           val res = eval(tagFacts)(q)
           res.output.value should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
         }
 
         "return the correct evidence for the matching values from a given subset" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.map(_.value).filter(_ in Set(Tags.asthma).map(_.value))
+          val q = factsOfType(FactTypes.Tag).map(_.value).filter {
+            _ in Set(Tags.asthma).map(_.value)
           }
           val res = eval(tagFacts)(q)
           pendingUntilFixed {
@@ -65,16 +65,16 @@ class FilterOutputSpec extends AnyWordSpec {
         }
 
         "return the matching values from a given superset" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.map(_.value).filter(_ in Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+          val q = factsOfType(FactTypes.Tag).map(_.value).filter {
+            _ in Set(Tags.asthma, Tags.obeseBmi).map(_.value)
           }
           val res = eval(tagFacts)(q)
           res.output.value should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
         }
 
         "return the correct evidence for the matching values from a given superset" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.map(_.value).filter(_ in Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+          val q = factsOfType(FactTypes.Tag).map(_.value).filter {
+            _ in Set(Tags.asthma, Tags.obeseBmi).map(_.value)
           }
           val res = eval(tagFacts)(q)
           pendingUntilFixed {
@@ -84,8 +84,8 @@ class FilterOutputSpec extends AnyWordSpec {
         }
 
         "return an empty list of values when given a set that contains no common elements" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.map(_.value).filter(_ in Set(Tags.obeseBmi).map(_.value))
+          val q = factsOfType(FactTypes.Tag).map(_.value).filter {
+            _ in Set(Tags.obeseBmi).map(_.value)
           }
           val res = eval(tagFacts)(q)
           assert(res.output.value.isEmpty)
@@ -96,16 +96,16 @@ class FilterOutputSpec extends AnyWordSpec {
       "using the 'containsAny' op" should {
 
         "return 'true' when the fact table contains a superset of the given set" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.map(_.value).containsAny(Set(Tags.asthma).map(_.value))
+          val q = factsOfType(FactTypes.Tag).map(_.value).containsAny {
+            Set(Tags.asthma).map(_.value)
           }
           val res = eval(tagFacts)(q)
           assert(res.output.value)
         }
 
         "return the correct evidence for the facts that contain a superset of the given set" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.map(_.value).containsAny(Set(Tags.asthma).map(_.value))
+          val q = factsOfType(FactTypes.Tag).map(_.value).containsAny {
+            Set(Tags.asthma).map(_.value)
           }
           val res = eval(tagFacts)(q)
           pendingUntilFixed {
@@ -115,16 +115,16 @@ class FilterOutputSpec extends AnyWordSpec {
         }
 
         "return 'true' when the fact table contains a subset of the given set" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.map(_.value).containsAny(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+          val q = factsOfType(FactTypes.Tag).map(_.value).containsAny {
+            Set(Tags.asthma, Tags.obeseBmi).map(_.value)
           }
           val res = eval(tagFacts)(q)
           assert(res.output.value)
         }
 
         "return the correct evidence for the facts that contain a subset of the given set" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.map(_.value).containsAny(Set(Tags.asthma, Tags.obeseBmi).map(_.value))
+          val q = factsOfType(FactTypes.Tag).map(_.value).containsAny {
+            Set(Tags.asthma, Tags.obeseBmi).map(_.value)
           }
           val res = eval(tagFacts)(q)
           pendingUntilFixed {
@@ -134,8 +134,8 @@ class FilterOutputSpec extends AnyWordSpec {
         }
 
         "return 'false' with no Evidence when the facts do not contain anything in the given set" in {
-          val q = withFactsOfType(FactTypes.Tag).where { facts =>
-            facts.map(_.value).containsAny(Set(Tags.obeseBmi).map(_.value))
+          val q = factsOfType(FactTypes.Tag).map(_.value).containsAny {
+            Set(Tags.obeseBmi).map(_.value)
           }
           val res = eval(tagFacts)(q)
           assert(!res.output.value)
@@ -151,16 +151,16 @@ class FilterOutputSpec extends AnyWordSpec {
       val numericFacts = FactTable(low, middle, high)
 
       "return all values that match the condition" in {
-        val q = withFactsOfType(FactTypes.Age).where { facts =>
-          facts.map(_.value).filter(_ >= middle.value)
+        val q = factsOfType(FactTypes.Age).map(_.value).filter {
+          _ >= middle.value
         }
         val res = eval(numericFacts)(q)
         res.output.value should contain theSameElementsAs Seq(middle, high).map(_.value)
       }
 
       "return the correct evidence for the matching values from a given subset" in {
-        val q = withFactsOfType(FactTypes.Age).where { facts =>
-          facts.map(_.value).filter(_ >= middle.value)
+        val q = factsOfType(FactTypes.Age).map(_.value).filter {
+          _ >= middle.value
         }
         val res = eval(numericFacts)(q)
         pendingUntilFixed {
@@ -170,8 +170,8 @@ class FilterOutputSpec extends AnyWordSpec {
       }
 
       "return all facts that match the condition" in {
-        val q = withFactsOfType(FactTypes.Age).where { facts =>
-          facts.filter(_.value >= middle.value)
+        val q = factsOfType(FactTypes.Age).filter {
+          _.value >= middle.value
         }
         val res = eval(numericFacts)(q)
         res.output.value should contain theSameElementsAs Seq(middle, high)
@@ -179,8 +179,8 @@ class FilterOutputSpec extends AnyWordSpec {
       }
 
       "return an empty list of values when none of the elements meet the condition" in {
-        val q = withFactsOfType(FactTypes.Age).where { facts =>
-          facts.map(_.value).filter(_ > high.value)
+        val q = factsOfType(FactTypes.Age).map(_.value).filter {
+          _ > high.value
         }
         val res = eval(numericFacts)(q)
         assert(res.output.value.isEmpty)
@@ -188,8 +188,8 @@ class FilterOutputSpec extends AnyWordSpec {
       }
 
       "return an empty list of facts when none meet the condition" in {
-        val q = withFactsOfType(FactTypes.Age).where { facts =>
-          facts.filter(_.value > high.value)
+        val q = factsOfType(FactTypes.Age).filter {
+          _.value > high.value
         }
         val res = eval(numericFacts)(q)
         assert(res.output.value.isEmpty)

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/InterpretExprAsResultFnSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/InterpretExprAsResultFnSpec.scala
@@ -12,10 +12,8 @@ class InterpretExprAsResultFnSpec extends AnyWordSpec {
     "using no post processing" should {
 
       "find a single fact from a query" in {
-        val q = withFactsOfType(FactTypes.Age).where {
-          _.exists {
-            _.get(_.select(_.value)) >= 18
-          }
+        val q = factsOfType(FactTypes.Age).exists {
+          _.get(_.select(_.value)) >= 18
         }
         val result = eval(JoeSchmoe.factTable)(q)
         assert(result.param.value === ())
@@ -25,11 +23,9 @@ class InterpretExprAsResultFnSpec extends AnyWordSpec {
       }
 
       "find a complex fact from a query" in {
-        val q = withFactsOfType(FactTypes.ProbabilityToUse).where {
-          _.exists {
-            _.getFoldable(_.select(_.value).select(_.scores).atKey("weightloss")).exists {
-              _ > 0.5
-            }
+        val q = factsOfType(FactTypes.ProbabilityToUse).exists {
+          _.getFoldable(_.select(_.value).select(_.scores).at("weightloss")).exists {
+            _ > 0.5
           }
         }
         val result = eval(JoeSchmoe.factTable)(q)
@@ -37,11 +33,9 @@ class InterpretExprAsResultFnSpec extends AnyWordSpec {
       }
 
       "define a fact expression" in {
-        val likelyToJoinWeightloss = withFactsOfType(FactTypes.ProbabilityToUse).where {
-          _.exists {
-            _.getFoldable(_.select(_.value).select(_.scores).atKey("weightloss")).exists {
-              _ > 0.5
-            }
+        val likelyToJoinWeightloss = factsOfType(FactTypes.ProbabilityToUse).exists {
+          _.getFoldable(_.select(_.value).select(_.scores).at("weightloss")).exists {
+            _ > 0.5
           }
         }
         val result = eval(JoeSchmoe.factTable)(likelyToJoinWeightloss)

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/OutputWithinSetExprSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/OutputWithinSetExprSpec.scala
@@ -10,10 +10,8 @@ class OutputWithinSetExprSpec extends AnyWordSpec {
   "Expr.OutputWithinSet" should {
 
     "find an asthma tag in a set that contains it" in {
-      val q = withFactsOfType(FactTypes.Tag).where {
-        _.exists {
-          _.value.in(Set("asthma", "diabetes"))
-        }
+      val q = factsOfType(FactTypes.Tag).exists {
+        _.value.in(Set("asthma", "diabetes"))
       }
       val result = eval(JoeSchmoe.factTable)(q)
       assert(result.output.value)
@@ -21,10 +19,8 @@ class OutputWithinSetExprSpec extends AnyWordSpec {
     }
 
     "not find an asthma tag in a set that does not contain it" in {
-      val q = withFactsOfType(FactTypes.Tag).where {
-        _.exists {
-          _.value.in(Set("diabetes"))
-        }
+      val q = factsOfType(FactTypes.Tag).exists {
+        _.value.in(Set("diabetes"))
       }
       val result = eval(JoeSchmoe.factTable)(q)
       assert(!result.output.value)

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/SelectFromOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/SelectFromOutputSpec.scala
@@ -34,7 +34,7 @@ class SelectFromOutputSpec extends AnyFreeSpec {
     val query = factsOfType(FactTypes.TagsUpdate)
       .groupBy(_.select(_.value.source))
       .flatMap { sourceAndFacts =>
-        val facts = sourceAndFacts.getFoldable(_.atKey(Nat._1))
+        val facts = sourceAndFacts.getFoldable(_.at(Nat._1))
         val latestFactTags = facts.sorted.headOption.toSet.flatMap(_.getFoldable(_.select(_.value.tags)))
         latestFactTags.to(View)
       }

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/SortOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/SortOutputSpec.scala
@@ -27,9 +27,7 @@ class SortOutputSpec extends AnyFreeSpec {
     )
 
     "sorted using natural ordering" in {
-      val query = withFactsOfType(FactTypes.BloodPressureMeasurement).where { facts =>
-        facts.map(_.value.get(_.select(_.diastolic))).sorted
-      }
+      val query = factsOfType(FactTypes.BloodPressureMeasurement).map(_.value.get(_.select(_.diastolic))).sorted
       assertResult(Some(highDiastolic)) {
         bpFacts.getSortedSeq(FactTypes.BloodPressureMeasurement).headOption.map(_.value)
       }
@@ -40,9 +38,7 @@ class SortOutputSpec extends AnyFreeSpec {
     }
 
     "sortBy ordered field" in {
-      val query = withFactsOfType(FactTypes.BloodPressureMeasurement).where { facts =>
-        facts.map(_.value).sortBy(_.select(_.diastolic))
-      }
+      val query = factsOfType(FactTypes.BloodPressureMeasurement).map(_.value).sortBy(_.select(_.diastolic))
       assertResult(Some(highDiastolic)) {
         bpFacts.getSortedSeq(FactTypes.BloodPressureMeasurement).headOption.map(_.value)
       }

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/TakeFromOutputSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/TakeFromOutputSpec.scala
@@ -18,19 +18,19 @@ class TakeFromOutputSpec extends AnyWordSpec {
     "using .take(n) with a positive number" should {
 
       "return an empty list if the collection is empty" in {
-        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(1))
+        val q = factsOfType(FactTypes.TagsUpdate).take(1)
         val res = eval(FactTable.empty)(q)
         assert(res.output.value.isEmpty)
       }
 
       "return the number of elements selected from the start of the list by fact ordering" in {
-        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(1))
+        val q = factsOfType(FactTypes.TagsUpdate).take(1)
         val res = eval(FactTable(updateABC, updateDEF))(q)
         assertResult(Seq(updateDEF))(res.output.value)
       }
 
       "return all the elements of the list by fact ordering when the number requested is greater than the size" in {
-        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(3))
+        val q = factsOfType(FactTypes.TagsUpdate).take(3)
         val res = eval(FactTable(updateABC, updateDEF))(q)
         assertResult(Seq(updateDEF, updateABC))(res.output.value)
       }
@@ -39,19 +39,19 @@ class TakeFromOutputSpec extends AnyWordSpec {
     "using .take(n) with a negative number" should {
 
       "return an empty list if the collection is empty" in {
-        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(-1))
+        val q = factsOfType(FactTypes.TagsUpdate).take(-1)
         val res = eval(FactTable.empty)(q)
         assert(res.output.value.isEmpty)
       }
 
       "return the number of elements selected from the end of the list by fact ordering" in {
-        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(-1))
+        val q = factsOfType(FactTypes.TagsUpdate).take(-1)
         val res = eval(FactTable(updateABC, updateDEF))(q)
         assertResult(Seq(updateABC))(res.output.value)
       }
 
       "return all the elements of the list by fact ordering when the number requested is greater than the size" in {
-        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(-3))
+        val q = factsOfType(FactTypes.TagsUpdate).take(-3)
         val res = eval(FactTable(updateABC, updateDEF))(q)
         assertResult(Seq(updateDEF, updateABC))(res.output.value)
       }
@@ -60,7 +60,7 @@ class TakeFromOutputSpec extends AnyWordSpec {
     "using .take(n) with 0" should {
 
       "return an empty collection" in {
-        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.take(0))
+        val q = factsOfType(FactTypes.TagsUpdate).take(0)
         val res = eval(FactTable(updateABC, updateDEF))(q)
         assertResult(Seq.empty)(res.output.value)
       }
@@ -69,13 +69,13 @@ class TakeFromOutputSpec extends AnyWordSpec {
     "using .headOption" should {
 
       "return None if the collection is empty" in {
-        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.headOption)
+        val q = factsOfType(FactTypes.TagsUpdate).headOption
         val res = eval(FactTable.empty)(q)
         assertResult(None)(res.output.value)
       }
 
       "return the head of the collection by fact ordering" in {
-        val q = withFactsOfType(FactTypes.TagsUpdate).where(_.headOption)
+        val q = factsOfType(FactTypes.TagsUpdate).headOption
         val res = eval(FactTable(updateABC, updateDEF))(q)
         assertResult(Some(updateDEF))(res.output.value)
       }

--- a/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/UsingDefinitionsExprSpec.scala
+++ b/core/src/test/scala/com/rallyhealth/vapors/core/interpreter/UsingDefinitionsExprSpec.scala
@@ -19,7 +19,7 @@ class UsingDefinitionsExprSpec extends AnyWordSpec {
     "add the defined facts to the fact table" in {
       val result = eval(JoeSchmoe.factTable) {
         usingDefinitions(Snippets.ageFromDateOfBirthDef) {
-          withFactsOfType(FactTypes.Age).returnInput
+          factsOfType(FactTypes.Age)
         }
       }
       val ages = result.output.value.map(_.value)
@@ -48,8 +48,8 @@ class UsingDefinitionsExprSpec extends AnyWordSpec {
       val definition = Snippets.isEligibleDef
       val result = eval(facts) {
         usingDefinitions(definition) {
-          withFactsOfType(definition.factType).where {
-            _.exists(_.get(_.select(_.value)))
+          factsOfType(definition.factType).exists {
+            _.get(_.select(_.value))
           }
         }
       }


### PR DESCRIPTION
- Convert all DSL methods and tests to use factsOfType
- Convert all methods from using deprecated NamedLens.atKey to .at