### PR TITLE
Implement a better performing interpreter

### DIFF
--- a/core/src/main/scala/vapors/algebra/Expr.scala
+++ b/core/src/main/scala/vapors/algebra/Expr.scala
@@ -52,10 +52,10 @@ object Expr {
     def visitDivideOutputs[R : Division](expr: DivideOutputs[V, R, P]): G[R]
     def visitEmbed[R](expr: Embed[V, R, P]): G[R]
     def visitExistsInOutput[M[_] : Foldable, U](expr: ExistsInOutput[V, M, U, P]): G[Boolean]
-    def visitFilterOutput[M[_] : Foldable : FunctorFilter, R](expr: FilterOutput[V, M, R, P]): G[M[R]]
-    def visitFlatMapOutput[M[_] : Foldable : FlatMap, U, X](expr: FlatMapOutput[V, M, U, X, P]): G[M[X]]
+    def visitFilterOutput[M[_] : TraverseFilter, R](expr: FilterOutput[V, M, R, P]): G[M[R]]
+    def visitFlatMapOutput[M[_] : FlatMap : Traverse, U, X](expr: FlatMapOutput[V, M, U, X, P]): G[M[X]]
     def visitGroupOutput[M[_] : Foldable, U : Order, K](expr: GroupOutput[V, M, U, K, P]): G[MapView[K, Seq[U]]]
-    def visitMapOutput[M[_] : Foldable : Functor, U, R](expr: MapOutput[V, M, U, R, P]): G[M[R]]
+    def visitMapOutput[M[_] : Traverse, U, R](expr: MapOutput[V, M, U, R, P]): G[M[R]]
     def visitMultiplyOutputs[R : Multiplication](expr: MultiplyOutputs[V, R, P]): G[R]
     def visitNegativeOutput[R : Negative](expr: NegativeOutput[V, R, P]): G[R]
     def visitNot[R : Negation](expr: Not[V, R, P]): G[R]
@@ -294,7 +294,7 @@ object Expr {
     override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitSelectFromOutput(this)
   }
 
-  final case class FilterOutput[V, M[_] : Foldable : FunctorFilter, R, P](
+  final case class FilterOutput[V, M[_] : TraverseFilter, R, P](
     inputExpr: Expr[V, M[R], P],
     condExpr: Expr[R, Boolean, P],
     capture: CaptureP[V, M[R], P],
@@ -321,7 +321,7 @@ object Expr {
     *
     * @note if you want to apply this to the input (i.e. `F[V]`), you can pass [[ReturnInput]] as the [[inputExpr]].
     */
-  final case class FlatMapOutput[V, M[_] : Foldable : FlatMap, U, R, P](
+  final case class FlatMapOutput[V, M[_] : FlatMap : Traverse, U, R, P](
     inputExpr: Expr[V, M[U], P],
     flatMapExpr: Expr[U, M[R], P],
     capture: CaptureP[V, M[R], P],
@@ -334,7 +334,7 @@ object Expr {
     *
     * @note if you want to apply this to the input (i.e. `F[V]`), you can pass [[ReturnInput]] as the [[inputExpr]].
     */
-  final case class MapOutput[V, M[_] : Foldable : Functor, U, R, P](
+  final case class MapOutput[V, M[_] : Traverse, U, R, P](
     inputExpr: Expr[V, M[U], P],
     mapExpr: Expr[U, R, P],
     capture: CaptureP[V, M[R], P],

--- a/core/src/main/scala/vapors/algebra/ExprResult.scala
+++ b/core/src/main/scala/vapors/algebra/ExprResult.scala
@@ -53,7 +53,7 @@ object ExprResult {
     def visitDivideOutputs[R](result: DivideOutputs[V, R, P]): G[R]
     def visitEmbed[R](result: Embed[V, R, P]): G[R]
     def visitExistsInOutput[M[_] : Foldable, U](result: ExistsInOutput[V, M, U, P]): G[Boolean]
-    def visitFilterOutput[M[_] : Foldable : FunctorFilter, R](result: FilterOutput[V, M, R, P]): G[M[R]]
+    def visitFilterOutput[M[_] : TraverseFilter, R](result: FilterOutput[V, M, R, P]): G[M[R]]
     def visitFlatMapOutput[M[_], U, R](result: FlatMapOutput[V, M, U, R, P]): G[M[R]]
     def visitGroupOutput[M[_] : Foldable, U : Order, K](result: GroupOutput[V, M, U, K, P]): G[MapView[K, Seq[U]]]
     def visitMapOutput[M[_], U, R](result: MapOutput[V, M, U, R, P]): G[M[R]]
@@ -188,7 +188,7 @@ object ExprResult {
     override def visit[G[_]](v: Visitor[V, P, G]): G[R] = v.visitSelectFromOutput(this)
   }
 
-  final case class FilterOutput[V, M[_] : Foldable : FunctorFilter, R, P](
+  final case class FilterOutput[V, M[_] : TraverseFilter, R, P](
     expr: Expr.FilterOutput[V, M, R, P],
     context: Context[V, M[R], P],
     inputResult: ExprResult[V, M[R], P],

--- a/core/src/main/scala/vapors/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/vapors/dsl/ExprBuilder.scala
@@ -289,8 +289,7 @@ final class FoldableExprBuilder[V, M[_], U, P](returnOutput: Expr[V, M[U], P])
   def map[R](
     buildFn: ValExprBuilder[U, U, P] => ExprBuilder[U, Id, R, P],
   )(implicit
-    foldableM: Foldable[M],
-    functorM: Functor[M],
+    traverseM: Traverse[M],
     postEachOutput: CaptureInputAsResult,
     postMap: CaptureResult[M[R]],
   ): FoldableExprBuilder[V, M, R, P] = {
@@ -319,7 +318,7 @@ final class FoldableExprBuilder[V, M[_], U, P](returnOutput: Expr[V, M[U], P])
   def flatMap[X](
     buildFn: ValExprBuilder[U, U, P] => ExprBuilder[U, M, X, P],
   )(implicit
-    foldableM: Foldable[M],
+    traverseM: Traverse[M],
     flatMapM: FlatMap[M],
     postEachInput: CaptureInputAsResult,
     postFlatMap: CaptureResult[M[X]],
@@ -385,8 +384,7 @@ final class FoldableExprBuilder[V, M[_], U, P](returnOutput: Expr[V, M[U], P])
   def filter(
     buildFn: ValExprBuilder[U, U, P] => ExprBuilder[U, Id, Boolean, P],
   )(implicit
-    foldableM: Foldable[M],
-    filterM: FunctorFilter[M],
+    filterM: TraverseFilter[M],
     captureInput: CaptureInputResult[U],
     captureResult: CaptureResult[M[U]],
   ): FoldableExprBuilder[V, M, U, P] = {
@@ -403,7 +401,7 @@ final class FoldableExprBuilder[V, M[_], U, P](returnOutput: Expr[V, M[U], P])
     validValues: Set[U],
   )(implicit
     foldableM: Foldable[M],
-    filterM: FunctorFilter[M],
+    filterM: TraverseFilter[M],
     captureCond: CaptureCondResult,
     captureFilterCond: CaptureInputCondResult,
     captureFilterInput: CaptureInputResult[U],

--- a/core/src/main/scala/vapors/dsl/ExprDsl.scala
+++ b/core/src/main/scala/vapors/dsl/ExprDsl.scala
@@ -28,17 +28,12 @@ trait ExprDsl extends TimeFunctions with WrapExprSyntax with WrapEachExprSyntax 
     * You can also apply a post-processing [[ExprResult.Visitor]] to analyze the results in more depth
     * in a recursive and type-safe way.
     */
+  @deprecated(
+    "Use StandardVaporsEngine.eval(query, facts).result instead. Now that there are multiple engines, you should choose the one you want explicitly.",
+    "0.18.0",
+  )
   def eval[R, P](facts: FactTable)(query: RootExpr[R, P]): ExprResult[FactTable, R, P] = {
     InterpretExprAsResultFn(query)(ExprInput.fromFactTable(facts))
-  }
-
-  /**
-    * A simpler, more efficient evaluator that returns a stack-safe cats-effect [[IO]].
-    *
-    * This only returns the result without any concern for evidence tracking or post-processing.
-    */
-  def evalFastIO[R](facts: FactTable)(query: RootExpr[R, Unit]): IO[R] = {
-    query.visit(new InterpretExprAsSimpleCatsEffectValue(ExprInput.fromFactTable(facts)))
   }
 
   /**

--- a/core/src/main/scala/vapors/interpreter/InterpretExprAsSimpleCatsEffectValue.scala
+++ b/core/src/main/scala/vapors/interpreter/InterpretExprAsSimpleCatsEffectValue.scala
@@ -57,7 +57,7 @@ class InterpretExprAsSimpleCatsEffectValue[V](state: ExprInput[V]) extends Expr.
       }
       .map { outputs =>
         val M = MonoidK[M].algebra[R]
-        outputs.reduce(M.combine)
+        outputs.reduceOption(M.combine).getOrElse(M.empty)
       }
   }
 

--- a/core/src/main/scala/vapors/interpreter/InterpretExprAsSimpleCatsEffectValue.scala
+++ b/core/src/main/scala/vapors/interpreter/InterpretExprAsSimpleCatsEffectValue.scala
@@ -1,0 +1,301 @@
+package com.rallyhealth
+
+package vapors.interpreter
+
+import vapors.algebra.{ConditionBranch, Expr}
+import vapors.data._
+import vapors.logic.{Conjunction, Disjunction, Negation}
+
+import cats._
+import cats.effect.IO
+import shapeless.HList
+
+import scala.collection.MapView
+
+class InterpretExprAsSimpleCatsEffectValue[V](state: ExprInput[V]) extends Expr.Visitor[V, Unit, IO] {
+  import vapors.math._
+
+  import cats.implicits._
+
+  override def visitAddOutputs[R : Addition](expr: Expr.AddOutputs[V, R, Unit]): IO[R] = {
+    implicit val addSemigroup: Semigroup[IO[R]] = { (x, y) =>
+      (x, y).mapN(Addition[R].add)
+    }
+    expr.inputExprList.map { inputExpr =>
+      inputExpr.visit(this)
+    }.reduce
+  }
+
+  override def visitAnd[R : Conjunction : ExtractBoolean](expr: Expr.And[V, R, Unit]): IO[R] = {
+    implicit val conjunctionSemigroup: Semigroup[R] = Conjunction[R].conjunction
+    expr.inputExprList
+      .map { inputExpr =>
+        inputExpr.visit(this)
+      }
+      .sequence
+      .map { results =>
+        results.reduce
+      }
+  }
+
+  override def visitCollectSomeOutput[M[_] : Foldable, U, R : Monoid](
+    expr: Expr.CollectFromOutput[V, M, U, R, Unit],
+  ): IO[R] = {
+    expr.inputExpr.visit(this).flatMap { inputValues =>
+      val lazyCollectResults = inputValues.collectFirstSomeM { v =>
+        val input = ExprInput(v, state.evidence, state.factTable)
+        expr.collectExpr.visit(new InterpretExprAsSimpleCatsEffectValue(input))
+      }
+      lazyCollectResults.map(_.getOrElse(Monoid[R].empty))
+    }
+  }
+
+  override def visitConcatOutput[M[_] : MonoidK, R](expr: Expr.ConcatOutput[V, M, R, Unit]): IO[M[R]] = {
+    expr.inputExprList
+      .traverse { inputExpr =>
+        inputExpr.visit(new InterpretExprAsSimpleCatsEffectValue(state))
+      }
+      .map { outputs =>
+        val M = MonoidK[M].algebra[R]
+        outputs.reduce(M.combine)
+      }
+  }
+
+  override def visitConstOutput[R](expr: Expr.ConstOutput[V, R, Unit]): IO[R] = IO.pure(expr.value)
+
+  override def visitCustomFunction[A, R](expr: Expr.CustomFunction[V, A, R, Unit]): IO[R] = {
+    val inputResult = expr.inputExpr.visit(this)
+    inputResult.map(expr.evaluate)
+  }
+
+  override def visitDefine[M[_] : Foldable, T](expr: Expr.Define[M, T, Unit]): IO[FactSet] = {
+    val factTableInput = ExprInput(state.factTable, state.evidence, state.factTable)
+    expr.definitionExpr.visit(new InterpretExprAsSimpleCatsEffectValue(factTableInput)).map { defnValues =>
+      defnValues.foldMap { v =>
+        FactSet(DerivedFact(expr.factType, v, state.evidence))
+      }
+    }
+  }
+
+  override def visitDivideOutputs[R : Division](expr: Expr.DivideOutputs[V, R, Unit]): IO[R] = {
+    implicit val divisionSemigroup: Semigroup[R] = Division[R].quot
+    expr.inputExprList
+      .map { inputExpr =>
+        inputExpr.visit(this)
+      }
+      .sequence
+      .map { results =>
+        results.reduce
+      }
+  }
+
+  override def visitEmbed[R](expr: Expr.Embed[V, R, Unit]): IO[R] = {
+    val input = ExprInput(state.factTable, state.evidence, state.factTable)
+    expr.embeddedExpr.visit(new InterpretExprAsSimpleCatsEffectValue(input))
+  }
+
+  override def visitExistsInOutput[M[_] : Foldable, U](expr: Expr.ExistsInOutput[V, M, U, Unit]): IO[Boolean] = {
+    expr.inputExpr.visit(this).flatMap { inputValues =>
+      inputValues.existsM { v =>
+        val condInput = ExprInput(v, state.evidence, state.factTable)
+        expr.conditionExpr.visit(new InterpretExprAsSimpleCatsEffectValue(condInput))
+      }
+    }
+  }
+
+  override def visitFilterOutput[M[_] : TraverseFilter, R](expr: Expr.FilterOutput[V, M, R, Unit]): IO[M[R]] = {
+    expr.inputExpr.visit(this).flatMap { inputValues =>
+      inputValues.filterA { v =>
+        val condInput = ExprInput(v, state.evidence, state.factTable)
+        expr.condExpr.visit(new InterpretExprAsSimpleCatsEffectValue(condInput))
+      }
+    }
+  }
+
+  override def visitFlatMapOutput[M[_] : FlatMap : Traverse, U, X](
+    expr: Expr.FlatMapOutput[V, M, U, X, Unit],
+  ): IO[M[X]] = {
+    expr.inputExpr.visit(this).flatMap { inputValues =>
+      inputValues.flatTraverse { v =>
+        val input = ExprInput(v, state.evidence, state.factTable)
+        expr.flatMapExpr.visit(new InterpretExprAsSimpleCatsEffectValue(input))
+      }
+    }
+  }
+
+  override def visitGroupOutput[M[_] : Foldable, U : Order, K](
+    expr: Expr.GroupOutput[V, M, U, K, Unit],
+  ): IO[MapView[K, Seq[U]]] = {
+    expr.inputExpr.visit(this).map { inputValues =>
+      inputValues.toIterable.groupBy(expr.groupByLens.get).view.mapValues(_.to(LazyList))
+    }
+  }
+
+  override def visitMapOutput[M[_] : Traverse, U, R](expr: Expr.MapOutput[V, M, U, R, Unit]): IO[M[R]] = {
+    expr.inputExpr.visit(this).flatMap { inputValues =>
+      inputValues.traverse { v =>
+        val mapInput = ExprInput(v, state.evidence, state.factTable)
+        expr.mapExpr.visit(new InterpretExprAsSimpleCatsEffectValue(mapInput))
+      }
+    }
+  }
+
+  override def visitMultiplyOutputs[R : Multiplication](expr: Expr.MultiplyOutputs[V, R, Unit]): IO[R] = {
+    implicit val multiplySemigroup: Semigroup[IO[R]] = { (x, y) =>
+      (x, y).mapN(Multiplication[R].multiply)
+    }
+    expr.inputExprList.map { inputExpr =>
+      inputExpr.visit(this)
+    }.reduce
+  }
+
+  override def visitNegativeOutput[R : Negative](expr: Expr.NegativeOutput[V, R, Unit]): IO[R] = {
+    expr.inputExpr.visit(this).map(Negative[R].negative)
+  }
+
+  override def visitNot[R : Negation](expr: Expr.Not[V, R, Unit]): IO[R] = {
+    expr.inputExpr.visit(this).map(Negation[R].negation)
+  }
+
+  override def visitOr[R : Disjunction : ExtractBoolean](expr: Expr.Or[V, R, Unit]): IO[R] = {
+    implicit val disjunctionSemigroup: Semigroup[R] = Disjunction[R].disjunction
+    expr.inputExprList
+      .map { inputExpr =>
+        inputExpr.visit(this)
+      }
+      .sequence
+      .map { results =>
+        results.reduce
+      }
+  }
+
+  override def visitOutputIsEmpty[M[_] : Foldable, R](expr: Expr.OutputIsEmpty[V, M, R, Unit]): IO[Boolean] = {
+    expr.inputExpr.visit(this).map { inputValues =>
+      inputValues.isEmpty
+    }
+  }
+
+  override def visitOutputWithinSet[R](expr: Expr.OutputWithinSet[V, R, Unit]): IO[Boolean] = {
+    expr.inputExpr.visit(this).map { inputValue =>
+      expr.accepted.contains(inputValue)
+    }
+  }
+
+  override def visitOutputWithinWindow[R](expr: Expr.OutputWithinWindow[V, R, Unit]): IO[Boolean] = {
+    (expr.inputExpr.visit(this), expr.windowExpr.visit(this)).mapN { (inputValue, window) =>
+      window.contains(inputValue)
+    }
+  }
+
+  override def visitFoldOutput[M[_] : Foldable, R : Monoid](expr: Expr.FoldOutput[V, M, R, Unit]): IO[R] = {
+    expr.inputExpr.visit(this).map { inputValues =>
+      inputValues.fold
+    }
+  }
+
+  override def visitReturnInput(expr: Expr.ReturnInput[V, Unit]): IO[V] = IO.pure(state.value)
+
+  override def visitSelectFromOutput[S, R](expr: Expr.SelectFromOutput[V, S, R, Unit]): IO[R] = {
+    expr.inputExpr.visit(this).map { inputValue =>
+      expr.lens.get(inputValue)
+    }
+  }
+
+  override def visitSortOutput[M[_], R](expr: Expr.SortOutput[V, M, R, Unit]): IO[M[R]] = {
+    expr.inputExpr.visit(this).map { inputValues =>
+      expr.sorter(inputValues)
+    }
+  }
+
+  override def visitSubtractOutputs[R : Subtraction](expr: Expr.SubtractOutputs[V, R, Unit]): IO[R] = {
+    implicit val subtractSemigroup: Semigroup[R] = Subtraction[R].subtract
+    expr.inputExprList
+      .map { inputExpr =>
+        inputExpr.visit(this)
+      }
+      .sequence
+      .map { results =>
+        results.reduce
+      }
+  }
+
+  override def visitTakeFromOutput[M[_] : Traverse : TraverseFilter, R](
+    expr: Expr.TakeFromOutput[V, M, R, Unit],
+  ): IO[M[R]] = {
+    expr.inputExpr.visit(this).map { inputValues =>
+      val takeWindow: Window[Int] = expr.take match {
+        case pos if pos > 0 => Window.between(0, pos)
+        case 0 => Window.empty
+        case neg if neg < 0 =>
+          val totalSize = inputValues.size.toInt
+          Window.between(totalSize + neg, totalSize)
+      }
+      val selectedValues = inputValues.zipWithIndex.collect {
+        case (elem, idx) if takeWindow.contains(idx) => elem
+      }
+      selectedValues
+    }
+  }
+
+  override def visitUsingDefinitions[R](expr: Expr.UsingDefinitions[V, R, Unit]): IO[R] = {
+    val factTableInput = ExprInput(state.factTable, state.evidence, state.factTable)
+    val runWithCurrentFactTable = new InterpretExprAsSimpleCatsEffectValue(factTableInput)
+    expr.definitions
+      .foldMapM { defn =>
+        defn.visit(runWithCurrentFactTable)
+      }
+      .flatMap { newFacts =>
+        val newFactTable = state.factTable.addAll(newFacts)
+        val newFactTableInput = ExprInput(state.value, state.evidence, newFactTable)
+        expr.subExpr.visit(new InterpretExprAsSimpleCatsEffectValue(newFactTableInput))
+      }
+  }
+
+  override def visitWhen[R](expr: Expr.When[V, R, Unit]): IO[R] = {
+    expr.conditionBranches
+      .foldLeftM(None: Option[ConditionBranch[V, R, Unit]]) {
+        case (matchedBranch @ Some(_), _) => IO.pure(matchedBranch)
+        case (None, branch) =>
+          branch.whenExpr.visit(this).map { conditionMet =>
+            if (conditionMet) Some(branch)
+            else None
+          }
+      }
+      .flatMap { maybeBranch =>
+        val branchExpr = maybeBranch.fold(expr.defaultExpr)(_.thenExpr)
+        branchExpr.visit(this)
+      }
+  }
+
+  override def visitWrapOutput[L, R](expr: Expr.WrapOutput[V, L, R, Unit]): IO[R] = {
+    expr.inputExpr.visit(this).map { inputValue =>
+      expr.converter(inputValue)
+    }
+  }
+
+  override def visitWrapOutputHList[T <: HList, R](expr: Expr.WrapOutputHList[V, T, R, Unit]): IO[R] = {
+    expr.inputExprHList.visitProduct(this).map { outputValue =>
+      expr.converter(outputValue)
+    }
+  }
+
+  override def visitWrapOutputSeq[R](expr: Expr.WrapOutputSeq[V, R, Unit]): IO[Seq[R]] = {
+    expr.inputExprList.to(LazyList).traverse { inputExpr =>
+      inputExpr.visit(this)
+    }
+  }
+
+  override def visitWithFactsOfType[T, R](expr: Expr.WithFactsOfType[T, R, Unit]): IO[R] = {
+    val matchingFacts = state.factTable.getSortedSeq(expr.factTypeSet)
+    val input = ExprInput[Seq[TypedFact[T]]](matchingFacts, state.evidence, state.factTable)
+    expr.subExpr.visit(new InterpretExprAsSimpleCatsEffectValue(input))
+  }
+
+  override def visitZipOutput[M[_] : Align : FunctorFilter, L <: HList, R](
+    expr: Expr.ZipOutput[V, M, L, R, Unit],
+  ): IO[M[R]] = {
+    expr.inputExprHList.visitZippedToShortest(this).map { outputValues =>
+      FunctorFilter[M].functor.map(outputValues)(expr.converter)
+    }
+  }
+}

--- a/core/src/main/scala/vapors/interpreter/VaporsEngine.scala
+++ b/core/src/main/scala/vapors/interpreter/VaporsEngine.scala
@@ -1,0 +1,70 @@
+package com.rallyhealth
+
+package vapors.interpreter
+
+import vapors.data.FactTable
+import vapors.dsl.RootExpr
+
+import cats.Id
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+
+sealed trait VaporsEngine[F[_], P] {
+  type Result[R] <: VaporsResult[F, R, P]
+  type ExtractParam
+
+  def eval[R](
+    rootExpr: RootExpr[R, P],
+    factTable: FactTable = FactTable.empty,
+  ): Result[R]
+
+  final def evalAndExtractValue[R](
+    rootExpr: RootExpr[R, P],
+    factTable: FactTable = FactTable.empty,
+  )(implicit
+    param: ExtractParam,
+  ): R =
+    extract(eval(rootExpr, factTable).value)
+
+  def extract[R](wrapped: F[R])(implicit param: ExtractParam): R
+}
+
+object StandardVaporsEngine extends StandardVaporsEngine[Unit] {
+  @inline final def apply[P]: StandardVaporsEngine[P] = this.asInstanceOf[StandardVaporsEngine[P]]
+}
+
+sealed class StandardVaporsEngine[P] private extends VaporsEngine[Id, P] {
+  override type Result[R] = StandardVaporsResult[R, P]
+  override type ExtractParam = DummyImplicit
+
+  override final def eval[R](
+    rootExpr: RootExpr[R, P],
+    factTable: FactTable,
+  ): StandardVaporsResult[R, P] = {
+    StandardVaporsResult(InterpretExprAsResultFn(rootExpr)(ExprInput.fromFactTable(factTable)))
+  }
+
+  override final def extract[R](wrapped: Id[R])(implicit param: DummyImplicit): R = wrapped
+}
+
+/**
+  * A simpler, more efficient evaluator that returns a stack-safe cats-effect [[IO]].
+  *
+  * This only returns the result without any concern for evidence tracking or post-processing.
+  */
+object CatsEffectSimpleVaporsEngine extends CatsEffectSimpleVaporsEngine
+sealed class CatsEffectSimpleVaporsEngine private extends VaporsEngine[IO, Unit] {
+  override type Result[R] = CatsEffectSimpleVaporsResult[R]
+  override type ExtractParam = IORuntime
+
+  override def eval[R](
+    rootExpr: RootExpr[R, Unit],
+    factTable: FactTable,
+  ): CatsEffectSimpleVaporsResult[R] = {
+    CatsEffectSimpleVaporsResult(
+      rootExpr.visit(new InterpretExprAsSimpleCatsEffectValue(ExprInput.fromFactTable(factTable))),
+    )
+  }
+
+  override def extract[R](wrapped: IO[R])(implicit param: IORuntime): R = wrapped.unsafeRunSync()
+}

--- a/core/src/main/scala/vapors/interpreter/VaporsResult.scala
+++ b/core/src/main/scala/vapors/interpreter/VaporsResult.scala
@@ -1,0 +1,29 @@
+package com.rallyhealth
+
+package vapors.interpreter
+
+import vapors.algebra.ExprResult
+import vapors.data.{Evidence, FactTable}
+
+import cats.Id
+import cats.effect.IO
+
+sealed trait VaporsResult[F[_], R, P] {
+
+  def value: F[R]
+
+  def maybeEvidence: Option[F[Evidence]]
+
+  def maybeParam: Option[F[P]]
+}
+
+final case class StandardVaporsResult[R, P](result: ExprResult[FactTable, R, P]) extends VaporsResult[Id, R, P] {
+  override def value: R = result.output.value
+  override def maybeEvidence: Option[Evidence] = Some(result.output.evidence)
+  override lazy val maybeParam: Option[P] = Some(result.param.value)
+}
+
+final case class CatsEffectSimpleVaporsResult[R](value: IO[R]) extends VaporsResult[IO, R, Unit] {
+  override def maybeEvidence: Option[IO[Evidence]] = None
+  override def maybeParam: Option[IO[Unit]] = None
+}

--- a/core/src/main/scala/vapors/interpreter/VisitGenericExprWithProxyFn.scala
+++ b/core/src/main/scala/vapors/interpreter/VisitGenericExprWithProxyFn.scala
@@ -62,11 +62,11 @@ abstract class VisitGenericExprWithProxyFn[V, P, G[_]] extends Visitor[V, P, Lam
     expr: Expr.ExistsInOutput[V, M, U, P],
   ): ExprInput[V] => G[Boolean] = visitGeneric(expr, _)
 
-  override def visitFilterOutput[M[_] : Foldable : FunctorFilter, R](
+  override def visitFilterOutput[M[_] : TraverseFilter, R](
     expr: Expr.FilterOutput[V, M, R, P],
   ): ExprInput[V] => G[M[R]] = visitGeneric(expr, _)
 
-  override def visitFlatMapOutput[M[_] : Foldable : FlatMap, U, X](
+  override def visitFlatMapOutput[M[_] : FlatMap : Traverse, U, X](
     expr: Expr.FlatMapOutput[V, M, U, X, P],
   ): ExprInput[V] => G[M[X]] = visitGeneric(expr, _)
 
@@ -74,9 +74,8 @@ abstract class VisitGenericExprWithProxyFn[V, P, G[_]] extends Visitor[V, P, Lam
     expr: Expr.GroupOutput[V, M, U, K, P],
   ): ExprInput[V] => G[MapView[K, Seq[U]]] = visitGeneric(expr, _)
 
-  override def visitMapOutput[M[_] : Foldable : Functor, U, R](
-    expr: Expr.MapOutput[V, M, U, R, P],
-  ): ExprInput[V] => G[M[R]] = visitGeneric(expr, _)
+  override def visitMapOutput[M[_] : Traverse, U, R](expr: Expr.MapOutput[V, M, U, R, P]): ExprInput[V] => G[M[R]] =
+    visitGeneric(expr, _)
 
   override def visitMultiplyOutputs[R : Multiplication](expr: Expr.MultiplyOutputs[V, R, P]): ExprInput[V] => G[R] =
     visitGeneric(expr, _)

--- a/core/src/main/scala/vapors/logic/Conjunction.scala
+++ b/core/src/main/scala/vapors/logic/Conjunction.scala
@@ -2,8 +2,6 @@ package com.rallyhealth
 
 package vapors.logic
 
-import vapors.interpreter.InterpretExprAsResultFn
-
 import cats.{Invariant, Semigroupal}
 
 /**

--- a/core/src/main/scala/vapors/logic/Disjunction.scala
+++ b/core/src/main/scala/vapors/logic/Disjunction.scala
@@ -4,7 +4,8 @@ package vapors.logic
 
 import vapors.interpreter.InterpretExprAsResultFn
 
-import cats.{Invariant, Semigroupal}
+import cats.syntax.apply._
+import cats.{Functor, Invariant, Semigroup, Semigroupal}
 
 /**
   * Defines logical disjunction (aka OR) for a specific type.

--- a/core/src/main/scala/vapors/math/Division.scala
+++ b/core/src/main/scala/vapors/math/Division.scala
@@ -16,5 +16,5 @@ trait Division[A] {
 }
 
 object Division extends NumericalImplicits {
-  def apply[A](implicit A: Division[A]): Division[A] = A
+  @inline final def apply[A](implicit A: Division[A]): Division[A] = A
 }

--- a/core/src/test/scala/vapors/interpreter/AddOutputsSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/AddOutputsSpec.scala
@@ -10,26 +10,45 @@ class AddOutputsSpec extends AnyFreeSpec {
 
   "Expr.AddOutputs" - {
 
+    "standard eval" - {
+      allTests(StandardVaporsEngine)
+    }
+
+    "fast eval" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
+    }
+  }
+
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
+
     "Int" - {
 
       "expression added to an expression" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Int, Int, Int, ArithmeticException](
           _ + _,
           const(_) + const(_),
+          engine,
         )
       }
 
       "value added to an expression" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Int, Int, Int, ArithmeticException](
           _ + _,
           const(_) + _,
+          engine,
         )
       }
 
       "expression added to a value" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Int, Int, Int, ArithmeticException](
           _ + _,
           const(_).addTo(_),
+          engine,
         )
       }
     }
@@ -37,23 +56,26 @@ class AddOutputsSpec extends AnyFreeSpec {
     "Double" - {
 
       "expression added to an expression" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Double, Double, Double, ArithmeticException](
           _ + _,
           const(_) + const(_),
+          engine,
         )
       }
 
       "value added to an expression" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Double, Double, Double, ArithmeticException](
           _ + _,
           const(_) + _,
+          engine,
         )
       }
 
       "expression added to a value" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Double, Double, Double, ArithmeticException](
           _ + _,
           const(_).addTo(_),
+          engine,
         )
       }
     }

--- a/core/src/test/scala/vapors/interpreter/FilterOutputSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/FilterOutputSpec.scala
@@ -7,196 +7,267 @@ import vapors.dsl._
 import vapors.example.{FactTypes, Tags}
 
 import org.scalatest.matchers.should.Matchers._
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class FilterOutputSpec extends AnyWordSpec {
+class FilterOutputSpec extends AnyFreeSpec {
 
-  "Expr.FilterOutput" when {
+  "Expr.FilterOutput" - {
 
-    "using with an 'OutputWithinSet' op" when {
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
+    }
+
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
+    }
+  }
+
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
+
+    "using with an 'OutputWithinSet' op" - {
       val tagFacts = FactTable(Tags.smoker, Tags.asthma, Tags.normalBmi)
 
-      "comparing facts" should {
+      "comparing facts" - {
 
         "return all matching facts from a given subset" in {
           val q = factsOfType(FactTypes.Tag).filter {
             _ in Set(Tags.asthma)
           }
-          val res = eval(tagFacts)(q)
-          res.output.value should contain theSameElementsAs Seq(Tags.asthma)
-          assertResult(Evidence(Tags.asthma))(res.output.evidence)
+          val res = engine.eval(q, tagFacts)
+          val resultValue = engine.extract(res.value)
+          resultValue should contain theSameElementsAs Seq(Tags.asthma)
+          for (evidence <- res.maybeEvidence) {
+            assertResult(Evidence(Tags.asthma)) {
+              engine.extract(evidence)
+            }
+          }
         }
 
         "return all matching facts from a given superset" in {
           val q = factsOfType(FactTypes.Tag).filter {
             _ in Set(Tags.asthma, Tags.obeseBmi)
           }
-          val res = eval(tagFacts)(q)
-          res.output.value should contain theSameElementsAs Seq(Tags.asthma)
-          assertResult(Evidence(Tags.asthma))(res.output.evidence)
+          val res = engine.eval(q, tagFacts)
+          val resultValue = engine.extract(res.value)
+          resultValue should contain theSameElementsAs Seq(Tags.asthma)
+          for (evidence <- res.maybeEvidence) {
+            assertResult(Evidence(Tags.asthma)) {
+              engine.extract(evidence)
+            }
+          }
         }
 
         "return an empty list of facts when given a set that contains no common elements" in {
           val q = factsOfType(FactTypes.Tag).filter {
             _ in Set(Tags.obeseBmi)
           }
-          val res = eval(tagFacts)(q)
-          assert(res.output.value.isEmpty)
-          assert(res.output.evidence.isEmpty)
+          val res = engine.eval(q, tagFacts)
+          val resultValue = engine.extract(res.value)
+          assert(resultValue.isEmpty)
+          for (evidence <- res.maybeEvidence) {
+            assert(engine.extract(evidence).isEmpty)
+          }
         }
       }
 
-      "comparing values" should {
+      "comparing values" - {
 
         "return all matching values from a given subset" in {
-          val q = factsOfType(FactTypes.Tag).map(_.value).filter {
+          val q = valuesOfType(FactTypes.Tag).filter {
             _ in Set(Tags.asthma).map(_.value)
           }
-          val res = eval(tagFacts)(q)
-          res.output.value should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
+          val res = engine.eval(q, tagFacts)
+          val resultValue = engine.extract(res.value)
+          resultValue should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
         }
 
         "return the correct evidence for the matching values from a given subset" in {
-          val q = factsOfType(FactTypes.Tag).map(_.value).filter {
+          val q = valuesOfType(FactTypes.Tag).filter {
             _ in Set(Tags.asthma).map(_.value)
           }
-          val res = eval(tagFacts)(q)
-          pendingUntilFixed {
+          val res = engine.eval(q, tagFacts)
+          for (evidence <- res.maybeEvidence) {
             // TODO: Merge this assertion the above unit test when it passes
-            assertResult(Evidence(Tags.asthma))(res.output.evidence)
+            pendingUntilFixed {
+              assertResult(Evidence(Tags.asthma)) {
+                engine.extract(evidence)
+              }
+            }
           }
         }
 
         "return the matching values from a given superset" in {
-          val q = factsOfType(FactTypes.Tag).map(_.value).filter {
+          val q = valuesOfType(FactTypes.Tag).filter {
             _ in Set(Tags.asthma, Tags.obeseBmi).map(_.value)
           }
-          val res = eval(tagFacts)(q)
-          res.output.value should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
+          val res = engine.eval(q, tagFacts)
+          val resultValue = engine.extract(res.value)
+          resultValue should contain theSameElementsAs Seq(Tags.asthma).map(_.value)
         }
 
         "return the correct evidence for the matching values from a given superset" in {
-          val q = factsOfType(FactTypes.Tag).map(_.value).filter {
+          val q = valuesOfType(FactTypes.Tag).filter {
             _ in Set(Tags.asthma, Tags.obeseBmi).map(_.value)
           }
-          val res = eval(tagFacts)(q)
-          pendingUntilFixed {
+          val res = engine.eval(q, tagFacts)
+          for (evidence <- res.maybeEvidence) {
             // TODO: Merge this assertion the above unit test when it passes
-            assertResult(Evidence(Tags.asthma))(res.output.evidence)
+            pendingUntilFixed {
+              assertResult(Evidence(Tags.asthma)) {
+                engine.extract(evidence)
+              }
+            }
           }
         }
 
         "return an empty list of values when given a set that contains no common elements" in {
-          val q = factsOfType(FactTypes.Tag).map(_.value).filter {
+          val q = valuesOfType(FactTypes.Tag).filter {
             _ in Set(Tags.obeseBmi).map(_.value)
           }
-          val res = eval(tagFacts)(q)
-          assert(res.output.value.isEmpty)
-          assert(res.output.evidence.isEmpty)
+          val res = engine.eval(q, tagFacts)
+          val resultValue = engine.extract(res.value)
+          assert(resultValue.isEmpty)
+          for (evidence <- res.maybeEvidence) {
+            assert(engine.extract(evidence).isEmpty)
+          }
         }
       }
 
-      "using the 'containsAny' op" should {
+      "using the 'containsAny' op" - {
 
         "return 'true' when the fact table contains a superset of the given set" in {
-          val q = factsOfType(FactTypes.Tag).map(_.value).containsAny {
+          val q = valuesOfType(FactTypes.Tag).containsAny {
             Set(Tags.asthma).map(_.value)
           }
-          val res = eval(tagFacts)(q)
-          assert(res.output.value)
+          val res = engine.eval(q, tagFacts)
+          val resultValue = engine.extract(res.value)
+          assert(resultValue)
         }
 
         "return the correct evidence for the facts that contain a superset of the given set" in {
-          val q = factsOfType(FactTypes.Tag).map(_.value).containsAny {
+          val q = valuesOfType(FactTypes.Tag).containsAny {
             Set(Tags.asthma).map(_.value)
           }
-          val res = eval(tagFacts)(q)
-          pendingUntilFixed {
+          val res = engine.eval(q, tagFacts)
+          for (evidence <- res.maybeEvidence) {
             // TODO: Merge this assertion the above unit test when it passes
-            assertResult(Evidence(Tags.asthma))(res.output.evidence)
+            pendingUntilFixed {
+              assertResult(Evidence(Tags.asthma)) {
+                engine.extract(evidence)
+              }
+            }
           }
         }
 
         "return 'true' when the fact table contains a subset of the given set" in {
-          val q = factsOfType(FactTypes.Tag).map(_.value).containsAny {
+          val q = valuesOfType(FactTypes.Tag).containsAny {
             Set(Tags.asthma, Tags.obeseBmi).map(_.value)
           }
-          val res = eval(tagFacts)(q)
-          assert(res.output.value)
+          val res = engine.eval(q, tagFacts)
+          val resultValue = engine.extract(res.value)
+          assert(resultValue)
         }
 
         "return the correct evidence for the facts that contain a subset of the given set" in {
-          val q = factsOfType(FactTypes.Tag).map(_.value).containsAny {
+          val q = valuesOfType(FactTypes.Tag).containsAny {
             Set(Tags.asthma, Tags.obeseBmi).map(_.value)
           }
-          val res = eval(tagFacts)(q)
-          pendingUntilFixed {
+          val res = engine.eval(q, tagFacts)
+          for (evidence <- res.maybeEvidence) {
             // TODO: Merge this assertion the above unit test when it passes
-            assertResult(Evidence(Tags.asthma))(res.output.evidence)
+            pendingUntilFixed {
+              assertResult(Evidence(Tags.asthma)) {
+                engine.extract(evidence)
+              }
+            }
           }
         }
 
         "return 'false' with no Evidence when the facts do not contain anything in the given set" in {
-          val q = factsOfType(FactTypes.Tag).map(_.value).containsAny {
+          val q = valuesOfType(FactTypes.Tag).containsAny {
             Set(Tags.obeseBmi).map(_.value)
           }
-          val res = eval(tagFacts)(q)
-          assert(!res.output.value)
-          assert(res.output.evidence.isEmpty)
+          val res = engine.eval(q, tagFacts)
+          val resultValue = engine.extract(res.value)
+          assert(!resultValue)
+          for (evidence <- res.maybeEvidence) {
+            assert(engine.extract(evidence).isEmpty)
+          }
         }
       }
     }
 
-    "using with an 'OutputWithinRange' operator" should {
+    "using with an 'OutputWithinRange' operator" - {
       val low = FactTypes.Age(10)
       val middle = FactTypes.Age(18)
       val high = FactTypes.Age(85)
       val numericFacts = FactTable(low, middle, high)
 
       "return all values that match the condition" in {
-        val q = factsOfType(FactTypes.Age).map(_.value).filter {
-          _ >= middle.value
+        val q = valuesOfType(FactTypes.Age).filter {
+          _ >= const(middle.value)
         }
-        val res = eval(numericFacts)(q)
-        res.output.value should contain theSameElementsAs Seq(middle, high).map(_.value)
+        val res = engine.eval(q, numericFacts)
+        val resultValue = engine.extract(res.value)
+        resultValue should contain theSameElementsAs Seq(middle, high).map(_.value)
       }
 
       "return the correct evidence for the matching values from a given subset" in {
-        val q = factsOfType(FactTypes.Age).map(_.value).filter {
-          _ >= middle.value
+        val q = valuesOfType(FactTypes.Age).filter {
+          _ >= const(middle.value)
         }
-        val res = eval(numericFacts)(q)
-        pendingUntilFixed {
+        val res = engine.eval(q, numericFacts)
+        for (evidence <- res.maybeEvidence) {
           // TODO: Merge this assertion the above unit test when it passes
-          assertResult(Evidence(middle, high))(res.output.evidence)
+          pendingUntilFixed {
+            assertResult(Evidence(middle, high)) {
+              engine.extract(evidence)
+            }
+          }
         }
       }
 
       "return all facts that match the condition" in {
         val q = factsOfType(FactTypes.Age).filter {
-          _.value >= middle.value
+          _.get(_.select(_.value)) >= const(middle.value)
         }
-        val res = eval(numericFacts)(q)
-        res.output.value should contain theSameElementsAs Seq(middle, high)
-        assertResult(Evidence(middle, high))(res.output.evidence)
+        val res = engine.eval(q, numericFacts)
+        val resultValue = engine.extract(res.value)
+        resultValue should contain theSameElementsAs Seq(middle, high)
+        for (evidence <- res.maybeEvidence) {
+          assertResult(Evidence(middle, high)) {
+            engine.extract(evidence)
+          }
+        }
       }
 
       "return an empty list of values when none of the elements meet the condition" in {
-        val q = factsOfType(FactTypes.Age).map(_.value).filter {
-          _ > high.value
+        val q = valuesOfType(FactTypes.Age).filter {
+          _ > const(high.value)
         }
-        val res = eval(numericFacts)(q)
-        assert(res.output.value.isEmpty)
-        assert(res.output.evidence.isEmpty)
+        val res = engine.eval(q, numericFacts)
+        val resultValue = engine.extract(res.value)
+        assert(resultValue.isEmpty)
+        for (evidence <- res.maybeEvidence) {
+          assert(engine.extract(evidence).isEmpty)
+        }
       }
 
       "return an empty list of facts when none meet the condition" in {
-        val q = factsOfType(FactTypes.Age).filter {
-          _.value > high.value
+        val q = valuesOfType(FactTypes.Age).filter {
+          _ > const(high.value)
         }
-        val res = eval(numericFacts)(q)
-        assert(res.output.value.isEmpty)
-        assert(res.output.evidence.isEmpty)
+        val res = engine.eval(q, numericFacts)
+        val resultValue = engine.extract(res.value)
+        assert(resultValue.isEmpty)
+        for (evidence <- res.maybeEvidence) {
+          assert(engine.extract(evidence).isEmpty)
+        }
       }
     }
   }

--- a/core/src/test/scala/vapors/interpreter/FoldOutputSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/FoldOutputSpec.scala
@@ -2,7 +2,6 @@ package com.rallyhealth
 
 package vapors.interpreter
 
-import vapors.data.FactTable
 import vapors.dsl._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -11,22 +10,44 @@ class FoldOutputSpec extends AnyFreeSpec {
 
   "Expr.FoldOutput" - {
 
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
+    }
+
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
+    }
+  }
+
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
+
     "fold a list of ints into its sum" in {
       val query = const(List(1, 2, 3)).withOutputFoldable.fold
-      val result = eval(FactTable.empty)(query)
-      assertResult(6)(result.output.value)
+      val result = engine.evalAndExtractValue(query)
+      assertResult(6) {
+        result
+      }
     }
 
     "fold a list of options of int into an option containing the sum" in {
       val query = const(List(Some(1), None, Some(3))).withOutputFoldable.fold
-      val result = eval(FactTable.empty)(query)
-      assertResult(Some(4))(result.output.value)
+      val result = engine.evalAndExtractValue(query)
+      assertResult(Some(4)) {
+        result
+      }
     }
 
     "fold a list of options of int into a None" in {
       val query = const(List[Option[Int]](None, None, None)).withOutputFoldable.fold
-      val result = eval(FactTable.empty)(query)
-      assertResult(None)(result.output.value)
+      val result = engine.evalAndExtractValue(query)
+      assertResult(None) {
+        result
+      }
     }
   }
 }

--- a/core/src/test/scala/vapors/interpreter/GroupOutputSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/GroupOutputSpec.scala
@@ -9,14 +9,30 @@ import org.scalatest.freespec.AnyFreeSpec
 
 class GroupOutputSpec extends AnyFreeSpec {
 
-  "groupBy should" - {
+  "Expr.GroupOutput" - {
+
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
+    }
+
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
+    }
+  }
+
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
 
     "create a map from a list using groupBy and mapValues" in {
       val query = valuesOfType(FactTypes.TagsUpdate).groupBy(_.select(_.source))
       val expected = User1.factTable.getSortedSeq(FactTypes.TagsUpdate).groupMap(_.value.source)(_.value)
-      val result = eval(User1.factTable)(query)
+      val result = engine.evalAndExtractValue(query, User1.factTable)
       assertResult(expected) {
-        result.output.value.toMap
+        result.toMap
       }
     }
   }

--- a/core/src/test/scala/vapors/interpreter/MultiplyOutputsSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/MultiplyOutputsSpec.scala
@@ -10,26 +10,45 @@ class MultiplyOutputsSpec extends AnyFreeSpec {
 
   "Expr.MultiplyOutputs" - {
 
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
+    }
+
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
+    }
+  }
+
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
+
     "Int" - {
 
       "expression multiplied by an expression" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Int, Int, Int, ArithmeticException](
           _ * _,
           const(_) * const(_),
+          engine,
         )
       }
 
       "expression multiplied by a value" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Int, Int, Int, ArithmeticException](
           _ * _,
           const(_) * _,
+          engine,
         )
       }
 
       "value multiplied to an expression" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Int, Int, Int, ArithmeticException](
           _ * _,
           const(_).multiplyTo(_),
+          engine,
         )
       }
     }
@@ -37,23 +56,26 @@ class MultiplyOutputsSpec extends AnyFreeSpec {
     "Double" - {
 
       "expression multiplied by an expression" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Double, Double, Double, ArithmeticException](
           _ * _,
           const(_) * const(_),
+          engine,
         )
       }
 
       "expression multiplied by a value" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Double, Double, Double, ArithmeticException](
           _ * _,
           const(_) * _,
+          engine,
         )
       }
 
       "value multiplied to an expression" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Double, Double, Double, ArithmeticException](
           _ * _,
           const(_).multiplyTo(_),
+          engine,
         )
       }
     }

--- a/core/src/test/scala/vapors/interpreter/OutputWithinSetExprSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/OutputWithinSetExprSpec.scala
@@ -6,28 +6,54 @@ import vapors.data.Evidence
 import vapors.dsl._
 import vapors.example.{FactTypes, JoeSchmoe}
 
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class OutputWithinSetExprSpec extends AnyWordSpec {
+class OutputWithinSetExprSpec extends AnyFreeSpec {
 
-  "Expr.OutputWithinSet" should {
+  "Expr.OutputWithinSet" - {
+
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
+    }
+
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
+    }
+  }
+
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
 
     "find an asthma tag in a set that contains it" in {
       val q = valuesOfType(FactTypes.Tag).exists {
         _ in Set("asthma", "diabetes")
       }
-      val result = eval(JoeSchmoe.factTable)(q)
-      assert(result.output.value)
-      assertResult(Evidence(JoeSchmoe.asthmaTag))(result.output.evidence)
+      val result = engine.eval(q, JoeSchmoe.factTable)
+      val resultValue = engine.extract(result.value)
+      assert(resultValue)
+      for (evidence <- result.maybeEvidence) {
+        assertResult(Evidence(JoeSchmoe.asthmaTag)) {
+          engine.extract(evidence)
+        }
+      }
     }
 
     "not find an asthma tag in a set that does not contain it" in {
       val q = valuesOfType(FactTypes.Tag).exists {
         _ in Set("diabetes")
       }
-      val result = eval(JoeSchmoe.factTable)(q)
-      assert(!result.output.value)
-      assertResult(Evidence.none)(result.output.evidence)
+      val result = engine.eval(q, JoeSchmoe.factTable)
+      val resultValue = engine.extract(result.value)
+      assert(!resultValue)
+      for (evidence <- result.maybeEvidence) {
+        assertResult(Evidence.none) {
+          engine.extract(evidence)
+        }
+      }
     }
   }
 }

--- a/core/src/test/scala/vapors/interpreter/OutputWithinWindowSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/OutputWithinWindowSpec.scala
@@ -5,39 +5,55 @@ package vapors.interpreter
 import vapors.data.FactTable
 import vapors.dsl._
 
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class OutputWithinWindowSpec extends AnyWordSpec {
+class OutputWithinWindowSpec extends AnyFreeSpec {
 
-  "Expr.OutputWithinWindow" when {
+  "Expr.OutputWithinWindow" - {
 
-    "using the === operator" should {
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
+    }
+
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
+    }
+  }
+
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
+
+    "using the === operator" - {
 
       "return 'true' when the values are equal" in {
-        val q = const(2 + 2) === 4
-        val result = eval(FactTable.empty)(q)
-        assert(result.output.value)
+        val q = const(2 + 2) === const(4)
+        val result = engine.evalAndExtractValue(q)
+        assert(result)
       }
 
       "return 'false' when the values are not equal" in {
-        val q = const(2 + 2) === 5
-        val result = eval(FactTable.empty)(q)
-        assert(!result.output.value)
+        val q = const(2 + 2) === const(5)
+        val result = engine.evalAndExtractValue(q)
+        assert(!result)
       }
     }
 
-    "using the !== operator" should {
+    "using the !== operator" - {
 
       "return 'false' when the values are equal" in {
-        val q = const(2 + 2) !== 4
-        val result = eval(FactTable.empty)(q)
-        assert(!result.output.value)
+        val q = const(2 + 2) !== const(4)
+        val result = engine.evalAndExtractValue(q)
+        assert(!result)
       }
 
       "return 'true' when the values are not equal" in {
-        val q = const(2 + 2) !== 5
-        val result = eval(FactTable.empty)(q)
-        assert(result.output.value)
+        val q = const(2 + 2) !== const(5)
+        val result = engine.evalAndExtractValue(q)
+        assert(result)
       }
     }
   }

--- a/core/src/test/scala/vapors/interpreter/SelectFromOutputSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/SelectFromOutputSpec.scala
@@ -13,40 +13,59 @@ import scala.collection.View
 
 class SelectFromOutputSpec extends AnyFreeSpec {
 
-  "create a map from a converting a list of facts to tuples" in {
-    val query = valuesOfType(FactTypes.TagsUpdate).map { update =>
-      wrap(
-        update.get(_.select(_.source)).returnOutput,
-        update.get(_.select(_.tags)).returnOutput,
-      ).asTuple.withOutputValue
-    }.toMap
-    val expected = User1.factTable
-      .getSortedSeq(FactTypes.TagsUpdate)
-      .map { fact =>
-        (fact.value.source, fact.value.tags)
-      }
-      .toMap
-    val result = eval(User1.factTable)(query)
-    assertResult(expected) {
-      result.output.value.toMap
+  "Expr.SelectFromOutput" - {
+
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
+    }
+
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
     }
   }
 
-  "create a set from a list using groupBy, flatMap, sorted, and headOption" in {
-    val query = factsOfType(FactTypes.TagsUpdate)
-      .groupBy(_.select(_.value.source))
-      .flatMap { sourceAndFacts =>
-        val facts = sourceAndFacts.getFoldable(_.at(Nat._1))
-        val latestFactTags = facts.sorted.headOption.toSet.flatMap(_.getFoldable(_.select(_.value.tags)))
-        latestFactTags.to(View)
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
+
+    "create a map from a converting a list of facts to tuples" in {
+      val query = valuesOfType(FactTypes.TagsUpdate).map { update =>
+        wrap(
+          update.get(_.select(_.source)).returnOutput,
+          update.get(_.select(_.tags)).returnOutput,
+        ).asTuple.withOutputValue
+      }.toMap
+      val expected = User1.factTable
+        .getSortedSeq(FactTypes.TagsUpdate)
+        .map { fact =>
+          (fact.value.source, fact.value.tags)
+        }
+        .toMap
+      val result = engine.evalAndExtractValue(query, User1.factTable)
+      assertResult(expected) {
+        result.toMap
       }
-    val expected = User1.factTable.getSortedSeq(FactTypes.TagsUpdate).groupBy(_.value.source).view.flatMap {
-      case (_, facts) =>
-        facts.map(_.value).sorted.headOption.toList.flatMap(_.tags)
     }
-    val result = eval(User1.factTable)(query)
-    assertResult(expected.toVector) {
-      result.output.value.toVector
+
+    "create a set from a list using groupBy, flatMap, sorted, and headOption" in {
+      val query = factsOfType(FactTypes.TagsUpdate)
+        .groupBy(_.select(_.value.source))
+        .flatMap { sourceAndFacts =>
+          val facts = sourceAndFacts.getFoldable(_.at(Nat._1))
+          val latestFactTags = facts.sorted.headOption.toSet.flatMap(_.getFoldable(_.select(_.value.tags)))
+          latestFactTags.to(View)
+        }
+      val expected = User1.factTable.getSortedSeq(FactTypes.TagsUpdate).groupBy(_.value.source).view.flatMap {
+        case (_, facts) =>
+          facts.map(_.value).sorted.headOption.toList.flatMap(_.tags)
+      }
+      val result = engine.evalAndExtractValue(query, User1.factTable)
+      assertResult(expected.toVector) {
+        result.toVector
+      }
     }
   }
 }

--- a/core/src/test/scala/vapors/interpreter/SortOutputSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/SortOutputSpec.scala
@@ -14,6 +14,22 @@ class SortOutputSpec extends AnyFreeSpec {
 
   "Expr.SortOutput" - {
 
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
+    }
+
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
+    }
+  }
+
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
+
     val bpNow = Instant.now()
     val bp5MinAgo = bpNow.minusSeconds(5 * 60)
     val bp15MinAgo = bpNow.minusSeconds(15 * 60)
@@ -34,9 +50,9 @@ class SortOutputSpec extends AnyFreeSpec {
       assertResult(Some(highDiastolic)) {
         bpFacts.getSortedSeq(FactTypes.BloodPressureMeasurement).headOption.map(_.value)
       }
-      val result = eval(bpFacts)(query)
+      val result = engine.evalAndExtractValue(query, bpFacts)
       assertResult(lowDiastolic.diastolic) {
-        result.output.value.head
+        result.head
       }
     }
 
@@ -45,9 +61,9 @@ class SortOutputSpec extends AnyFreeSpec {
       assertResult(Some(highDiastolic)) {
         bpFacts.getSortedSeq(FactTypes.BloodPressureMeasurement).headOption.map(_.value)
       }
-      val result = eval(bpFacts)(query)
+      val result = engine.evalAndExtractValue(query, bpFacts)
       assertResult(lowDiastolic) {
-        result.output.value.head
+        result.head
       }
     }
   }

--- a/core/src/test/scala/vapors/interpreter/StandardVaporsEngineSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/StandardVaporsEngineSpec.scala
@@ -6,19 +6,19 @@ import vapors.data.Evidence
 import vapors.dsl._
 import vapors.example.{FactTypes, JoeSchmoe}
 
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class InterpretExprAsResultFnSpec extends AnyWordSpec {
+class StandardVaporsEngineSpec extends AnyFreeSpec {
 
-  "InterpretExprAsFunction" when {
+  "StandardVaporsEngine" - {
 
-    "using no post processing" should {
+    "using no post processing" - {
 
       "find a single fact from a query" in {
         val q = valuesOfType(FactTypes.Age).exists {
-          _ >= 18
+          _ >= const(18)
         }
-        val result = eval(JoeSchmoe.factTable)(q)
+        val result = StandardVaporsEngine.eval(q, JoeSchmoe.factTable).result
         assert(result.param.value === ())
         assert(result.output.value)
         assert(result.output.evidence.nonEmpty)
@@ -26,22 +26,12 @@ class InterpretExprAsResultFnSpec extends AnyWordSpec {
       }
 
       "find a complex fact from a query" in {
-        val q = valuesOfType(FactTypes.ProbabilityToUse).exists {
-          _.getFoldable(_.select(_.scores).at("weightloss")).exists {
-            _ > 0.5
-          }
-        }
-        val result = eval(JoeSchmoe.factTable)(q)
-        assertResult(Evidence(JoeSchmoe.probs))(result.output.evidence)
-      }
-
-      "define a fact expression" in {
         val likelyToJoinWeightloss = valuesOfType(FactTypes.ProbabilityToUse).exists {
           _.getFoldable(_.select(_.scores).at("weightloss")).exists {
-            _ > 0.5
+            _ > const(0.5)
           }
         }
-        val result = eval(JoeSchmoe.factTable)(likelyToJoinWeightloss)
+        val result = StandardVaporsEngine.eval(likelyToJoinWeightloss, JoeSchmoe.factTable).result
         assertResult(Evidence(JoeSchmoe.probs))(result.output.evidence)
       }
     }

--- a/core/src/test/scala/vapors/interpreter/SubtractOutputsSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/SubtractOutputsSpec.scala
@@ -10,26 +10,45 @@ class SubtractOutputsSpec extends AnyFreeSpec {
 
   "Expr.SubtractOutputs" - {
 
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
+    }
+
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
+    }
+  }
+
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
+
     "Int" - {
 
       "expression subtracted by an expression" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Int, Int, Int, ArithmeticException](
           _ - _,
           const(_) - const(_),
+          engine,
         )
       }
 
       "expression subtracted by a value" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Int, Int, Int, ArithmeticException](
           _ - _,
           const(_) - _,
+          engine,
         )
       }
 
       "value subtracted by an expression" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Int, Int, Int, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Int, Int, Int, ArithmeticException](
           (a, b) => b - a,
           const(_).subtractFrom(_),
+          engine,
         )
       }
     }
@@ -37,23 +56,26 @@ class SubtractOutputsSpec extends AnyFreeSpec {
     "Double" - {
 
       "expression subtracted by an expression" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Double, Double, Double, ArithmeticException](
           _ - _,
           const(_) - const(_),
+          engine,
         )
       }
 
       "expression subtracted by a value" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Double, Double, Double, ArithmeticException](
           _ - _,
           const(_) - _,
+          engine,
         )
       }
 
       "value subtracted by an expression" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Double, Double, Double, ArithmeticException](
+        VaporsEvalTestHelpers.producesTheSameResultOrException[F, Double, Double, Double, ArithmeticException](
           (a, b) => b - a,
           const(_).subtractFrom(_),
+          engine,
         )
       }
     }

--- a/core/src/test/scala/vapors/interpreter/TakeFromOutputSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/TakeFromOutputSpec.scala
@@ -6,81 +6,98 @@ import vapors.data.FactTable
 import vapors.dsl._
 import vapors.example.{FactTypes, TagsUpdate}
 
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 import java.time.Instant
 
-class TakeFromOutputSpec extends AnyWordSpec {
+class TakeFromOutputSpec extends AnyFreeSpec {
 
-  "Expr.TakeFromOutput" when {
+  "Expr.TakeFromOutput" - {
+
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
+    }
+
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
+    }
+  }
+
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
+
     val now = Instant.now()
     val updateABC =
       FactTypes.TagsUpdate(TagsUpdate("ABC", Set("A", "B", "C"), now.minusSeconds(60 * 60 * 24)))
     val updateDEF = FactTypes.TagsUpdate(TagsUpdate("DEF", Set("D", "E", "F"), now))
 
-    "using .take(n) with a positive number" should {
+    "using .take(n) with a positive number" - {
 
       "return an empty list if the collection is empty" in {
         val q = factsOfType(FactTypes.TagsUpdate).take(1)
-        val res = eval(FactTable.empty)(q)
-        assert(res.output.value.isEmpty)
+        val res = engine.evalAndExtractValue(q)
+        assert(res.isEmpty)
       }
 
       "return the number of elements selected from the start of the list by fact ordering" in {
         val q = factsOfType(FactTypes.TagsUpdate).take(1)
-        val res = eval(FactTable(updateABC, updateDEF))(q)
-        assertResult(Seq(updateDEF))(res.output.value)
+        val res = engine.evalAndExtractValue(q, FactTable(updateABC, updateDEF))
+        assertResult(Seq(updateDEF))(res)
       }
 
       "return all the elements of the list by fact ordering when the number requested is greater than the size" in {
         val q = factsOfType(FactTypes.TagsUpdate).take(3)
-        val res = eval(FactTable(updateABC, updateDEF))(q)
-        assertResult(Seq(updateDEF, updateABC))(res.output.value)
+        val res = engine.evalAndExtractValue(q, FactTable(updateABC, updateDEF))
+        assertResult(Seq(updateDEF, updateABC))(res)
       }
     }
 
-    "using .take(n) with a negative number" should {
+    "using .take(n) with a negative number" - {
 
       "return an empty list if the collection is empty" in {
         val q = factsOfType(FactTypes.TagsUpdate).take(-1)
-        val res = eval(FactTable.empty)(q)
-        assert(res.output.value.isEmpty)
+        val res = engine.evalAndExtractValue(q)
+        assert(res.isEmpty)
       }
 
       "return the number of elements selected from the end of the list by fact ordering" in {
         val q = factsOfType(FactTypes.TagsUpdate).take(-1)
-        val res = eval(FactTable(updateABC, updateDEF))(q)
-        assertResult(Seq(updateABC))(res.output.value)
+        val res = engine.evalAndExtractValue(q, FactTable(updateABC, updateDEF))
+        assertResult(Seq(updateABC))(res)
       }
 
       "return all the elements of the list by fact ordering when the number requested is greater than the size" in {
         val q = factsOfType(FactTypes.TagsUpdate).take(-3)
-        val res = eval(FactTable(updateABC, updateDEF))(q)
-        assertResult(Seq(updateDEF, updateABC))(res.output.value)
+        val res = engine.evalAndExtractValue(q, FactTable(updateABC, updateDEF))
+        assertResult(Seq(updateDEF, updateABC))(res)
       }
     }
 
-    "using .take(n) with 0" should {
+    "using .take(n) with 0" - {
 
       "return an empty collection" in {
         val q = factsOfType(FactTypes.TagsUpdate).take(0)
-        val res = eval(FactTable(updateABC, updateDEF))(q)
-        assertResult(Seq.empty)(res.output.value)
+        val res = engine.evalAndExtractValue(q, FactTable(updateABC, updateDEF))
+        assertResult(Seq.empty)(res)
       }
     }
 
-    "using .headOption" should {
+    "using .headOption" - {
 
       "return None if the collection is empty" in {
         val q = factsOfType(FactTypes.TagsUpdate).headOption
-        val res = eval(FactTable.empty)(q)
-        assertResult(None)(res.output.value)
+        val res = engine.evalAndExtractValue(q)
+        assertResult(None)(res)
       }
 
       "return the head of the collection by fact ordering" in {
         val q = factsOfType(FactTypes.TagsUpdate).headOption
-        val res = eval(FactTable(updateABC, updateDEF))(q)
-        assertResult(Some(updateDEF))(res.output.value)
+        val res = engine.evalAndExtractValue(q, FactTable(updateABC, updateDEF))
+        assertResult(Some(updateDEF))(res)
       }
     }
   }

--- a/core/src/test/scala/vapors/interpreter/TimeFunctionsSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/TimeFunctionsSpec.scala
@@ -15,189 +15,222 @@ import java.time._
 import java.time.temporal.ChronoUnit
 
 class TimeFunctionsSpec extends AnyFreeSpec {
+
   import TimeFunctionsSpec._
 
-  "dateAdd" - {
+  "datetime functions" - {
 
-    "Instant with" - {
-
-      "Duration works the same as .plus" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[Instant, Duration, Instant, DateTimeException](
-          _.plus(_),
-          (t, d) => dateAdd(const(t), const(d)),
-        )
-      }
-
-      "Period fails to compile" in {
-        val now = Instant.now()
-        val period = Period.ofYears(1)
-        assertDoesNotCompile {
-          "dateAdd(const(now), const(period))"
-        }
-        assertThrows[DateTimeException] {
-          now.plus(period)
-        }
-      }
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
     }
 
-    "LocalDate with" - {
-
-      "Duration fails to compile" in {
-        val today = LocalDate.now()
-        val duration = Duration.ofSeconds(10)
-        assertDoesNotCompile {
-          "dateAdd(const(today), const(duration))"
-        }
-        assertThrows[DateTimeException] {
-          today.plus(duration)
-        }
-      }
-
-      "Period works the same as .plus" in {
-        VaporsEvalTestHelpers.producesTheSameResultOrException[LocalDate, Period, LocalDate, DateTimeException](
-          _.plus(_),
-          (t, d) => dateAdd(const(t), const(d)),
-        )
-      }
-    }
-
-    "LocalDateTime with" - {
-
-      "Duration works the same as .plus" in {
-        VaporsEvalTestHelpers
-          .producesTheSameResultOrException[LocalDateTime, Duration, LocalDateTime, DateTimeException](
-            _.plus(_),
-            (t, d) => dateAdd(const(t), const(d)),
-          )
-      }
-
-      "Period works the same as .plus" in {
-        VaporsEvalTestHelpers
-          .producesTheSameResultOrException[LocalDateTime, Period, LocalDateTime, DateTimeException](
-            _.plus(_),
-            (t, d) => dateAdd(const(t), const(d)),
-          )
-      }
-    }
-
-    "ZonedDateTime with" - {
-
-      "Duration works the same as .plus" in {
-        VaporsEvalTestHelpers
-          .producesTheSameResultOrException[ZonedDateTime, Duration, ZonedDateTime, DateTimeException](
-            _.plus(_),
-            (t, d) => dateAdd(const(t), const(d)),
-          )
-      }
-
-      "Period works the same as .plus" in {
-        VaporsEvalTestHelpers
-          .producesTheSameResultOrException[ZonedDateTime, Period, ZonedDateTime, DateTimeException](
-            _.plus(_),
-            (t, d) => dateAdd(const(t), const(d)),
-          )
-      }
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
     }
   }
 
-  "dateDiff" - {
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
 
-    "computing Age from DateOfBirth" - {
+    "dateAdd" - {
 
-      val feb28Year2021 = LocalDate.of(2021, 2, 28)
-      val onFeb28Year2021 = new Snippets(feb28Year2021)
+      "Instant with" - {
 
-      // leap year
-      val feb29Year2020 = LocalDate.of(2020, 2, 29)
-      val onFeb29Year2020 = new Snippets(feb29Year2020)
-
-      "rounds the year down" in {
-        val feb1Minus20Years = LocalDate.of(feb28Year2021.getYear - 20, 2, 1)
-        // validate that it works outside of vapors
-        assertResult(20) {
-          feb1Minus20Years.until(feb28Year2021, ChronoUnit.YEARS)
+        "Duration works the same as .plus" in {
+          VaporsEvalTestHelpers.producesTheSameResultOrException[F, Instant, Duration, Instant, DateTimeException](
+            _.plus(_),
+            (t, d) => dateAdd(const(t), const(d)),
+            engine,
+          )
         }
-        // validate that it works inside of vapors
-        val result = eval(FactTable(FactTypes.DateOfBirth(feb1Minus20Years))) {
-          onFeb28Year2021.ageFromDateOfBirth
-        }
-        assertResult(Seq(20)) { // Just turned 20 this month
-          result.output.value
+
+        "Period fails to compile" in {
+          val now = Instant.now()
+          val period = Period.ofYears(1)
+          assertDoesNotCompile {
+            "dateAdd(const(now), const(period))"
+          }
+          assertThrows[DateTimeException] {
+            now.plus(period)
+          }
         }
       }
 
-      "rounds the year down, even when close" in {
-        val feb29Year2000 = feb28Year2021.minusYears(21).plusDays(1)
-        // validate that it works outside of vapors
-        assertResult(20) {
-          feb29Year2000.until(feb28Year2021, ChronoUnit.YEARS)
+      "LocalDate with" - {
+
+        "Duration fails to compile" in {
+          val today = LocalDate.now()
+          val duration = Duration.ofSeconds(10)
+          assertDoesNotCompile {
+            "dateAdd(const(today), const(duration))"
+          }
+          assertThrows[DateTimeException] {
+            today.plus(duration)
+          }
         }
-        // validate that it works inside of vapors
-        val result = eval(FactTable(FactTypes.DateOfBirth(feb29Year2000))) {
-          onFeb28Year2021.ageFromDateOfBirth
-        }
-        assertResult(Seq(20)) { // Sorry, birthday is tomorrow
-          result.output.value
+
+        "Period works the same as .plus" in {
+          VaporsEvalTestHelpers.producesTheSameResultOrException[F, LocalDate, Period, LocalDate, DateTimeException](
+            _.plus(_),
+            (t, d) => dateAdd(const(t), const(d)),
+            engine,
+          )
         }
       }
 
-      "counts the current year on their birthday" in {
-        val feb28Year2000 = feb28Year2021.minusYears(21)
-        // validate that it works outside of vapors
-        assertResult(21) {
-          feb28Year2000.until(feb28Year2021, ChronoUnit.YEARS)
+      "LocalDateTime with" - {
+
+        "Duration works the same as .plus" in {
+          VaporsEvalTestHelpers
+            .producesTheSameResultOrException[F, LocalDateTime, Duration, LocalDateTime, DateTimeException](
+              _.plus(_),
+              (t, d) => dateAdd(const(t), const(d)),
+              engine,
+            )
         }
-        // validate that it works inside of vapors
-        val result = eval(FactTable(FactTypes.DateOfBirth(feb28Year2000))) {
-          onFeb28Year2021.ageFromDateOfBirth
-        }
-        assertResult(Seq(21)) { // 🎉 happy birthday! 🍻
-          result.output.value
+
+        "Period works the same as .plus" in {
+          VaporsEvalTestHelpers
+            .producesTheSameResultOrException[F, LocalDateTime, Period, LocalDateTime, DateTimeException](
+              _.plus(_),
+              (t, d) => dateAdd(const(t), const(d)),
+              engine,
+            )
         }
       }
 
-      "returns the correct number of years between leap years" in {
-        val feb29Year2000 = LocalDate.of(2000, 2, 29)
-        // validate that it works outside of vapors
-        assertResult(20) {
-          feb29Year2000.until(feb29Year2020, ChronoUnit.YEARS)
+      "ZonedDateTime with" - {
+
+        "Duration works the same as .plus" in {
+          VaporsEvalTestHelpers
+            .producesTheSameResultOrException[F, ZonedDateTime, Duration, ZonedDateTime, DateTimeException](
+              _.plus(_),
+              (t, d) => dateAdd(const(t), const(d)),
+              engine,
+            )
         }
-        // validate that it works inside of vapors
-        val result = eval(FactTable(FactTypes.DateOfBirth(feb29Year2000))) {
-          new Snippets(feb29Year2020).ageFromDateOfBirth
-        }
-        assertResult(Seq(20)) { // leap years work as expected
-          result.output.value
+
+        "Period works the same as .plus" in {
+          VaporsEvalTestHelpers
+            .producesTheSameResultOrException[F, ZonedDateTime, Period, ZonedDateTime, DateTimeException](
+              _.plus(_),
+              (t, d) => dateAdd(const(t), const(d)),
+              engine,
+            )
         }
       }
+    }
 
-      "returns the correct number of years on a leap year" in {
-        val mar1Year1999 = LocalDate.of(1999, 3, 1)
-        // validate that it works outside of vapors
-        assertResult(20) {
-          mar1Year1999.until(feb29Year2020, ChronoUnit.YEARS)
-        }
-        // validate that it works inside of vapors
-        val result = eval(FactTable(FactTypes.DateOfBirth(mar1Year1999))) {
-          onFeb29Year2020.ageFromDateOfBirth
-        }
-        assertResult(Seq(20)) {
-          result.output.value
-        }
-      }
+    "dateDiff" - {
 
-      "returns the correct number of years from a leap year birthday" in {
-        val feb29Year2000 = LocalDate.of(2000, 2, 29)
-        // validate that it works outside of vapors
-        assertResult(20) {
-          feb29Year2000.until(feb28Year2021, ChronoUnit.YEARS)
+      "computing Age from DateOfBirth" - {
+
+        val feb28Year2021 = LocalDate.of(2021, 2, 28)
+        val onFeb28Year2021 = new Snippets(feb28Year2021)
+
+        // leap year
+        val feb29Year2020 = LocalDate.of(2020, 2, 29)
+        val onFeb29Year2020 = new Snippets(feb29Year2020)
+
+        "rounds the year down" in {
+          val feb1Minus20Years = LocalDate.of(feb28Year2021.getYear - 20, 2, 1)
+          // validate that it works outside of vapors
+          assertResult(20) {
+            feb1Minus20Years.until(feb28Year2021, ChronoUnit.YEARS)
+          }
+          // validate that it works inside of vapors
+          val result = engine.evalAndExtractValue(
+            onFeb28Year2021.ageFromDateOfBirth,
+            FactTable(FactTypes.DateOfBirth(feb1Minus20Years)),
+          )
+          assertResult(Seq(20)) { // Just turned 20 this month
+            result
+          }
         }
-        // validate that it works inside of vapors
-        val result = eval(FactTable(FactTypes.DateOfBirth(feb29Year2000))) {
-          onFeb28Year2021.ageFromDateOfBirth
+
+        "rounds the year down, even when close" in {
+          val feb29Year2000 = feb28Year2021.minusYears(21).plusDays(1)
+          // validate that it works outside of vapors
+          assertResult(20) {
+            feb29Year2000.until(feb28Year2021, ChronoUnit.YEARS)
+          }
+          // validate that it works inside of vapors
+          val result = engine.evalAndExtractValue(
+            onFeb28Year2021.ageFromDateOfBirth,
+            FactTable(FactTypes.DateOfBirth(feb29Year2000)),
+          )
+          assertResult(Seq(20)) { // Sorry, birthday is tomorrow
+            result
+          }
         }
-        assertResult(Seq(20)) {
-          result.output.value
+
+        "counts the current year on their birthday" in {
+          val feb28Year2000 = feb28Year2021.minusYears(21)
+          // validate that it works outside of vapors
+          assertResult(21) {
+            feb28Year2000.until(feb28Year2021, ChronoUnit.YEARS)
+          }
+          // validate that it works inside of vapors
+          val result = engine.evalAndExtractValue(
+            onFeb28Year2021.ageFromDateOfBirth,
+            FactTable(FactTypes.DateOfBirth(feb28Year2000)),
+          )
+          assertResult(Seq(21)) { // 🎉 happy birthday! 🍻
+            result
+          }
+        }
+
+        "returns the correct number of years between leap years" in {
+          val feb29Year2000 = LocalDate.of(2000, 2, 29)
+          // validate that it works outside of vapors
+          assertResult(20) {
+            feb29Year2000.until(feb29Year2020, ChronoUnit.YEARS)
+          }
+          // validate that it works inside of vapors
+          val result = engine.evalAndExtractValue(
+            new Snippets(feb29Year2020).ageFromDateOfBirth,
+            FactTable(FactTypes.DateOfBirth(feb29Year2000)),
+          )
+          assertResult(Seq(20)) { // leap years work as expected
+            result
+          }
+        }
+
+        "returns the correct number of years on a leap year" in {
+          val mar1Year1999 = LocalDate.of(1999, 3, 1)
+          // validate that it works outside of vapors
+          assertResult(20) {
+            mar1Year1999.until(feb29Year2020, ChronoUnit.YEARS)
+          }
+          // validate that it works inside of vapors
+          val result =
+            engine.evalAndExtractValue(
+              onFeb29Year2020.ageFromDateOfBirth,
+              FactTable(FactTypes.DateOfBirth(mar1Year1999)),
+            )
+          assertResult(Seq(20)) {
+            result
+          }
+        }
+
+        "returns the correct number of years from a leap year birthday" in {
+          val feb29Year2000 = LocalDate.of(2000, 2, 29)
+          // validate that it works outside of vapors
+          assertResult(20) {
+            feb29Year2000.until(feb28Year2021, ChronoUnit.YEARS)
+          }
+          // validate that it works inside of vapors
+          val result = engine.evalAndExtractValue(
+            onFeb28Year2021.ageFromDateOfBirth,
+            FactTable(FactTypes.DateOfBirth(feb29Year2000)),
+          )
+          assertResult(Seq(20)) {
+            result
+          }
         }
       }
     }

--- a/core/src/test/scala/vapors/interpreter/WrapOutputHListSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/WrapOutputHListSpec.scala
@@ -11,73 +11,99 @@ import shapeless.HNil
 
 class WrapOutputHListSpec extends AnyFreeSpec {
 
-  import vapors.example.SimpleTagUpdates._
+  "Expr.WrapOutputHList" - {
 
-  "wrap, when given const nodes, should" - {
-
-    "convert to a case class with the correct number of inputs" in {
-      val query = {
-        wrap(const(tagsNow.source), const(tagsNow.tags), const(tagsNow.timestamp)).as[TagsUpdate]
-      }
-      val result = eval(FactTable.empty)(query)
-      assertResult(tagsNow)(result.output.value)
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
     }
 
-    "NOT compile when attempting to convert fewer inputs than required into a case class" in {
-      assertDoesNotCompile {
-        "wrap(const(tagsNow.tags)).as[TagsUpdate]"
-      }
-    }
-
-    "NOT compile when attempting to convert inputs into a case class in the wrong order" in {
-      assertDoesNotCompile {
-        "wrap(const(tagsNow.tags), const(tagsNow.timestamp), const(tagsNow.source)).as[TagsUpdate]"
-      }
-    }
-
-    "convert into a tuple-3" in {
-      val t = (1, "two", ColorCoding.Blue)
-      val query = {
-        wrap(const(t._1), const(t._2), const(t._3)).asTuple
-      }
-      val result = eval(FactTable.empty)(query)
-      assertResult(t)(result.output.value)
-    }
-
-    "convert into an hlist of size 3" in {
-      val hlist = 1 :: "two" :: ColorCoding.Blue :: HNil
-      val t = hlist.tupled
-      val query = {
-        wrap(const(t._1), const(t._2), const(t._3)).asHList
-      }
-      val result = eval(FactTable.empty)(query)
-      assertResult(hlist)(result.output.value)
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
     }
   }
 
-  "wrap, when comparing evidence, should" - {
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
+    import vapors.example.SimpleTagUpdates._
 
-    "combine all non-empty evidence" in {
-      val query = {
-        wrap(
-          factsOfType(FactTypes.Name).headOption,
-          factsOfType(FactTypes.Age).headOption,
-        ).asHList
+    "wrap, when given const nodes, should" - {
+
+      "convert to a case class with the correct number of inputs" in {
+        val query = {
+          wrap(const(tagsNow.source), const(tagsNow.tags), const(tagsNow.timestamp)).as[TagsUpdate]
+        }
+        val result = engine.evalAndExtractValue(query)
+        assertResult(tagsNow)(result)
       }
-      val facts = List(JoeSchmoe.name, JoeSchmoe.age)
-      val result = eval(FactTable(facts))(query)
-      assertResult(Evidence(facts))(result.output.evidence)
+
+      "NOT compile when attempting to convert fewer inputs than required into a case class" in {
+        assertDoesNotCompile {
+          "wrap(const(tagsNow.tags)).as[TagsUpdate]"
+        }
+      }
+
+      "NOT compile when attempting to convert inputs into a case class in the wrong order" in {
+        assertDoesNotCompile {
+          "wrap(const(tagsNow.tags), const(tagsNow.timestamp), const(tagsNow.source)).as[TagsUpdate]"
+        }
+      }
+
+      "convert into a tuple-3" in {
+        val t = (1, "two", ColorCoding.Blue)
+        val query = {
+          wrap(const(t._1), const(t._2), const(t._3)).asTuple
+        }
+        val result = engine.evalAndExtractValue(query)
+        assertResult(t)(result)
+      }
+
+      "convert into an hlist of size 3" in {
+        val hlist = 1 :: "two" :: ColorCoding.Blue :: HNil
+        val t = hlist.tupled
+        val query = {
+          wrap(const(t._1), const(t._2), const(t._3)).asHList
+        }
+        val result = engine.evalAndExtractValue(query)
+        assertResult(hlist)(result)
+      }
     }
 
-    "return no evidence if any branch has no evidence" in {
-      val query = {
-        wrap(
-          factsOfType(FactTypes.Name).headOption,
-          factsOfType(FactTypes.Age).headOption,
-        ).asHList
+    "wrap, when comparing evidence, should" - {
+
+      "combine all non-empty evidence" in {
+        val query = {
+          wrap(
+            factsOfType(FactTypes.Name).headOption,
+            factsOfType(FactTypes.Age).headOption,
+          ).asHList
+        }
+        val facts = List(JoeSchmoe.name, JoeSchmoe.age)
+        val result = engine.eval(query, FactTable(facts))
+        for (evidence <- result.maybeEvidence) {
+          assertResult(Evidence(facts)) {
+            engine.extract(evidence)
+          }
+        }
       }
-      val result = eval(FactTable(JoeSchmoe.name))(query)
-      assertResult(Evidence.none)(result.output.evidence)
+
+      "return no evidence if any branch has no evidence" in {
+        val query = {
+          wrap(
+            factsOfType(FactTypes.Name).headOption,
+            factsOfType(FactTypes.Age).headOption,
+          ).asHList
+        }
+        val result = engine.eval(query, FactTable(JoeSchmoe.name))
+        for (evidence <- result.maybeEvidence) {
+          assertResult(Evidence.none) {
+            engine.extract(evidence)
+          }
+        }
+      }
     }
   }
 

--- a/core/src/test/scala/vapors/interpreter/WrapOutputSeqSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/WrapOutputSeqSpec.scala
@@ -11,53 +11,75 @@ import org.scalatest.freespec.AnyFreeSpec
 
 class WrapOutputSeqSpec extends AnyFreeSpec {
 
-  "wrapSeq / sequence should" - {
+  "Expr.WrapOutputSeq" - {
 
-    "wrap a list of constant expressions into an expression of a list of the values" in {
-      val query = wrapSeq(
-        const(1),
-        const(2),
-        const(3),
-      )
-      val result = eval(FactTable.empty)(query)
-      assertResult(Seq(1, 2, 3)) {
-        result.output.value
-      }
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
     }
 
-    "not force the resulting lazy list" in {
-      val query = wrapSeq(
-        const(1),
-        const(2),
-        const(3),
-      )
-      val result = eval(FactTable.empty)(query)
-      inside(result.output.value) {
-        case values: LazyList[_] =>
-          // confirm that the collection does not start with a definite size because it was unforced
-          assert(!values.hasDefiniteSize)
-          // confirm that forcing the collection causes it to have a definite size
-          assert(values.force.hasDefiniteSize)
-      }
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
     }
+  }
 
-    "wrap a list of expressions and combine the evidence from all of them" in {
-      val factTypes = List[FactType[_ <: HasTimestamp]](
-        FactTypes.BloodPressureMeasurement,
-        FactTypes.WeightSelfReported,
-        FactTypes.TagsUpdate,
-      )
-      val subExpressions =
-        factTypes.map(t => valuesOfType(t).map(_.get(_.select(_.timestamp))).returnOutput)
-      val query = sequence(subExpressions)
-      val factsPerType = factTypes.map(JoeSchmoe.factTable.getSortedSeq(_))
-      val expectedValues = factsPerType.map(_.map(_.value.timestamp))
-      val result = eval(JoeSchmoe.factTable)(query)
-      assertResult(expectedValues) {
-        result.output.value
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
+
+    "wrapSeq / sequence should" - {
+
+      "wrap a list of constant expressions into an expression of a list of the values" in {
+        val query = wrapSeq(
+          const(1),
+          const(2),
+          const(3),
+        )
+        val result = engine.evalAndExtractValue(query)
+        assertResult(Seq(1, 2, 3)) {
+          result
+        }
       }
-      assertResult(Evidence(factsPerType.flatten)) {
-        result.output.evidence
+
+      "not force the resulting lazy list" in {
+        val query = wrapSeq(
+          const(1),
+          const(2),
+          const(3),
+        )
+        val result = engine.evalAndExtractValue(query)
+        inside(result) {
+          case values: LazyList[_] =>
+            // confirm that the collection does not start with a definite size because it was unforced
+            assert(!values.hasDefiniteSize)
+            // confirm that forcing the collection causes it to have a definite size
+            assert(values.force.hasDefiniteSize)
+        }
+      }
+
+      "wrap a list of expressions and combine the evidence from all of them" in {
+        val factTypes = List[FactType[_ <: HasTimestamp]](
+          FactTypes.BloodPressureMeasurement,
+          FactTypes.WeightSelfReported,
+          FactTypes.TagsUpdate,
+        )
+        val subExpressions =
+          factTypes.map(t => valuesOfType(t).map(_.get(_.select(_.timestamp))).returnOutput)
+        val query = sequence(subExpressions)
+        val factsPerType = factTypes.map(JoeSchmoe.factTable.getSortedSeq(_))
+        val expectedValues = factsPerType.map(_.map(_.value.timestamp))
+        val result = engine.eval(query, JoeSchmoe.factTable)
+        val resultValue = engine.extract(result.value)
+        assertResult(expectedValues) {
+          resultValue
+        }
+        for (evidence <- result.maybeEvidence) {
+          assertResult(Evidence(factsPerType.flatten)) {
+            engine.extract(evidence)
+          }
+        }
       }
     }
   }

--- a/core/src/test/scala/vapors/interpreter/ZipOutputSpec.scala
+++ b/core/src/test/scala/vapors/interpreter/ZipOutputSpec.scala
@@ -13,134 +13,152 @@ import java.time.Instant
 
 class ZipOutputSpec extends AnyFreeSpec {
 
-  import vapors.example.SimpleTagUpdates._
+  "Expr.ZipOutput" - {
 
-  "zippedToShortest should" - {
-
-    "return a list as long as the shortest input list of" - {
-
-      "tuple values" in {
-        val query = wrapEach(
-          const(List("A", "B", "C")),
-          const(List(1, 2, 3, 4, 5)),
-        ).zippedToShortest.asTuple
-        val result = eval(FactTable.empty)(query)
-        assertResult(List(("A", 1), ("B", 2), ("C", 3))) {
-          result.output.value
-        }
-      }
-
-      "HList values" in {
-        val query = wrapEach(
-          const(List("A", "B", "C")),
-          const(List(1, 2, 3, 4, 5)),
-        ).zippedToShortest.asHList
-        val result = eval(FactTable.empty)(query)
-        assertResult(List("A" :: 1 :: HNil, "B" :: 2 :: HNil, "C" :: 3 :: HNil)) {
-          result.output.value
-        }
-      }
-
-      "case class values" in {
-        val query = wrapEach(
-          const(List(tagsNow, tags5MinAgo, tags15MinAgo).map(_.source)),
-          const(List(tagsNow, tags5MinAgo).map(_.tags)),
-          const(List(tagsNow, tags5MinAgo, tags15MinAgo).map(_.timestamp)),
-        ).zippedToShortest.as[TagsUpdate]
-        val result = eval(FactTable.empty)(query)
-        assertResult(List(tagsNow, tags5MinAgo)) {
-          result.output.value
-        }
-      }
+    "standard engine" - {
+      allTests(StandardVaporsEngine)
     }
 
-    "return nil when any input list is nil for" - {
-
-      "tuple values" in {
-        val query = wrapEach(
-          const(List("A", "B", "C")),
-          const(List.empty[Int]),
-        ).zippedToShortest.asTuple
-        val result = eval(FactTable.empty)(query)
-        assertResult(Nil) {
-          result.output.value
-        }
-      }
-
-      "HList values" in {
-        val query = wrapEach(
-          const(List.empty[String]),
-          const(List(1, 2, 3, 4, 5)),
-        ).zippedToShortest.asHList
-        val result = eval(FactTable.empty)(query)
-        assertResult(Nil) {
-          result.output.value
-        }
-      }
-
-      "case class values" in {
-        val query = wrapEach(
-          const(List(tagsNow).map(_.source)),
-          const(List(tagsNow, tags5MinAgo).map(_.tags)),
-          const(List.empty[Instant]),
-        ).zippedToShortest.asHList
-        val result = eval(FactTable.empty)(query)
-        assertResult(Nil) {
-          result.output.value
-        }
-      }
+    "cats effect engine" - {
+      import cats.effect.unsafe.implicits.global
+      allTests(CatsEffectSimpleVaporsEngine)
     }
+  }
 
-    "not force a LazyList when" - {
+  private def allTests[F[_]](
+    engine: VaporsEngine[F, Unit],
+  )(implicit
+    engineExtractParam: engine.ExtractParam,
+  ): Unit = {
+    import vapors.example.SimpleTagUpdates._
 
-      "taking the headOption" in {
-        val query = wrapEach(
-          const((tagsNow #:: fail("forced source") #:: LazyList.empty).map(_.source)),
-          const((tagsNow #:: fail("forced tags") #:: LazyList.empty).map(_.tags)),
-          const((tagsNow #:: fail("forced timestamp") #:: LazyList.empty).map(_.timestamp)),
-        ).zippedToShortest.as[TagsUpdate].withOutputFoldable.headOption
-        val result = eval(FactTable.empty)(query)
-        assertResult(Some(tagsNow)) {
-          result.output.value
+    "zippedToShortest should" - {
+
+      "return a list as long as the shortest input list of" - {
+
+        "tuple values" in {
+          val query = wrapEach(
+            const(List("A", "B", "C")),
+            const(List(1, 2, 3, 4, 5)),
+          ).zippedToShortest.asTuple
+          val result = engine.evalAndExtractValue(query)
+          assertResult(List(("A", 1), ("B", 2), ("C", 3))) {
+            result
+          }
+        }
+
+        "HList values" in {
+          val query = wrapEach(
+            const(List("A", "B", "C")),
+            const(List(1, 2, 3, 4, 5)),
+          ).zippedToShortest.asHList
+          val result = engine.evalAndExtractValue(query)
+          assertResult(List("A" :: 1 :: HNil, "B" :: 2 :: HNil, "C" :: 3 :: HNil)) {
+            result
+          }
+        }
+
+        "case class values" in {
+          val query = wrapEach(
+            const(List(tagsNow, tags5MinAgo, tags15MinAgo).map(_.source)),
+            const(List(tagsNow, tags5MinAgo).map(_.tags)),
+            const(List(tagsNow, tags5MinAgo, tags15MinAgo).map(_.timestamp)),
+          ).zippedToShortest.as[TagsUpdate]
+          val result = engine.evalAndExtractValue(query)
+          assertResult(List(tagsNow, tags5MinAgo)) {
+            result
+          }
         }
       }
-    }
 
-    "not compile when" - {
+      "return nil when any input list is nil for" - {
 
-      "given too many arguments for a case class" in {
-        assertDoesNotCompile {
-          """
-          wrapEach(
+        "tuple values" in {
+          val query = wrapEach(
+            const(List("A", "B", "C")),
+            const(List.empty[Int]),
+          ).zippedToShortest.asTuple
+          val result = engine.evalAndExtractValue(query)
+          assertResult(Nil) {
+            result
+          }
+        }
+
+        "HList values" in {
+          val query = wrapEach(
             const(List.empty[String]),
-            const(List.empty[Set[String]]),
+            const(List(1, 2, 3, 4, 5)),
+          ).zippedToShortest.asHList
+          val result = engine.evalAndExtractValue(query)
+          assertResult(Nil) {
+            result
+          }
+        }
+
+        "case class values" in {
+          val query = wrapEach(
+            const(List(tagsNow).map(_.source)),
+            const(List(tagsNow, tags5MinAgo).map(_.tags)),
             const(List.empty[Instant]),
-            const(List.empty[Int]), // too many
-          ).zippedToShortest.as[TagsUpdate]
-        """
+          ).zippedToShortest.asHList
+          val result = engine.evalAndExtractValue(query)
+          assertResult(Nil) {
+            result
+          }
         }
       }
 
-      "given too few arguments for a case class" in {
-        assertDoesNotCompile {
-          """
-          wrapEach(
-            const(List.empty[String]),
-            const(List.empty[Set[String]]),
-          ).zippedToShortest.as[TagsUpdate]
-        """
+      "not force a LazyList when" - {
+
+        "taking the headOption" in {
+          val query = wrapEach(
+            const((tagsNow #:: fail("forced source") #:: LazyList.empty).map(_.source)),
+            const((tagsNow #:: fail("forced tags") #:: LazyList.empty).map(_.tags)),
+            const((tagsNow #:: fail("forced timestamp") #:: LazyList.empty).map(_.timestamp)),
+          ).zippedToShortest.as[TagsUpdate].withOutputFoldable.headOption
+          val result = engine.evalAndExtractValue(query)
+          assertResult(Some(tagsNow)) {
+            result
+          }
         }
       }
 
-      "given arguments out of order for a case class" in {
-        assertDoesNotCompile {
-          """
-          wrapEach(
-            const(List.empty[Set[String]]),
-            const(List.empty[Instant]),
-            const(List.empty[String]),
-          ).zippedToShortest.as[TagsUpdate]
-        """
+      "not compile when" - {
+
+        "given too many arguments for a case class" in {
+          assertDoesNotCompile {
+            """
+              wrapEach(
+                const(List.empty[String]),
+                const(List.empty[Set[String]]),
+                const(List.empty[Instant]),
+                const(List.empty[Int]), // too many
+              ).zippedToShortest.as[TagsUpdate]
+            """
+          }
+        }
+
+        "given too few arguments for a case class" in {
+          assertDoesNotCompile {
+            """
+              wrapEach(
+                const(List.empty[String]),
+                const(List.empty[Set[String]]),
+              ).zippedToShortest.as[TagsUpdate]
+            """
+          }
+        }
+
+        "given arguments out of order for a case class" in {
+          assertDoesNotCompile {
+            """
+              wrapEach(
+                const(List.empty[Set[String]]),
+                const(List.empty[Instant]),
+                const(List.empty[String]),
+              ).zippedToShortest.as[TagsUpdate]
+            """
+          }
         }
       }
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,28 +4,20 @@ object Dependencies {
 
   final val Scala_2_13 = "2.13.6"
 
-  private final val catsVersion = "2.6.1"
-  private final val kindProjectorVersion = "0.13.0"
-  private final val scalaCheckVersion = "1.15.4"
-  private final val scalaCheckOpsVersion = "2.6.0"
-  private final val scalaTestVersion = "3.2.9"
-  private final val scalaTestPlusScalaCheckVersion = "3.2.9.0"
-  private final val shapelessVersion = "2.3.7"
-
-  private val alleyCatsCore = "org.typelevel" %% "alleycats-core" % catsVersion
-  private val catsCore = "org.typelevel" %% "cats-core" % catsVersion
-  private val catsFree = "org.typelevel" %% "cats-free" % catsVersion
-  private val scalaCheck = "org.scalacheck" %% "scalacheck" % scalaCheckVersion
-  private val scalaCheckOps = "com.rallyhealth" %% "scalacheck-ops_1-15" % scalaCheckOpsVersion
-  private val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion
-  private val scalaTestPlusScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % scalaTestPlusScalaCheckVersion
+  private val alleyCatsCore = "org.typelevel" %% "alleycats-core" % "2.6.1"
+  private val catsCore = "org.typelevel" %% "cats-core" % "2.6.1"
+  private val catsFree = "org.typelevel" %% "cats-free" % "2.6.1"
+  private val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.15.4"
+  private val scalaCheckOps = "com.rallyhealth" %% "scalacheck-ops_1-15" % "2.6.0"
+  private val scalaTest = "org.scalatest" %% "scalatest" % "3.2.9"
+  private val scalaTestPlusScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0"
   private def scalaReflect(scalacVersion: String): ModuleID = "org.scala-lang" % "scala-reflect" % scalacVersion
-  private val shapeless = "com.chuusai" %% "shapeless" % shapelessVersion
+  private val shapeless = "com.chuusai" %% "shapeless" % "2.3.7"
 
   final object Plugins {
 
     val kindProjector = {
-      compilerPlugin("org.typelevel" %% "kind-projector" % kindProjectorVersion).cross(CrossVersion.full)
+      compilerPlugin("org.typelevel" %% "kind-projector" % "0.13.0").cross(CrossVersion.full)
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   private val catsCore = "org.typelevel" %% "cats-core" % "2.6.1"
   private val catsFree = "org.typelevel" %% "cats-free" % "2.6.1"
   private val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.15.4"
-  private val scalaCheckOps = "com.rallyhealth" %% "scalacheck-ops_1-15" % "2.6.0"
+  private val scalaCheckOps = "com.rallyhealth" %% "scalacheck-ops_1-15" % "2.7.1"
   private val scalaTest = "org.scalatest" %% "scalatest" % "3.2.9"
   private val scalaTestPlusScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0"
   private def scalaReflect(scalacVersion: String): ModuleID = "org.scala-lang" % "scala-reflect" % scalacVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,10 @@ object Dependencies {
 
   private val alleyCatsCore = "org.typelevel" %% "alleycats-core" % "2.6.1"
   private val catsCore = "org.typelevel" %% "cats-core" % "2.6.1"
+  private val catsEffect = "org.typelevel" %% "cats-effect" % "3.2.2"
   private val catsFree = "org.typelevel" %% "cats-free" % "2.6.1"
+  private val munit = "org.scalameta" %% "munit" % "0.7.28"
+  private val munitCatsEffect = "org.typelevel" %% "munit-cats-effect-3" % "1.0.5"
   private val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.15.4"
   private val scalaCheckOps = "com.rallyhealth" %% "scalacheck-ops_1-15" % "2.7.1"
   private val scalaTest = "org.scalatest" %% "scalatest" % "3.2.9"
@@ -28,11 +31,14 @@ object Dependencies {
         Plugins.kindProjector,
         alleyCatsCore,
         catsCore,
+        catsEffect,
         catsFree,
         scalaReflect(scalaVersion),
         shapeless,
       ) ++ Seq(
         // Test-only dependencies
+        munit,
+        munitCatsEffect,
         scalaCheck,
         scalaCheckOps,
         scalaTest,


### PR DESCRIPTION
### Updates

* Allow semigroup definition for ExprOutput
* Inline dependencies versions for better IDE support
* Upgrade scalacheck-ops to 2.7.1
* Create faster InterpretExprAsSimpleCatsEffectValue interpreter
  - Uses Cats Effect 3
  - Avoids Evidence tracking
  - Returns result without evidence

### Work Remaining

- [x] Copy existing unit tests to support new result format
- [ ] ~~Add micro benchmark tests~~ (TODO in a follow-up PR)