### PR TITLE
Add SimpleCachingEngine and create initial benchmark project for comparing performance

### DIFF
--- a/bench/src/test/scala/bench/FindInSeqOfTagsListsBenchmarkSetup.scala
+++ b/bench/src/test/scala/bench/FindInSeqOfTagsListsBenchmarkSetup.scala
@@ -1,0 +1,82 @@
+package com.rallyhealth.vapors
+
+package bench
+
+import bench.timeit.{Benchmark, BenchmarkConfig}
+import v1.data.FactTable
+import v1.dsl.simple.OP
+import v1.example.{CombinedTags, FactTypes}
+
+import org.scalacheck.Gen
+import org.scalacheck.ops._
+
+import scala.collection.immutable.SortedSet
+
+trait FindInSeqOfTagsListsBenchmarkSetup {
+  import FindInSeqOfTagsListsBenchmarkSetup._
+
+  protected def findInSeqOfTagsLists(setup: VaporsBenchmarkSetup[Params, Boolean, OP]): Benchmark[Params]
+
+  final lazy val benchmarkDefaultFindInSeqOfTagsLists: Benchmark[Params] =
+    findInSeqOfTagsLists(FindInSeqOfTagsListsBenchmarkSetup.setupDefaultFindInSeqOfTagsLists)
+
+  final lazy val benchmarkMultiFindInSeqOfTags: Seq[Benchmark[Params]] = Seq(
+    Params(1, 10, 10),
+    Params(2, 10, 10),
+    Params(3, 10, 10),
+    Params(4, 10, 10),
+    Params(5, 10, 10),
+    Params(6, 10, 10),
+    Params(7, 10, 10),
+    Params(8, 10, 10),
+    Params(9, 10, 10),
+    Params(10, 10, 10),
+  ).map { params =>
+    findInSeqOfTagsLists(setupFindInSeqOfTagsLists(params))
+  }
+}
+
+object FindInSeqOfTagsListsBenchmarkSetup {
+  import v1.dsl.simple._
+
+  final case class Params(
+    numExpressions: Int,
+    numTagFacts: Int,
+    numTagsPerFact: Int,
+  )
+
+  // TODO: Make number of runs configurable?
+  val setupDefaultFindInSeqOfTagsLists: VaporsBenchmarkSetup[Params, Boolean, OP] =
+    setupFindInSeqOfTagsLists(Params(30, 10, 50))
+
+  def setupFindInSeqOfTagsLists(
+    params: Params,
+  )(implicit
+    gc: GenConfig,
+  ): VaporsBenchmarkSetup[Params, Boolean, OP] = {
+    val expectedTag = "waldo"
+    val genTags = Gen.containerOfN[Set, String](params.numTagsPerFact, Gen.identifier)
+    val genTagSets = Gen.listOfN(params.numTagFacts, genTags)
+    val tagsetsWithoutExpected = genTagSets.head
+    val lastTagsetWithExpected = tagsetsWithoutExpected.head.drop(1) + expectedTag
+    val tagsetsWithExpected = lastTagsetWithExpected :: tagsetsWithoutExpected.tail
+    val facts = tagsetsWithExpected.zipWithIndex.map {
+      case (tagset, idx) =>
+        FactTypes.CombinedTags(CombinedTags(SortedSet.from(tagset), idx + 1))
+    }
+    VaporsBenchmarkSetup(
+      BenchmarkConfig(
+        s"[x${params.numExpressions}] find tag in ${params.numTagFacts} tag facts (${params.numTagsPerFact} tags each)",
+        params,
+      ),
+      FactTable(facts),
+    ).repeated(params.numExpressions) {
+        valuesOfType(FactTypes.CombinedTags).exists {
+          _.getAs[Seq](_.select(_.tags)).exists { tag =>
+            tag === expectedTag.const
+          }
+        }
+      }
+      .ensuringResultIsTrue
+  }
+}

--- a/bench/src/test/scala/bench/Main.scala
+++ b/bench/src/test/scala/bench/Main.scala
@@ -1,0 +1,28 @@
+package com.rallyhealth.vapors
+
+package bench
+
+import java.util.concurrent.TimeUnit
+
+object Main {
+
+  def main(args: Array[String]): Unit = {
+    val benchmarkMatrix =
+      SimpleWithCachingBenchmarks.benchmarkMultiFindInSeqOfTags ++ SimpleWithoutCachingBenchmarks.benchmarkMultiFindInSeqOfTags
+    println("Name,Exprs,Facts,Tags/Fact,Avg,StdDev")
+    val unit = TimeUnit.MICROSECONDS
+    for (benchmark <- benchmarkMatrix) {
+      val results = benchmark.run()
+      val p = benchmark.config.params
+      val row = (
+        benchmark.config.name.takeWhile(_ != ':'),
+        p.numExpressions,
+        p.numTagFacts,
+        p.numTagsPerFact,
+        results.durationAvg.toUnit(unit),
+        results.durationStdDev.toUnit(unit),
+      )
+      println(row.productIterator.mkString(","))
+    }
+  }
+}

--- a/bench/src/test/scala/bench/SimpleWithCachingBenchmarks.scala
+++ b/bench/src/test/scala/bench/SimpleWithCachingBenchmarks.scala
@@ -1,0 +1,18 @@
+package com.rallyhealth.vapors
+
+package bench
+
+import bench.timeit._
+import v1.engine.SimpleCachingEngine
+
+object SimpleWithCachingBenchmarks extends FindInSeqOfTagsListsBenchmarkSetup {
+  import FindInSeqOfTagsListsBenchmarkSetup.Params
+
+  import v1.dsl.simple._
+
+  override protected def findInSeqOfTagsLists(setup: VaporsBenchmarkSetup[Params, Boolean, OP]): Benchmark[Params] = {
+    Benchmark.create(setup.config.prefixName("with caching: ")) {
+      SimpleCachingEngine.evalMultiple(setup.expressions, setup.factTable).foreach(setup.ensureValidResult)
+    }
+  }
+}

--- a/bench/src/test/scala/bench/SimpleWithoutCachingBenchmarks.scala
+++ b/bench/src/test/scala/bench/SimpleWithoutCachingBenchmarks.scala
@@ -1,0 +1,19 @@
+package com.rallyhealth.vapors
+
+package bench
+
+import bench.timeit._
+
+object SimpleWithoutCachingBenchmarks extends FindInSeqOfTagsListsBenchmarkSetup {
+  import FindInSeqOfTagsListsBenchmarkSetup.Params
+
+  import v1.dsl.simple._
+
+  override protected def findInSeqOfTagsLists(setup: VaporsBenchmarkSetup[Params, Boolean, OP]): Benchmark[Params] = {
+    Benchmark.create(setup.config.prefixName("without caching: ")) {
+      setup.expressions.foreach { e =>
+        setup.ensureValidResult(e.run(setup.factTable))
+      }
+    }
+  }
+}

--- a/bench/src/test/scala/bench/VaporsBenchmarkSetup.scala
+++ b/bench/src/test/scala/bench/VaporsBenchmarkSetup.scala
@@ -1,0 +1,56 @@
+package com.rallyhealth.vapors
+
+package bench
+
+import bench.timeit.BenchmarkConfig
+import v1.algebra.Expr
+import v1.data.FactTable
+
+// TODO: Use type member?
+final class VaporsBenchmarkSetup[+P, R, OP[_]] private (
+  val config: BenchmarkConfig[P],
+  val factTable: FactTable,
+  val expressions: Seq[Expr[Any, R, OP]],
+  validateResult: R => Boolean,
+) {
+
+  def ensureValidResult(result: R): Unit = {
+    require(validateResult(result), s"Invalid result $result for benchmark: '${config.name}''")
+  }
+}
+
+object VaporsBenchmarkSetup {
+
+  def apply[P](
+    config: BenchmarkConfig[P],
+    factTable: FactTable,
+  ): RepeatBuilder[P] =
+    new RepeatBuilder(config, factTable)
+
+  final class RepeatBuilder[P](
+    config: BenchmarkConfig[P],
+    factTable: FactTable,
+  ) {
+
+    def single[R, OP[_]](expr: Expr[Any, R, OP]): ValidatingBuilder[P, R, OP] =
+      repeated(1)(expr)
+
+    def repeated[R, OP[_]](numRepeats: Int)(expr: Expr[Any, R, OP]): ValidatingBuilder[P, R, OP] =
+      new ValidatingBuilder(config, factTable, Seq.fill(numRepeats)(expr))
+  }
+
+  final class ValidatingBuilder[P, R, OP[_]](
+    config: BenchmarkConfig[P],
+    factTable: FactTable,
+    expressions: Seq[Expr[Any, R, OP]],
+  ) {
+
+    def ensuringResultIsTrue(implicit ev: R =:= Boolean): VaporsBenchmarkSetup[P, R, OP] =
+      ensuringResult(ev)
+
+    def ensuringResult(cond: R => Boolean): VaporsBenchmarkSetup[P, R, OP] =
+      new VaporsBenchmarkSetup(config, factTable, expressions, cond)
+
+    def ignoreResult: VaporsBenchmarkSetup[P, R, OP] = ensuringResult(_ => true)
+  }
+}

--- a/bench/src/test/scala/bench/timeit/Benchmark.scala
+++ b/bench/src/test/scala/bench/timeit/Benchmark.scala
@@ -1,0 +1,28 @@
+package com.rallyhealth.vapors
+
+package bench.timeit
+
+final class Benchmark[+P] private (
+  val config: BenchmarkConfig[P],
+  runFn: () => BenchmarkResults,
+) {
+  def run(): BenchmarkResults = runFn()
+}
+
+object Benchmark {
+
+  def create[P](config: BenchmarkConfig[P])(block: => Any): Benchmark[P] =
+    new Benchmark(config, () => {
+      for (_ <- 0 until config.warmupIterations) {
+        block
+      }
+      val resultArray = new Array[Long](config.iterations)
+      for (i <- 0 until config.iterations) {
+        val start = System.nanoTime()
+        block
+        val end = System.nanoTime()
+        resultArray(i) = end - start
+      }
+      BenchmarkResults(resultArray)
+    })
+}

--- a/bench/src/test/scala/bench/timeit/BenchmarkConfig.scala
+++ b/bench/src/test/scala/bench/timeit/BenchmarkConfig.scala
@@ -1,0 +1,20 @@
+package com.rallyhealth.vapors
+
+package bench.timeit
+
+final case class BenchmarkConfig[+P](
+  name: String,
+  params: P,
+  iterations: Int = BenchmarkConfig.defaultIterations,
+  warmupIterations: Int = BenchmarkConfig.defaultWarmupIterations,
+) {
+
+  def prefixName(prefix: String): BenchmarkConfig[P] =
+    copy(name = prefix + this.name)
+}
+
+object BenchmarkConfig {
+  // TODO: Read defaults from a config file / env vars / properties?
+  final val defaultIterations = 10_000
+  final val defaultWarmupIterations = 5_000
+}

--- a/bench/src/test/scala/bench/timeit/BenchmarkResults.scala
+++ b/bench/src/test/scala/bench/timeit/BenchmarkResults.scala
@@ -1,0 +1,44 @@
+package com.rallyhealth.vapors
+
+package bench.timeit
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration._
+
+final case class BenchmarkResults(
+  nanoDurations: IndexedSeq[Long], // should this be non-empty?
+) {
+  lazy val durations: IndexedSeq[FiniteDuration] = nanoDurations.map(_.nanos)
+  lazy val durationMin: FiniteDuration = nanoDurations.min.nanos
+  lazy val durationMax: FiniteDuration = nanoDurations.max.nanos
+  lazy val durationAvg: FiniteDuration = (nanoDurations.sum / nanoDurations.size).nanos
+  lazy val durationStdDev: FiniteDuration = {
+    if (nanoDurations.isEmpty)
+      throw new UnsupportedOperationException("durationStdDev called on empty BenchmarkResults")
+
+    val n = nanoDurations.length
+    val u = nanoDurations.foldLeft(0d) {
+      case (acc, nanos) =>
+        acc + (nanos.toDouble / n)
+    }
+    val root = nanoDurations.foldLeft(0d) {
+      case (acc, nanos) =>
+        acc + (Math.pow(nanos.toDouble - u, 2) / n)
+    }
+    val stddevNanos = Math.pow(root, .5)
+    stddevNanos.nanos
+  }
+}
+
+object BenchmarkResults {
+
+  def shortUnitName(unit: TimeUnit): String = unit match {
+    case TimeUnit.NANOSECONDS => "ns"
+    case TimeUnit.MICROSECONDS => "µs"
+    case TimeUnit.MILLISECONDS => "ms"
+    case TimeUnit.SECONDS => "s"
+    case TimeUnit.MINUTES => "m"
+    case TimeUnit.HOURS => "h"
+    case TimeUnit.DAYS => "d"
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,13 @@ def commonProject(
     )
 }
 
+lazy val bench = commonProject("bench", "vapors")
+  .dependsOn(`core-v1` % "test->test") // TODO: Include other projects for comparison
+  .settings(
+    libraryDependencies ++= BenchProject.all,
+    Test / parallelExecution := false,
+  )
+
 lazy val core = commonProject("core")
   .dependsOn(`core-v1`)
   .settings(

--- a/core-v1/src/main/scala/algebra/Expr.scala
+++ b/core-v1/src/main/scala/algebra/Expr.scala
@@ -2,11 +2,11 @@ package com.rallyhealth.vapors.v1
 
 package algebra
 
-import cats.data.{NonEmptyList, NonEmptyVector}
+import cats.data.{NonEmptySeq, NonEmptyVector}
 import cats.{Foldable, Functor}
 import data.{Extract, ExtractValue, FactTypeSet, TypedFact, Window}
 import debug.{DebugArgs, Debugging, NoDebugging}
-import lens.{DataPath, VariantLens}
+import lens.VariantLens
 import logic.{Conjunction, Disjunction, Negation}
 import math.Add
 
@@ -154,7 +154,11 @@ object Expr {
       opB: OP[W[B]],
     ): I ~:> W[B]
 
-    def visitAndThen[II, IO : OP, OI, OO : OP](expr: AndThen[II, IO, OI, OO, OP])(implicit evBI: IO <:< OI): II ~:> OO
+    def visitAndThen[II, IO : OP, OI, OO : OP](
+      expr: AndThen[II, IO, OI, OO, OP],
+    )(implicit
+      evIOisOI: IO <:< OI,
+    ): II ~:> OO
 
     def visitCombine[I, LI, LO : OP, RI, RO : OP, O : OP](
       expr: Combine[I, LI, LO, RI, RO, O, OP],
@@ -406,8 +410,8 @@ object Expr {
     */
   final case class Exists[C[_] : Foldable, A, B : ExtractValue.AsBoolean : OP, OP[_]](
     conditionExpr: Expr[A, B, OP],
-    combineTrue: NonEmptyList[B] => B,
-    combineFalse: List[B] => B,
+    combineTrue: NonEmptySeq[B] => B,
+    combineFalse: Seq[B] => B,
     shortCircuit: Boolean,
     override private[v1] val debugging: Debugging[Nothing, Nothing] = NoDebugging,
   ) extends Expr[C[A], B, OP]("exists") {
@@ -430,8 +434,8 @@ object Expr {
     */
   final case class ForAll[C[_] : Foldable, A, B : ExtractValue.AsBoolean : OP, OP[_]](
     conditionExpr: Expr[A, B, OP],
-    combineTrue: List[B] => B,
-    combineFalse: NonEmptyList[B] => B,
+    combineTrue: Seq[B] => B,
+    combineFalse: NonEmptySeq[B] => B,
     shortCircuit: Boolean,
     override private[v1] val debugging: Debugging[Nothing, Nothing] = NoDebugging,
   ) extends Expr[C[A], B, OP]("forall") {

--- a/core-v1/src/main/scala/algebra/WindowComparable.scala
+++ b/core-v1/src/main/scala/algebra/WindowComparable.scala
@@ -4,9 +4,8 @@ package algebra
 
 import data.{Justified, Window}
 import debug.HasShow
-
 import cats.Show
-import cats.data.NonEmptyList
+import cats.data.{NonEmptyList, NonEmptySeq}
 import shapeless.Id
 
 /**
@@ -48,7 +47,7 @@ object WindowComparable {
         }
         val comparison = Window.showWindowWithTerm[V]("_").show(window.value)
         val isWithinWindow = window.value.contains(value.value)
-        Justified.byInference(comparison, isWithinWindow, NonEmptyList.of(value, window))
+        Justified.byInference(comparison, isWithinWindow, NonEmptySeq(value, Vector(window)))
       }
     }
   }

--- a/core-v1/src/main/scala/data/Justified.scala
+++ b/core-v1/src/main/scala/data/Justified.scala
@@ -5,6 +5,10 @@ package data
 import algebra.EqualComparable
 import cats.data.{NonEmptyList, NonEmptySeq, NonEmptySet, NonEmptyVector}
 import cats.{Eq, Order}
+import cats.data.{NonEmptyList, NonEmptySeq, NonEmptySet}
+import cats.{Eq, Functor, Order}
+import cats.syntax.show._
+import data.ExtractValue.AsBoolean
 import dsl.{WrapConst, WrapFact, WrapQuantifier, WrapSelected}
 import lens.{DataPath, VariantLens}
 import logic.Logic
@@ -172,20 +176,6 @@ object Justified {
     sources: NonEmptySeq[Justified[Any]],
   ): Justified[V] = ByInference(reason, value, sources)
 
-  // TODO: Deprecate the other byInference methods below?
-
-  def byInference[V](
-    reason: String,
-    value: V,
-    sources: NonEmptyVector[Justified[Any]],
-  ): Justified[V] = ByInference(reason, value, NonEmptySeq.fromSeqUnsafe(sources.toVector))
-
-  def byInference[V](
-    reason: String,
-    value: V,
-    sources: NonEmptyList[Justified[Any]],
-  ): Justified[V] = ByInference(reason, value, NonEmptySeq.fromSeqUnsafe(sources.toList))
-
   final case class ByInference[+V](
     reason: String,
     value: V,
@@ -209,7 +199,7 @@ object Justified {
         opO: OP[Justified[Boolean]],
       ): Justified[Boolean] = {
         val isEqual = Eq[V].eqv(left.value, right.value)
-        Justified.byInference("isEqual", isEqual, NonEmptyList.of(left, right))
+        Justified.byInference("isEqual", isEqual, NonEmptySeq(left, Vector(right)))
       }
     }
 
@@ -312,7 +302,7 @@ object Justified {
       opB: Any,
     ): Justified[B] = {
       val outcome = left.value && right.value
-      Justified.byInference("and", fromBoolean(outcome), NonEmptyList.of(left, right))
+      Justified.byInference("and", fromBoolean(outcome), NonEmptySeq(left, Vector(right)))
     }
 
     override def or(
@@ -322,12 +312,12 @@ object Justified {
       opB: Any,
     ): Justified[B] = {
       val outcome = left.value || right.value
-      Justified.byInference("or", fromBoolean(outcome), NonEmptyList.of(left, right))
+      Justified.byInference("or", fromBoolean(outcome), NonEmptySeq(left, Vector(right)))
     }
 
     override def not(value: Justified[B])(implicit opB: Any): Justified[B] = {
       val outcome = !value.value
-      Justified.byInference("not", fromBoolean(outcome), NonEmptyList.of(value))
+      Justified.byInference("not", fromBoolean(outcome), NonEmptySeq.of(value))
     }
   }
 

--- a/core-v1/src/main/scala/debug/DebugArgs.scala
+++ b/core-v1/src/main/scala/debug/DebugArgs.scala
@@ -3,10 +3,9 @@ package com.rallyhealth.vapors.v1
 package debug
 
 import algebra.Expr
+import cats.data.{NonEmptySeq, NonEmptyVector}
 import data.{ExprState, Window}
 import lens.VariantLens
-
-import cats.data.{NonEmptyList, NonEmptyVector}
 import izumi.reflect.Tag
 
 import scala.reflect.ClassTag
@@ -183,9 +182,9 @@ object DebugArgs {
     A,
     B,
     OP[_],
-  ]: Aux[Expr.Exists[C, A, B, OP], OP, (C[A], Either[List[B], NonEmptyList[B]]), B] =
+  ]: Aux[Expr.Exists[C, A, B, OP], OP, (C[A], Either[Seq[B], NonEmptySeq[B]]), B] =
     new DebugArgs[Expr.Exists[C, A, B, OP], OP] {
-      override type In = (C[A], Either[List[B], NonEmptyList[B]])
+      override type In = (C[A], Either[Seq[B], NonEmptySeq[B]])
       override type Out = B
     }
 
@@ -194,9 +193,9 @@ object DebugArgs {
     A,
     B,
     OP[_],
-  ]: Aux[Expr.ForAll[C, A, B, OP], OP, (C[A], Either[NonEmptyList[B], List[B]]), B] =
+  ]: Aux[Expr.ForAll[C, A, B, OP], OP, (C[A], Either[NonEmptySeq[B], Seq[B]]), B] =
     new DebugArgs[Expr.ForAll[C, A, B, OP], OP] {
-      override type In = (C[A], Either[NonEmptyList[B], List[B]])
+      override type In = (C[A], Either[NonEmptySeq[B], Seq[B]])
       override type Out = B
     }
 

--- a/core-v1/src/main/scala/dsl/WrapQuantifier.scala
+++ b/core-v1/src/main/scala/dsl/WrapQuantifier.scala
@@ -1,16 +1,16 @@
 package com.rallyhealth.vapors.v1.dsl
 
-import cats.data.NonEmptyList
+import cats.data.NonEmptySeq
 
 trait WrapQuantifier[W[+_], OP[_]] {
 
   def shortCircuit: Boolean
 
-  def wrapFalseForAll(falseResults: NonEmptyList[W[Boolean]])(implicit opB: OP[W[Boolean]]): W[Boolean]
+  def wrapFalseForAll(falseResults: NonEmptySeq[W[Boolean]])(implicit opB: OP[W[Boolean]]): W[Boolean]
 
-  def wrapTrueForAll(trueResults: List[W[Boolean]])(implicit opB: OP[W[Boolean]]): W[Boolean]
+  def wrapTrueForAll(trueResults: Seq[W[Boolean]])(implicit opB: OP[W[Boolean]]): W[Boolean]
 
-  def wrapFalseExists(falseResults: List[W[Boolean]])(implicit opB: OP[W[Boolean]]): W[Boolean]
+  def wrapFalseExists(falseResults: Seq[W[Boolean]])(implicit opB: OP[W[Boolean]]): W[Boolean]
 
-  def wrapTrueExists(trueResults: NonEmptyList[W[Boolean]])(implicit opB: OP[W[Boolean]]): W[Boolean]
+  def wrapTrueExists(trueResults: NonEmptySeq[W[Boolean]])(implicit opB: OP[W[Boolean]]): W[Boolean]
 }

--- a/core-v1/src/main/scala/engine/CommonEngine.scala
+++ b/core-v1/src/main/scala/engine/CommonEngine.scala
@@ -3,74 +3,165 @@ package com.rallyhealth.vapors.v1
 package engine
 
 import algebra.Expr
-import data.ExtractValue
-
-import cats.data.NonEmptyList
-import cats.{Eval, Foldable}
+import cats.data.NonEmptySeq
+import cats.{Eval, Foldable, Functor}
+import data.{Extract, ExtractValue}
+import shapeless.Id
 
 /**
   * Shared implementation for expression interpreters.
   *
+  * @tparam S a higher-kinded type for caching the current state (must be able to extract a value, map over the state,
+  *           and fold the current state with a new value into a new state).
   * @tparam OP the type of output parameter. This is unused, but must be defined to satisfy the compiler.
   */
-trait CommonEngine[OP[_]] {
+abstract class CommonEngine[S[_] : Extract : Foldable : Functor, OP[_]] {
   import cats.implicits._
 
+  private final val S = Extract[S]
+
+  /**
+    * Computes the given [[Expr.ForAll]] node by folding the initial state with the state produced
+    * by computing each condition.
+    *
+    * @param expr the [[Expr.ForAll]] expression to interpret and compute
+    * @param initialState the initial cached state of the interpreter with the foldable value inside
+    * @param applyCondition use the cached result of each element to recursively interpret and compute
+    *                       the condition result
+    *
+    * @tparam C the collection to perform the exists operation
+    * @tparam A the element type
+    * @tparam B the boolean-like condition result type
+    * @return the cached result of either a non-empty Vector of the true results (if the expression
+    *         short-circuits, then it will only return the first true result) OR all the true results
+    */
   protected def visitForAllCommon[C[_] : Foldable, A, B : ExtractValue.AsBoolean : OP](
     expr: Expr.ForAll[C, A, B, OP],
-    ca: C[A],
+    initialState: S[C[A]],
   )(
-    applyCondition: A => B,
-  ): (Either[NonEmptyList[B], List[B]], B) = {
-    val falseOrTrueResults = ca
-      .foldRight[Either[NonEmptyList[B], List[B]]](Eval.now(Right(Nil))) { (a, evalResults) =>
-        val b = applyCondition(a)
+    applyCondition: S[A] => S[B],
+  ): S[(Either[NonEmptySeq[B], Seq[B]], B)] = {
+    // Create a foldable that folds over each value of the initial state
+    val SC = Foldable[S].compose[C]
+    // Replace the current value of the initial state with an empty Eval for computing the accumulated result
+    // This is effectively creating an empty value with the same state as the initial state
+    val acc: S[Eval[Either[NonEmptySeq[B], Seq[B]]]] = initialState.as(Eval.now(Right(Vector())))
+    // Fold the initial state into the initially empty accumulator
+    val finalState = SC.foldLeft(initialState, acc) {
+      case (prevState, a) =>
+        // Apply the given condition to get the next state and value
+        val sb = applyCondition(prevState.as(a))
+        // Extract the value
+        val b = S.extract(sb)
+        // Determine if the value is truthy
         val isTrue = ExtractValue.asBoolean(b)
         if (isTrue) {
-          evalResults.map {
-            case Right(ts) => Right(b :: ts) // combine true evidence for true result
-            case bs => bs // exclude true evidence for false result
+          prevState.map { prevStep =>
+            prevStep.map {
+              case Right(ts) => Right(ts :+ b) // combine true evidence for true result
+              case bs => bs // exclude true evidence for false result
+            }
           }
         } else {
-          if (expr.shortCircuit) Eval.now(Left(NonEmptyList.of(b)))
-          else {
-            evalResults.map {
-              case Right(_) => Left(NonEmptyList.of(b)) // this whole expression is now a false result
-              case Left(fs) => Left(b :: fs) // combine false evidence for false result
+          // If we have a true condition AND we can short-circuit, then we are done
+          // Just replace the latest computed state with this result and stop
+          if (expr.shortCircuit) sb.as(Eval.now(Left(NonEmptySeq(b, Vector.empty))))
+          else // we are not going to short-circuit, so keep collecting the values
+            prevState.map { prevStep =>
+              prevStep.map {
+                case Right(_) => Left(NonEmptySeq(b, Vector.empty)) // this whole expression is now a false result
+                case Left(fs) => Left(fs :+ b) // combine false evidence for false result
+              }
+            }
+        }
+    }
+    // Run the evaluation and produce the final state
+    finalState.map { computeResults =>
+      val falseOrTrueResults = computeResults.value
+      val finalOutput = falseOrTrueResults.fold(expr.combineFalse, expr.combineTrue)
+      // Keep the intermediate results alongside the final output
+      (falseOrTrueResults, finalOutput)
+    }
+  }
+
+  /**
+    * Computes the given [[Expr.Exists]] node by folding the initial state with the state produced
+    * by computing each condition.
+    *
+    * @param expr the [[Expr.Exists]] expression to interpret and compute
+    * @param initialState the initial cached state of the interpreter with the foldable value inside
+    * @param applyCondition use the cached result of each element to recursively interpret and compute
+    *                       the condition result
+    *
+    * @tparam C the collection to perform the exists operation
+    * @tparam A the element type
+    * @tparam B the boolean-like condition result type
+    * @return the cached result of either all the true results OR a non-empty Vector of the false results
+    *         (if the expression short-circuits, then it will only return the first false result)
+    */
+  protected def visitExistsCommon[C[_] : Foldable, A, B : ExtractValue.AsBoolean : OP](
+    expr: Expr.Exists[C, A, B, OP],
+    initialState: S[C[A]],
+  )(
+    applyCondition: S[A] => S[B],
+  ): S[(Either[Seq[B], NonEmptySeq[B]], B)] = {
+    // Create a foldable that folds over each value of the initial state
+    val SC = Foldable[S].compose[C]
+    // Replace the current value of the initial state with an empty Eval for computing the accumulated result
+    // This is effectively creating an empty value with the same state as the initial state
+    val acc: S[Eval[Either[Seq[B], NonEmptySeq[B]]]] = initialState.as(Eval.now(Left(Vector())))
+    // Fold the initial state into the initially empty accumulator
+    val finalState = SC.foldLeft(initialState, acc) {
+      case (prevState, a) =>
+        // Apply the given condition to get the next state and value
+        val sb = applyCondition(prevState.as(a))
+        // Extract the value
+        val b = S.extract(sb)
+        // Determine if the value is truthy
+        val isTrue = ExtractValue.asBoolean(b)
+        if (isTrue) {
+          // If we have a true condition AND we can short-circuit, then we are done
+          // Just replace the latest computed state with this result and stop
+          if (expr.shortCircuit) sb.as(Eval.now(Right(NonEmptySeq(b, Vector.empty))))
+          else // we are not going to short-circuit, so keep collecting the values
+            prevState.map { prevStep =>
+              prevStep.map {
+                case Left(_) => Right(NonEmptySeq(b, Vector.empty)) // this whole expression is now a true result
+                case Right(ts) => Right(ts :+ b) // combine true evidence for true result
+              }
+            }
+        } else {
+          prevState.map { prevStep =>
+            prevStep.map {
+              case Left(fs) => Left(fs :+ b) // combine false evidence for false result
+              case bs => bs // exclude false evidence for true result
             }
           }
         }
-      }
-      .value
-    val o = falseOrTrueResults.fold(expr.combineFalse, expr.combineTrue)
-    (falseOrTrueResults, o)
+    }
+    // Run the evaluation and produce the final state
+    finalState.map { computeResults =>
+      val falseOrTrueResults = computeResults.value
+      val finalOutput = falseOrTrueResults.fold(expr.combineFalse, expr.combineTrue)
+      // Keep the intermediate results alongside the final output
+      (falseOrTrueResults, finalOutput)
+    }
   }
+}
 
-  protected def visitExistsCommon[C[_] : Foldable, A, B : ExtractValue.AsBoolean : OP](
-    expr: Expr.Exists[C, A, B, OP],
-    ca: C[A],
+abstract class CommonUncachedEngine[OP[_]] extends CommonEngine[Id, OP] {
+
+  override protected def visitForAllCommon[C[_] : Foldable, A, B : ExtractValue.AsBoolean : OP](
+    expr: Expr.ForAll[C, A, B, OP],
+    initialState: C[A],
   )(
     applyCondition: A => B,
-  ): (Either[List[B], NonEmptyList[B]], B) = {
-    val falseOrTrueResults = ca
-      .foldRight[Either[List[B], NonEmptyList[B]]](Eval.now(Left(Nil))) { (a, evalResults) =>
-        val b = applyCondition(a)
-        val isTrue = ExtractValue.asBoolean(b)
-        if (isTrue) {
-          if (expr.shortCircuit) Eval.now(Right(NonEmptyList.of(b)))
-          else
-            evalResults.map {
-              case Left(_) => Right(NonEmptyList.of(b)) // this whole expression is now a true result
-              case Right(ts) => Right(b :: ts) // combine true evidence for true result
-            }
-        } else
-          evalResults.map {
-            case Left(fs) => Left(b :: fs) // combine false evidence for false result
-            case bs => bs // exclude false evidence for true result
-          }
-      }
-      .value
-    val o = falseOrTrueResults.fold(expr.combineFalse, expr.combineTrue)
-    (falseOrTrueResults, o)
-  }
+  ): (Either[NonEmptySeq[B], Seq[B]], B) = super.visitForAllCommon(expr, initialState: Id[C[A]])(applyCondition)
+
+  override protected def visitExistsCommon[C[_] : Foldable, A, B : ExtractValue.AsBoolean : OP](
+    expr: Expr.Exists[C, A, B, OP],
+    initialState: C[A],
+  )(
+    applyCondition: A => B,
+  ): (Either[Seq[B], NonEmptySeq[B]], B) = super.visitExistsCommon(expr, initialState: Id[C[A]])(applyCondition)
 }

--- a/core-v1/src/main/scala/engine/SimpleCachingEngine.scala
+++ b/core-v1/src/main/scala/engine/SimpleCachingEngine.scala
@@ -256,17 +256,15 @@ object SimpleCachingEngine {
       debugging(expr).invokeAndReturn(state((i, inputs), result))
     }
 
-    override def visitSelect[I, W[+_] : Extract, A, B, O : OP](
-      expr: Expr.Select[I, W, A, B, O, OP],
-    ): I => CachedResult[O] = memoize(expr, _) { i =>
-      val inputResult = expr.inputExpr.visit(this)(i)
-      val wa = inputResult.value
-      val a = Extract[W].extract(wa)
-      val b = expr.lens.get(a)
-      val o = expr.wrapSelected(wa, b)
-      val outputResult = CachedResult(o, inputResult.cacheState)
-      debugging(expr).invokeAndReturn(state((i, wa, expr.lens, b), outputResult))
-    }
+    override def visitSelect[I, A, B, O : OP](expr: Expr.Select[I, A, B, O, OP]): I => CachedResult[O] =
+      memoize(expr, _) { i =>
+        val inputResult = expr.inputExpr.visit(this)(i)
+        val a = inputResult.value
+        val b = expr.lens.get(a)
+        val o = expr.wrapSelected(a, b)
+        val outputResult = CachedResult(o, inputResult.cacheState)
+        debugging(expr).invokeAndReturn(state((i, a, expr.lens, b), outputResult))
+      }
 
     override def visitValuesOfType[T, O](
       expr: Expr.ValuesOfType[T, O, OP],

--- a/core-v1/src/main/scala/engine/SimpleCachingEngine.scala
+++ b/core-v1/src/main/scala/engine/SimpleCachingEngine.scala
@@ -1,0 +1,338 @@
+package com.rallyhealth.vapors.v1
+
+package engine
+
+import algebra.{EqualComparable, Expr, WindowComparable}
+import cats.data.NonEmptyVector
+import data.ExtractValue.AsBoolean
+import data.{ExprState, Extract, FactTable, Window}
+import debug.DebugArgs
+import debug.DebugArgs.Invoker
+import logic.{Conjunction, Disjunction, Negation}
+import cats.{Eval, Foldable, Functor}
+
+object SimpleCachingEngine {
+
+  // TODO: Use a more type-safe cache with opaque typed keys (rather than Any)
+
+  type Key = Any
+  type Result = Any
+
+  type ResultCache = Map[Key, Result]
+
+  final case class CachedResult[+V](
+    value: V,
+    cacheState: ResultCache,
+  )
+
+  final object CachedResult {
+    implicit val instance: Extract[CachedResult] with Foldable[CachedResult] with Functor[CachedResult] =
+      new Extract[CachedResult] with Foldable[CachedResult] with Functor[CachedResult] {
+
+        override final def extract[A](fa: CachedResult[A]): A = fa.value
+
+        override final def foldLeft[A, B](
+          fa: CachedResult[A],
+          b: B,
+        )(
+          f: (B, A) => B,
+        ): B = f(b, fa.value)
+
+        override final def foldRight[A, B](
+          fa: CachedResult[A],
+          lb: Eval[B],
+        )(
+          f: (A, Eval[B]) => Eval[B],
+        ): Eval[B] = f(fa.value, lb)
+
+        override final def map[A, B](fa: CachedResult[A])(f: A => B): CachedResult[B] = {
+          val b = f(fa.value)
+          CachedResult(b, fa.cacheState)
+        }
+      }
+  }
+
+  class Visitor[OP[_]](
+    protected val factTable: FactTable,
+    protected val resultCache: ResultCache,
+  ) extends CommonEngine[CachedResult, OP]
+    with Expr.Visitor[Lambda[(`-I`, `+O`) => I => CachedResult[O]], OP] {
+
+    import cats.implicits._
+
+    protected def visitWithUpdatedCache[I, O](
+      input: I,
+      expr: Expr[I, O, OP],
+      updated: ResultCache,
+    ): CachedResult[O] = {
+      val visitor = new Visitor[OP](factTable, updated)
+      expr.visit(visitor)(input)
+    }
+
+    protected def visitWithUpdatedCache2[I, A, B, R](
+      input: I,
+      xa: Expr[I, A, OP],
+      xb: Expr[I, B, OP],
+    )(
+      operation: (A, B) => R,
+    ): (A, B, CachedResult[R]) = {
+      val a = xa.visit(this)(input)
+      val b = visitWithUpdatedCache(input, xb, a.cacheState)
+      val r = operation(a.value, b.value)
+      (a.value, b.value, CachedResult(r, b.cacheState))
+    }
+
+    protected def visitWithUpdatedCacheN[I, A](
+      input: I,
+      xs: NonEmptyVector[Expr[I, A, OP]],
+    ): CachedResult[NonEmptyVector[A]] = {
+      val (cacheState, values) = xs.toVector.foldLeft((resultCache, Vector.empty[A])) {
+        case ((updated, values), x) =>
+          val result = visitWithUpdatedCache(input, x, updated)
+          (result.cacheState, values :+ result.value)
+      }
+      // Safe: because the original vector is non-empty and the fold always produces a vector of the same size
+      CachedResult(NonEmptyVector.fromVectorUnsafe(values), cacheState)
+    }
+
+    protected def cached[V](
+      value: V,
+      cacheState: ResultCache = resultCache,
+    ): CachedResult[V] = CachedResult(value, cacheState)
+
+    protected def state[I, O](
+      input: I,
+      output: CachedResult[O],
+    ): ExprState[I, CachedResult[O]] = ExprState(factTable, Some(input), Some(output))
+
+    protected def debugging[E <: Expr.AnyWith[OP]](
+      expr: E,
+    )(implicit
+      debugArgs: DebugArgs[E, OP],
+    ): InvokeAndReturn[E, OP, debugArgs.In, debugArgs.Out] =
+      new InvokeAndReturn(DebugArgs[OP].of(expr)(debugArgs))
+
+    // TODO: Use Hash type bounds on I?
+    protected def memoize[I, O](
+      expr: Expr[I, O, OP],
+      input: I,
+    )(
+      operation: I => CachedResult[O],
+    ): CachedResult[O] = {
+      val key = (expr, input)
+      val CachedResult(value, cacheState) = resultCache.get(key).map(o => cached(o.asInstanceOf[O])).getOrElse {
+        operation(input)
+      }
+      CachedResult(value, cacheState.updated(key, value))
+    }
+
+    override def visitAnd[I, B, F[+_]](
+      expr: Expr.And[I, B, F, OP],
+    )(implicit
+      logic: Conjunction[F, B, OP],
+      opO: OP[F[B]],
+    ): I => CachedResult[F[B]] =
+      memoize(expr, _) { i =>
+        val inputCachedResult = visitWithUpdatedCacheN(i, expr.leftExpr +: expr.rightExpressions)
+        val inputs = inputCachedResult.value
+        val output = inputs.reduceLeft { (l, r) =>
+          logic.and(l, r)
+        }
+        val result = CachedResult(output, inputCachedResult.cacheState)
+        debugging(expr).invokeAndReturn(state((i, inputs), result))
+      }
+
+    override def visitAndThen[II, IO : OP, OI, OO : OP](
+      expr: Expr.AndThen[II, IO, OI, OO, OP],
+    )(implicit
+      evIOisOI: IO <:< OI,
+    ): II => CachedResult[OO] = memoize(expr, _) { ii =>
+      val io = expr.inputExpr.visit(this)(ii)
+      val oo = visitWithUpdatedCache(evIOisOI(io.value), expr.outputExpr, io.cacheState)
+      debugging(expr).invokeAndReturn(state((ii, io.value), oo))
+    }
+
+    override def visitCombine[I, LI, LO : OP, RI, RO : OP, O : OP](
+      expr: Expr.Combine[I, LI, LO, RI, RO, O, OP],
+    )(implicit
+      evLOisLI: LO <:< LI,
+      evROisRI: RO <:< RI,
+    ): I => CachedResult[O] = memoize(expr, _) { i =>
+      val (lo, ro, o) = visitWithUpdatedCache2(i, expr.leftExpr, expr.rightExpr) { (lo, ro) =>
+        expr.operation(lo, ro)
+      }
+      debugging(expr).invokeAndReturn(state((i, lo, ro), o))
+    }
+
+    override def visitConst[O : OP](expr: Expr.Const[O, OP]): Any => CachedResult[O] = { i =>
+      // NOTE: This result is not memoized as const is simple to execute
+      val o = expr.value
+      debugging(expr).invokeAndReturn(state(i, cached(o)))
+    }
+
+    override def visitCustomFunction[I, O : OP](expr: Expr.CustomFunction[I, O, OP]): I => CachedResult[O] =
+      memoize(expr, _) { i =>
+        val o = expr.function(i)
+        debugging(expr).invokeAndReturn(state(i, cached(o)))
+      }
+
+    override def visitExists[C[_] : Foldable, A, B : AsBoolean : OP](
+      expr: Expr.Exists[C, A, B, OP],
+    ): C[A] => CachedResult[B] = memoize(expr, _) { ca =>
+      val finalState = visitExistsCommon(expr, CachedResult(ca, resultCache)) { sa =>
+        visitWithUpdatedCache(sa.value, expr.conditionExpr, sa.cacheState)
+      }
+      val (results, o) = finalState.value
+      debugging(expr).invokeAndReturn(state((ca, results), cached(o, finalState.cacheState)))
+    }
+
+    override def visitForAll[C[_] : Foldable, A, B : AsBoolean : OP](
+      expr: Expr.ForAll[C, A, B, OP],
+    ): C[A] => CachedResult[B] = memoize(expr, _) { ca =>
+      val finalState = visitForAllCommon(expr, CachedResult(ca, resultCache)) { sa =>
+        visitWithUpdatedCache(sa.value, expr.conditionExpr, sa.cacheState)
+      }
+      val (results, o) = finalState.value
+      debugging(expr).invokeAndReturn(state((ca, results), cached(o, finalState.cacheState)))
+    }
+
+    override def visitIdentity[I : OP](expr: Expr.Identity[I, OP]): I => CachedResult[I] = { i =>
+      // NOTE: This result is not memoized as identity is simple to execute
+      debugging(expr).invokeAndReturn(state(i, cached(i)))
+    }
+
+    override def visitIsEqual[I, V, W[+_]](
+      expr: Expr.IsEqual[I, V, W, OP],
+    )(implicit
+      eq: EqualComparable[W, V, OP],
+      opV: OP[W[V]],
+      opO: OP[W[Boolean]],
+    ): I => CachedResult[W[Boolean]] = memoize(expr, _) { i =>
+      val (left, right, isEqual) = visitWithUpdatedCache2(i, expr.leftExpr, expr.rightExpr) { (left, right) =>
+        eq.isEqual(left, right)
+      }
+      debugging(expr).invokeAndReturn(state((i, left, right), isEqual))
+    }
+
+    override def visitMapEvery[C[_] : Functor, A, B](
+      expr: Expr.MapEvery[C, A, B, OP],
+    )(implicit
+      opO: OP[C[B]],
+    ): C[A] => CachedResult[C[B]] = memoize(expr, _) { ca =>
+      val mapFn = expr.mapExpr.visit(this).andThen(_.value)
+      // NOTE: This does not utilize caching between elements.
+      // Caching would only help improve performance if the collection contains duplicates,
+      // however, the likelihood of duplicates is probably rare enough to make caching a
+      // pre-mature optimization that would require obstructing the interface. Most values
+      // come from facts and all fact types require some definition of order that is used
+      // to deduplicate facts.
+      val cb = ca.map(mapFn)
+      debugging(expr).invokeAndReturn(state(ca, cached(cb)))
+    }
+
+    override def visitNot[I, B, F[+_]](
+      expr: Expr.Not[I, B, F, OP],
+    )(implicit
+      logic: Negation[F, B, OP],
+      opB: OP[F[B]],
+    ): I => CachedResult[F[B]] = memoize(expr, _) { i =>
+      val output = expr.innerExpr.visit(this)(i)
+      val negatedOutput = logic.not(output.value)
+      debugging(expr).invokeAndReturn(state((i, output.value), cached(negatedOutput, output.cacheState)))
+    }
+
+    override def visitOr[I, B, F[+_]](
+      expr: Expr.Or[I, B, F, OP],
+    )(implicit
+      logic: Disjunction[F, B, OP],
+      opO: OP[F[B]],
+    ): I => CachedResult[F[B]] = memoize(expr, _) { i =>
+      val inputCachedResult = visitWithUpdatedCacheN(i, expr.leftExpr +: expr.rightExpressions)
+      val inputs = inputCachedResult.value
+      val output = inputs.reduceLeft { (l, r) =>
+        logic.or(l, r)
+      }
+      val result = CachedResult(output, inputCachedResult.cacheState)
+      debugging(expr).invokeAndReturn(state((i, inputs), result))
+    }
+
+    override def visitSelect[I, W[+_] : Extract, A, B, O : OP](
+      expr: Expr.Select[I, W, A, B, O, OP],
+    ): I => CachedResult[O] = memoize(expr, _) { i =>
+      val inputResult = expr.inputExpr.visit(this)(i)
+      val wa = inputResult.value
+      val a = Extract[W].extract(wa)
+      val b = expr.lens.get(a)
+      val o = expr.wrapSelected(wa, b)
+      val outputResult = CachedResult(o, inputResult.cacheState)
+      debugging(expr).invokeAndReturn(state((i, wa, expr.lens, b), outputResult))
+    }
+
+    override def visitValuesOfType[T, O](
+      expr: Expr.ValuesOfType[T, O, OP],
+    )(implicit
+      opTs: OP[Seq[O]],
+    ): Any => CachedResult[Seq[O]] = { i =>
+      // NOTE: This result is not memoized as valuesOfType is simple to execute and does not depend on the input
+      val matchingFacts = factTable.getSortedSeq(expr.factTypeSet)
+      val o = matchingFacts.map(expr.transform)
+      debugging(expr).invokeAndReturn(state(i, cached(o)))
+    }
+
+    override def visitWithinWindow[I, V, F[+_]](
+      expr: Expr.WithinWindow[I, V, F, OP],
+    )(implicit
+      comparison: WindowComparable[F, OP],
+      opV: OP[F[V]],
+      opW: OP[F[Window[V]]],
+      opB: OP[F[Boolean]],
+    ): I => CachedResult[F[Boolean]] = memoize(expr, _) { i =>
+      val (value, window, o) = visitWithUpdatedCache2(i, expr.valueExpr, expr.windowExpr) { (value, window) =>
+        comparison.withinWindow(value, window)
+      }
+      debugging(expr).invokeAndReturn(state((i, value, window), o))
+    }
+  }
+
+  // TODO: Support an eval method that returns an HMap with type-safe keys and / or HList?
+
+  def evalMultiple[I, O, OP[_]](
+    expressions: Seq[Expr[I, O, OP]],
+    factTable: FactTable = FactTable.empty,
+    input: I = (),
+    cache: ResultCache = Map.empty,
+  ): IndexedSeq[O] = {
+    debugMultiple(expressions, factTable, input, cache).map(_.value)
+  }
+
+  def debugMultiple[I, O, OP[_]](
+    expressions: Seq[Expr[I, O, OP]],
+    factTable: FactTable = FactTable.empty,
+    input: I = (),
+    cache: ResultCache = Map.empty,
+  ): IndexedSeq[CachedResult[O]] = {
+    // Using a mutable var to improve performance by avoiding wrapping and unwrapping tuples
+    var lastResultCache = cache
+    var results = Vector.empty[CachedResult[O]]
+    for (next <- expressions) {
+      val result = next.visit(new Visitor[OP](factTable, lastResultCache))(input)
+      lastResultCache = result.cacheState
+      results :+= result
+    }
+    results
+  }
+
+  protected implicit class InvokeAndReturn[E <: Expr.AnyWith[OP], OP[_], DI, DO](
+    private val invoker: Invoker[E, OP, DI, DO],
+  ) extends AnyVal {
+
+    /**
+      * A convenience method for returning the output after debugging.
+      */
+    def invokeAndReturn(args: ExprState[DI, CachedResult[DO]]): CachedResult[DO] = {
+      invoker.invokeDebugger(args.mapOutput(_.value))
+      args.output
+    }
+  }
+
+}

--- a/core-v1/src/main/scala/engine/StandardEngine.scala
+++ b/core-v1/src/main/scala/engine/StandardEngine.scala
@@ -6,7 +6,7 @@ import algebra._
 import data.{ExprState, Extract, ExtractValue, Window}
 import debug.DebugArgs
 import logic.{Conjunction, Disjunction, Negation}
-import cats.{Foldable, Functor}
+import cats.{Foldable, Functor, Id}
 
 import scala.annotation.nowarn
 
@@ -27,8 +27,8 @@ object StandardEngine {
     *       which would simplify all the places where I am using `implicitly`.
     */
   class Visitor[PO, OP[_]](val state: ExprState[Any, PO])
-    extends Expr.Visitor[Lambda[(`-I`, `+O`) => PO <:< I => ExprResult[PO, I, O, OP]], OP]
-    with CommonEngine[OP] {
+    extends CommonUncachedEngine[OP]
+    with Expr.Visitor[Lambda[(`-I`, `+O`) => PO <:< I => ExprResult[PO, I, O, OP]], OP] {
 
     import cats.implicits._
 
@@ -119,7 +119,6 @@ object StandardEngine {
         conditionResult.state.output
       }
       val finalState = state.swapAndReplaceOutput(o)
-      val debugState = stateFromInput(i => (i: C[A], results), finalState.output)
       debugging(expr).invokeDebugger(stateFromInput((_, results), finalState.output))
       ExprResult.Exists(expr, finalState)
     }

--- a/core-v1/src/test/scala/SimpleJustifiedArithmeticSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedArithmeticSpec.scala
@@ -1,8 +1,7 @@
 package com.rallyhealth.vapors.v1
 
 import data.Justified
-
-import cats.data.NonEmptyList
+import cats.data.NonEmptySeq
 
 class SimpleJustifiedArithmeticSpec extends munit.FunSuite {
 
@@ -13,21 +12,21 @@ class SimpleJustifiedArithmeticSpec extends munit.FunSuite {
   test("Justified[Int] + Justified[Int]") {
     val expr = 1.const + 2.const
     val observed = expr.run()
-    val expected = Justified.byInference("add", 3, NonEmptyList.of(Justified.byConst(1), Justified.byConst(2)))
+    val expected = Justified.byInference("add", 3, NonEmptySeq.of(Justified.byConst(1), Justified.byConst(2)))
     assertEquals(observed, expected)
   }
 
   test("Justified[Long] + Justified[Int]") {
     val expr = 1L.const.+(2.const)
     val observed = expr.run()
-    val expected = Justified.byInference("add", 3L, NonEmptyList.of(Justified.byConst(1L), Justified.byConst(2)))
+    val expected = Justified.byInference("add", 3L, NonEmptySeq.of(Justified.byConst(1L), Justified.byConst(2)))
     assertEquals(observed, expected)
   }
 
   test("Justified[Int] + Justified[Long]") {
     val expr = 1.const + 2L.const
     val observed = expr.run()
-    val expected = Justified.byInference("add", 3L, NonEmptyList.of(Justified.byConst(1), Justified.byConst(2L)))
+    val expected = Justified.byInference("add", 3L, NonEmptySeq.of(Justified.byConst(1), Justified.byConst(2L)))
     assertEquals(observed, expected)
   }
 
@@ -39,7 +38,7 @@ class SimpleJustifiedArithmeticSpec extends munit.FunSuite {
     val expected = Justified.byInference(
       "add",
       now.plus(duration),
-      NonEmptyList.of(Justified.byConst(now), Justified.byConst(duration)),
+      NonEmptySeq.of(Justified.byConst(now), Justified.byConst(duration)),
     )
     assertEquals(observed, expected)
   }
@@ -52,7 +51,7 @@ class SimpleJustifiedArithmeticSpec extends munit.FunSuite {
     val expected = Justified.byInference(
       "add",
       now.plus(duration),
-      NonEmptyList.of(Justified.byConst(duration), Justified.byConst(now)),
+      NonEmptySeq.of(Justified.byConst(duration), Justified.byConst(now)),
     )
     assertEquals(observed, expected)
   }

--- a/core-v1/src/test/scala/SimpleJustifiedBooleanLogicSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedBooleanLogicSpec.scala
@@ -2,8 +2,7 @@ package com.rallyhealth.vapors.v1
 
 import algebra.Expr
 import data.Justified
-
-import cats.data.{NonEmptyList, NonEmptyVector}
+import cats.data.{NonEmptySeq, NonEmptyVector}
 import munit.{FunSuite, Location}
 
 class SimpleJustifiedBooleanLogicSpec extends FunSuite {
@@ -35,7 +34,7 @@ class SimpleJustifiedBooleanLogicSpec extends FunSuite {
     val tail = NonEmptyVector(r, m.toVector)
     testLogic(l, tail) {
       _.reduceLeft { (l, r) =>
-        Justified.byInference("and", l.value && r.value, NonEmptyList.of(l, r))
+        Justified.byInference("and", l.value && r.value, NonEmptySeq.of(l, r))
       }
     } { (h, t) =>
       t.foldLeft(h) {
@@ -86,7 +85,7 @@ class SimpleJustifiedBooleanLogicSpec extends FunSuite {
     val tail = NonEmptyVector(r, m.toVector)
     testLogic(l, tail) {
       _.reduceLeft { (l, r) =>
-        Justified.byInference("and", l.value && r.value, NonEmptyList.of(l, r))
+        Justified.byInference("and", l.value && r.value, NonEmptySeq.of(l, r))
       }
     } { (h, t) =>
       and(h, t.head, t.tail: _*)
@@ -135,7 +134,7 @@ class SimpleJustifiedBooleanLogicSpec extends FunSuite {
     val tail = NonEmptyVector(r, m.toVector)
     testLogic(l, tail) {
       _.reduceLeft { (l, r) =>
-        Justified.byInference("or", l.value || r.value, NonEmptyList.of(l, r))
+        Justified.byInference("or", l.value || r.value, NonEmptySeq.of(l, r))
       }
     } { (h, t) =>
       t.foldLeft(h) {
@@ -186,7 +185,7 @@ class SimpleJustifiedBooleanLogicSpec extends FunSuite {
     val tail = NonEmptyVector(r, m.toVector)
     testLogic(l, tail) {
       _.reduceLeft { (l, r) =>
-        Justified.byInference("or", l.value || r.value, NonEmptyList.of(l, r))
+        Justified.byInference("or", l.value || r.value, NonEmptySeq.of(l, r))
       }
     } { (h, t) =>
       or(h, t.head, t.tail: _*)
@@ -233,7 +232,7 @@ class SimpleJustifiedBooleanLogicSpec extends FunSuite {
     loc: Location,
   ): Unit = {
     val expr = buildExpr(v)
-    val expected = Justified.byInference("not", !v.value.value, NonEmptyList.of(v.value))
+    val expected = Justified.byInference("not", !v.value.value, NonEmptySeq.of(v.value))
     val obtained = expr.run()
     assertEquals(obtained, expected)
   }

--- a/core-v1/src/test/scala/SimpleJustifiedExistsEvidenceSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedExistsEvidenceSpec.scala
@@ -2,8 +2,7 @@ package com.rallyhealth.vapors.v1
 
 import data.{Evidence, FactTable, Justified, NoEvidence, Window}
 import example.{CombinedTags, FactTypes}
-
-import cats.data.NonEmptyList
+import cats.data.NonEmptySeq
 import munit.FunSuite
 
 import scala.collection.immutable.SortedSet
@@ -46,11 +45,11 @@ class SimpleJustifiedExistsEvidenceSpec extends FunSuite {
       Justified.byInference(
         "exists",
         false,
-        NonEmptyList.of(
+        NonEmptySeq.of(
           Justified.byInference(
             "_ >= 18",
             false,
-            NonEmptyList.of(
+            NonEmptySeq.of(
               Justified.byFact(age10),
               Justified.byConst(Window.greaterThanOrEqual(18)),
             ),
@@ -58,7 +57,7 @@ class SimpleJustifiedExistsEvidenceSpec extends FunSuite {
           Justified.byInference(
             "_ >= 18",
             false,
-            NonEmptyList.of(
+            NonEmptySeq.of(
               Justified.byFact(age14),
               Justified.byConst(Window.greaterThanOrEqual(18)),
             ),
@@ -80,11 +79,11 @@ class SimpleJustifiedExistsEvidenceSpec extends FunSuite {
       Justified.byInference(
         "exists",
         true,
-        NonEmptyList.of(
+        NonEmptySeq.of(
           Justified.byInference(
             "_ >= 18",
             true,
-            NonEmptyList.of(
+            NonEmptySeq.of(
               Justified.byFact(age18),
               Justified.byConst(Window.greaterThanOrEqual(18)),
             ),

--- a/core-v1/src/test/scala/SimpleJustifiedForAllEvidenceSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedForAllEvidenceSpec.scala
@@ -2,8 +2,7 @@ package com.rallyhealth.vapors.v1
 
 import data.{Evidence, FactTable, Justified, NoEvidence, Window}
 import example.{CombinedTags, FactTypes}
-
-import cats.data.NonEmptyList
+import cats.data.NonEmptySeq
 import munit.FunSuite
 
 import scala.collection.immutable.SortedSet
@@ -45,11 +44,11 @@ class SimpleJustifiedForAllEvidenceSpec extends FunSuite {
       Justified.byInference(
         "forall",
         true,
-        NonEmptyList.of(
+        NonEmptySeq.of(
           Justified.byInference(
             "_ >= 18",
             true,
-            NonEmptyList.of(
+            NonEmptySeq.of(
               Justified.byFact(age21),
               Justified.byConst(Window.greaterThanOrEqual(18)),
             ),
@@ -57,7 +56,7 @@ class SimpleJustifiedForAllEvidenceSpec extends FunSuite {
           Justified.byInference(
             "_ >= 18",
             true,
-            NonEmptyList.of(
+            NonEmptySeq.of(
               Justified.byFact(age23),
               Justified.byConst(Window.greaterThanOrEqual(18)),
             ),
@@ -79,11 +78,11 @@ class SimpleJustifiedForAllEvidenceSpec extends FunSuite {
       Justified.byInference(
         "forall",
         false,
-        NonEmptyList.of(
+        NonEmptySeq.of(
           Justified.byInference(
             "_ >= 18",
             false,
-            NonEmptyList.of(
+            NonEmptySeq.of(
               Justified.byFact(age10),
               Justified.byConst(Window.greaterThanOrEqual(18)),
             ),

--- a/core-v1/src/test/scala/StandardJustifiedExistsEvidenceSpec.scala
+++ b/core-v1/src/test/scala/StandardJustifiedExistsEvidenceSpec.scala
@@ -2,8 +2,7 @@ package com.rallyhealth.vapors.v1
 
 import data.{Evidence, FactTable, Justified, NoEvidence, Window}
 import example.FactTypes
-
-import cats.data.NonEmptyList
+import cats.data.NonEmptySeq
 import munit.FunSuite
 
 class StandardJustifiedExistsEvidenceSpec extends FunSuite {
@@ -31,11 +30,11 @@ class StandardJustifiedExistsEvidenceSpec extends FunSuite {
       Justified.byInference(
         "exists",
         false,
-        NonEmptyList.of(
+        NonEmptySeq.of(
           Justified.byInference(
             "_ >= 18",
             false,
-            NonEmptyList.of(
+            NonEmptySeq.of(
               Justified.byFact(age10),
               Justified.byConst(Window.greaterThanOrEqual(18)),
             ),
@@ -43,7 +42,7 @@ class StandardJustifiedExistsEvidenceSpec extends FunSuite {
           Justified.byInference(
             "_ >= 18",
             false,
-            NonEmptyList.of(
+            NonEmptySeq.of(
               Justified.byFact(age14),
               Justified.byConst(Window.greaterThanOrEqual(18)),
             ),
@@ -65,11 +64,11 @@ class StandardJustifiedExistsEvidenceSpec extends FunSuite {
       Justified.byInference(
         "exists",
         true,
-        NonEmptyList.of(
+        NonEmptySeq.of(
           Justified.byInference(
             "_ >= 18",
             true,
-            NonEmptyList.of(
+            NonEmptySeq.of(
               Justified.byFact(age18),
               Justified.byConst(Window.greaterThanOrEqual(18)),
             ),

--- a/core-v1/src/test/scala/StandardJustifiedForAllEvidenceSpec.scala
+++ b/core-v1/src/test/scala/StandardJustifiedForAllEvidenceSpec.scala
@@ -1,8 +1,8 @@
 package com.rallyhealth.vapors.v1
 
-import data.{Evidence, FactTable, Justified, NoEvidence, Window}
+import cats.data.NonEmptySeq
+import data._
 import example.FactTypes
-import cats.data.NonEmptyList
 import munit.FunSuite
 
 class StandardJustifiedForAllEvidenceSpec extends FunSuite {
@@ -30,11 +30,11 @@ class StandardJustifiedForAllEvidenceSpec extends FunSuite {
       Justified.byInference(
         "forall",
         true,
-        NonEmptyList.of(
+        NonEmptySeq.of(
           Justified.byInference(
             "_ >= 18",
             true,
-            NonEmptyList.of(
+            NonEmptySeq.of(
               Justified.byFact(age21),
               Justified.byConst(Window.greaterThanOrEqual(18)),
             ),
@@ -42,7 +42,7 @@ class StandardJustifiedForAllEvidenceSpec extends FunSuite {
           Justified.byInference(
             "_ >= 18",
             true,
-            NonEmptyList.of(
+            NonEmptySeq.of(
               Justified.byFact(age23),
               Justified.byConst(Window.greaterThanOrEqual(18)),
             ),
@@ -64,11 +64,11 @@ class StandardJustifiedForAllEvidenceSpec extends FunSuite {
       Justified.byInference(
         "forall",
         false,
-        NonEmptyList.of(
+        NonEmptySeq.of(
           Justified.byInference(
             "_ >= 18",
             false,
-            NonEmptyList.of(
+            NonEmptySeq.of(
               Justified.byFact(age10),
               Justified.byConst(Window.greaterThanOrEqual(18)),
             ),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,6 +42,13 @@ object Dependencies {
   private val sourcecode = "com.lihaoyi" %% "sourcecode" % sourcecodeVersion
   private val zio = "dev.zio" %% "zio" % zioVersion
 
+  final object BenchProject {
+
+    val all: Seq[ModuleID] = Seq(
+      scalaCheckOps,
+    ).map(_ % Test)
+  }
+
   final object CoreProject {
 
     def all(scalaVersion: String): Seq[ModuleID] =


### PR DESCRIPTION
Used to create this [spreadsheet](https://docs.google.com/spreadsheets/d/1sZxsFUm222eXQYcKR_-TAwglTHOmhz5lf17JbiQa6gA/edit?usp=sharing)

- Implement SimpleCachingEngine and add performance tests
  - Add SimpleCachingEngine that utilizes memoization of sub-expressions
  - Create new bench project for performance testing
  - Use a matrix of params for number of expressions in benchmark test
  - Use higher-kinded cache wrapper type for CommonEngine
  - Document the CommonEngine.{exists, forall} methods
  - Use NonEmptySeq instead of NonEmptyList to improve performance of append operation and hide details
- Remove Justified.byInference methods that accept NonEmptyList / NonEmptyVector