### PR TITLE
Remove deprecated warnings from the arithmetic operators

### DIFF
--- a/core/src/main/scala/vapors/dsl/ExprBuilder.scala
+++ b/core/src/main/scala/vapors/dsl/ExprBuilder.scala
@@ -506,10 +506,6 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, R, P] =
     new ValExprBuilder(ExprDsl.add(returnOutput, rhs))
 
-  @deprecated(
-    "Use + const(...) instead. This overloaded convenience method will be removed to support better type inference",
-    "0.17.0",
-  )
   def +(
     rhs: R,
   )(implicit
@@ -534,10 +530,6 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, R, P] =
     new ValExprBuilder(ExprDsl.multiply(returnOutput, rhs))
 
-  @deprecated(
-    "Use * const(...) instead. This overloaded convenience method will be removed to support better type inference",
-    "0.17.0",
-  )
   def *(
     rhs: R,
   )(implicit
@@ -562,10 +554,6 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, R, P] =
     new ValExprBuilder(ExprDsl.subtract(returnOutput, rhs))
 
-  @deprecated(
-    "Use - const(...) instead. This overloaded convenience method will be removed to support better type inference",
-    "0.17.0",
-  )
   def -(
     rhs: R,
   )(implicit
@@ -590,10 +578,6 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, R, P] =
     new ValExprBuilder(ExprDsl.divide(returnOutput, rhs))
 
-  @deprecated(
-    "Use / const(...) instead. This overloaded convenience method will be removed to support better type inference",
-    "0.17.0",
-  )
   def /(
     rhs: R,
   )(implicit
@@ -646,10 +630,6 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, Boolean, P] =
     within(Window.equalTo(value))
 
-  @deprecated(
-    "Use === const(...) instead. This overloaded convenience method will be removed to support better type inference",
-    "0.17.0",
-  )
   def ===(
     value: R,
   )(implicit
@@ -669,10 +649,6 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, Boolean, P] =
     withinWindow(Expr.WrapOutput(valueExpr, ExprConverter.asWindow[R](Window.equalTo(_)), captureWindow))
 
-  @deprecated(
-    "Use !== const(...) instead. This overloaded convenience method will be removed to support better type inference",
-    "0.17.0",
-  )
   def !==(
     value: R,
   )(implicit
@@ -692,10 +668,6 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, Boolean, P] =
     Expr.Not(this === valueExpr, captureResult)
 
-  @deprecated(
-    "Use < const(...) instead. This overloaded convenience method will be removed to support better type inference",
-    "0.17.0",
-  )
   def <(
     value: R,
   )(implicit
@@ -715,10 +687,6 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, Boolean, P] =
     withinWindow(Expr.WrapOutput(valueExpr, ExprConverter.asWindow[R](Window.lessThan(_)), captureWindow))
 
-  @deprecated(
-    "Use <= const(...) instead. This overloaded convenience method will be removed to support better type inference",
-    "0.17.0",
-  )
   def <=(
     value: R,
   )(implicit
@@ -738,10 +706,6 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, Boolean, P] =
     withinWindow(Expr.WrapOutput(valueExpr, ExprConverter.asWindow[R](Window.lessThanOrEqual(_)), captureWindow))
 
-  @deprecated(
-    "Use > const(...) instead. This overloaded convenience method will be removed to support better type inference",
-    "0.17.0",
-  )
   def >(
     value: R,
   )(implicit
@@ -761,10 +725,6 @@ final class ValExprBuilder[V, R, P](override val returnOutput: Expr[V, R, P])
   ): ValExprBuilder[V, Boolean, P] =
     withinWindow(Expr.WrapOutput(valueExpr, ExprConverter.asWindow[R](Window.greaterThan(_)), captureWindow))
 
-  @deprecated(
-    "Use >= const(...) instead. This overloaded convenience method will be removed to support better type inference",
-    "0.17.0",
-  )
   def >=(
     value: R,
   )(implicit


### PR DESCRIPTION
I attempted to roll out the removal of the deprecated methods from https://github.com/jeffmay/vapors/pull/65 in the Rally code base and type inference was not improved by removing these methods. I have plans to improve type inference with a better DSL and algebra in the future, but for now, we should remove these deprecation warnings.