### PR TITLE
Add support for operations on HList of Expr

### DIFF
--- a/core-v1/src/main/scala/algebra/NonEmptyExprHList.scala
+++ b/core-v1/src/main/scala/algebra/NonEmptyExprHList.scala
@@ -1,0 +1,113 @@
+package com.rallyhealth.vapors.v1
+
+package algebra
+
+import cats.arrow.Arrow
+import cats.implicits._
+import cats.{Functor, Semigroupal}
+import shapeless.ops.hlist.Comapped
+import shapeless.{::, HList, HNil}
+
+// TODO: Remove extra head param?
+sealed abstract class NonEmptyExprHList[-I, F[+_], +WL <: HList, +UL <: HList, OP[_]](
+  implicit
+  comapped: Comapped.Aux[WL, F, UL],
+) {
+
+  def ::[PI <: I, PH](expr: Expr[PI, F[PH], OP]): ExprHCons[PI, F, PH, WL, UL, OP] =
+    ExprHCons(expr, this)
+
+  def concatToHListWith[G[-_, +_]](v: ConcatToHList.Visitor[F, G, OP]): G[I, WL]
+
+  def zipToHListWith[G[-_, +_]](v: ZipToHList.Visitor[F, G, OP]): G[I, F[UL]]
+
+}
+
+final case class ExprHCons[-I, F[+_], +H, +WT <: HList, +UT <: HList, OP[_]](
+  head: Expr[I, F[H], OP],
+  tail: NonEmptyExprHList[I, F, WT, UT, OP],
+)(implicit
+  comapped: Comapped.Aux[F[H] :: WT, F, H :: UT],
+) extends NonEmptyExprHList[I, F, F[H] :: WT, H :: UT, OP] {
+
+  override def concatToHListWith[G[-_, +_]](v: ConcatToHList.Visitor[F, G, OP]): G[I, F[H] :: WT] =
+    v.visitHCons(this)
+
+  override def zipToHListWith[G[-_, +_]](v: ZipToHList.Visitor[F, G, OP]): G[I, F[H :: UT]] =
+    v.visitHCons(this)
+}
+
+final case class ExprHLast[-I, F[+_], +H, OP[_]](last: Expr[I, F[H], OP])
+  extends NonEmptyExprHList[I, F, F[H] :: HNil, H :: HNil, OP] {
+
+  override def concatToHListWith[G[-_, +_]](v: ConcatToHList.Visitor[F, G, OP]): G[I, F[H] :: HNil] =
+    v.visitHLast(this)
+
+  override def zipToHListWith[G[-_, +_]](v: ZipToHList.Visitor[F, G, OP]): G[I, F[H :: HNil]] =
+    v.visitHLast(this)
+}
+
+object ConcatToHList {
+
+  def proxy[F[+_], G[-_, +_] : Arrow, OP[_]](exprVisitor: Expr.Visitor[G, OP]): Visitor[F, G, OP] =
+    new ProxyVisitor(exprVisitor)
+
+  trait Visitor[F[+_], G[-_, +_], OP[_]] {
+
+    def visitHCons[I, H, WT <: HList, UT <: HList](xhl: ExprHCons[I, F, H, WT, UT, OP]): G[I, F[H] :: WT]
+
+    def visitHLast[I, H](xhl: ExprHLast[I, F, H, OP]): G[I, F[H] :: HNil]
+  }
+
+  class ProxyVisitor[F[+_], G[-_, +_] : Arrow, OP[_]](exprVisitor: Expr.Visitor[G, OP]) extends Visitor[F, G, OP] {
+
+    private final val G: Arrow[G] = implicitly
+
+    override def visitHCons[I, H, WT <: HList, UT <: HList](xhl: ExprHCons[I, F, H, WT, UT, OP]): G[I, F[H] :: WT] = {
+      val headResult = xhl.head.visit(exprVisitor)
+      val tailResult = xhl.tail.concatToHListWith(this)
+      (headResult &&& tailResult) >>> G.lift { case (fh, ft) => fh :: ft }
+    }
+
+    override def visitHLast[I, H](xhl: ExprHLast[I, F, H, OP]): G[I, F[H] :: HNil] = {
+      val lastResult = xhl.last.visit(exprVisitor)
+      lastResult >>> G.lift { _ :: HNil }
+    }
+  }
+}
+
+object ZipToHList {
+
+  def proxy[F[+_] : Functor : Semigroupal, G[-_, +_] : Arrow, OP[_]](
+    exprVisitor: Expr.Visitor[G, OP],
+  ): Visitor[F, G, OP] = new ProxyVisitor(exprVisitor)
+
+  trait Visitor[F[+_], G[-_, +_], OP[_]] {
+
+    def visitHLast[I, H](xhl: ExprHLast[I, F, H, OP]): G[I, F[H :: HNil]]
+
+    def visitHCons[I, H, WT <: HList, UT <: HList](xhl: ExprHCons[I, F, H, WT, UT, OP]): G[I, F[H :: UT]]
+  }
+
+  class ProxyVisitor[F[+_] : Functor : Semigroupal, G[-_, +_] : Arrow, OP[_]](exprVisitor: Expr.Visitor[G, OP])
+    extends Visitor[F, G, OP] {
+
+    private val G: Arrow[G] = implicitly
+
+    def visitHLast[I, H](xhl: ExprHLast[I, F, H, OP]): G[I, F[H :: HNil]] = {
+      xhl.last.visit(exprVisitor) >>> G.lift(_.map(_ :: HNil))
+    }
+
+    def visitHCons[I, H, WT <: HList, UT <: HList](xhl: ExprHCons[I, F, H, WT, UT, OP]): G[I, F[H :: UT]] = {
+      val headResult = xhl.head.visit(exprVisitor)
+      val tailResult = xhl.tail.zipToHListWith(this)
+      val result = (headResult &&& tailResult) >>> G.lift {
+        case (fh, ft) =>
+          (fh, ft).mapN { (h, t) =>
+            h :: t
+          }
+      }
+      result
+    }
+  }
+}

--- a/core-v1/src/main/scala/dsl/BuildExprHLast.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprHLast.scala
@@ -1,0 +1,13 @@
+//package com.rallyhealth.vapors.v1
+//
+//package dsl
+//
+//import algebra.{Expr, ExprHCons, ExprHLast}
+//
+//import shapeless._
+//
+//final class BuildExprHLast[I, W[_], O, OP[_]](private val last: Expr[I, W[O], OP]) extends AnyVal {
+//
+//  def ::[HI <: I, HO](head: Expr[HI, W[HO], OP]): ExprHCons[HI, W, HO, O :: HNil, W[O] :: HNil, OP] =
+//    ExprHCons(head, ExprHLast(last))
+//}

--- a/core-v1/src/main/scala/dsl/StandardRunDsl.scala
+++ b/core-v1/src/main/scala/dsl/StandardRunDsl.scala
@@ -37,7 +37,7 @@ trait StandardRunDsl extends RunExprDsl {
     override def run(factTable: FactTable = FactTable.empty): ExprResult[Nothing, Nothing, O, OP] = super.run(factTable)
   }
 
-  final class RunWithStandardExpr[-I, +O](expr: I ~:> O) extends RunWithExpr(expr) {
+  final class RunWithStandardExpr[-I, +O](expr: I ~:> O) extends RunWithExpr[I, O](expr) {
     override def runWith[In <: I](
       input: In,
       factTable: FactTable = FactTable.empty,

--- a/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
@@ -56,7 +56,7 @@ trait UnwrappedBuildExprDsl extends BuildExprDsl with UnwrappedDslTypes {
       opL: OP[L],
       opP: OP[P],
     ): Ap[I, L, P] =
-      Expr.AndThen(inputExpr, Expr.Convert(ExprConverter.asProductType))
+      inputExpr.andThen(Expr.Convert(ExprConverter.asProductType))
   }
 
   override implicit final def hk[I, C[_], A](expr: I ~:> C[A]): HkIdExprBuilder[I, C, A] = new HkIdExprBuilder(expr)

--- a/core-v1/src/main/scala/klist/KList.scala
+++ b/core-v1/src/main/scala/klist/KList.scala
@@ -1,0 +1,40 @@
+package com.rallyhealth.vapors.v1
+
+package klist
+
+import cats.~>
+import shapeless.{::, HList, HNil}
+
+// TODO: Figure out how to replace this with UnaryTCConstraint (and whether that is a good idea)
+//       https://stackoverflow.com/questions/64622828/shapeless-mapping-an-natural-transformation-over-a-klist
+sealed trait KList[+F[_], HL <: HList] {
+
+  def :^:[N[X] >: F[X], A](g: N[A]): KCons[N, A, HL] = KCons(g, this)
+
+  def transform[M[a] >: F[a], N[_]](fn: M ~> N): KList[N, HL]
+}
+
+// TODO: Should I require variance here?
+final case class KCons[+F[_], H, T <: HList](
+  head: F[H],
+  tail: KList[F, T],
+) extends KList[F, H :: T] {
+
+  override def transform[M[a] >: F[a], N[_]](fn: M ~> N): KList[N, H :: T] =
+    KCons(fn(head), tail.transform(fn))
+}
+
+sealed class KNil extends KList[Nothing, HNil] {
+
+  override final def transform[M[_], N[_]](fn: M ~> N): KList[N, HNil] = this
+}
+
+object KNil extends KNil
+
+object KList {
+
+  implicit final class Ops[KL <: KList[Any, HL], HL <: HList](private val kl: KL) extends AnyVal {
+
+    def toHList(implicit thl: KToHList[KL]): thl.HL = thl(kl)
+  }
+}

--- a/core-v1/src/main/scala/klist/KToHList.scala
+++ b/core-v1/src/main/scala/klist/KToHList.scala
@@ -1,0 +1,138 @@
+package com.rallyhealth.vapors.v1
+
+package klist
+
+import klist.ops.IsKCons
+
+import shapeless.{::, HList, HNil}
+
+sealed trait KToHList[KL <: KList[Any, _]] {
+  type HL <: HList
+
+  def apply(kl: KL): HL
+}
+
+object Example {
+
+  // Doesn't work... :(
+//  val nilHL = KNil.toHList
+//  val one = List(1, 2, 3) :^: KNil
+//  val oneHL = one.toHList
+//
+//  val two = List("one", "two", "three") :^: one
+//  val twoHL = two.toHList
+}
+
+object KToHList extends LowPriorityKToHList {
+  type Aux[KL <: KList[Any, _], O <: HList] = KToHList[KL] { type HL = O }
+
+  implicit def toHNil[KL <: KList[Any, HNil]]: KToHList.Aux[KL, HNil] =
+    new KToHList[KL] {
+      override type HL = HNil
+      override final def apply(kl: KL): HNil = HNil
+    }
+
+  implicit def toHLast[KL <: KList[F, H :: HNil], F[+_], H](
+    implicit
+    isHCons: IsKCons.Aux[KL, F, H, HNil],
+  ): KToHList[KL] =
+    new KToHList[KL] {
+      override type HL = F[H] :: HNil
+      override def apply(kl: KL): F[H] :: HNil = {
+        isHCons.head(kl) :: HNil
+      }
+    }
+
+  implicit def toHCons[KL <: KList[F, H :: T], F[+_], H, T <: HList](
+    implicit
+    isHCons: IsKCons.Aux[KL, F, H, T],
+    toHList: KToHList[KList[F, T]],
+  ): KToHList.Aux[KL, F[H] :: toHList.HL] =
+    new KToHList[KL] {
+      override type HL = F[H] :: toHList.HL
+      override def apply(kl: KL): F[H] :: toHList.HL = {
+        isHCons.head(kl) :: toHList(isHCons.tail(kl))
+      }
+    }
+
+//  implicit def toHList[F[+_], H, T <: HList](
+//    implicit
+//    toHList: KToHList[KList[F, T]],
+//  ): KToHList.Aux[KCons[F, H, T], F[H] :: toHList.HL] =
+//    new KToHList[KCons[F, H, T]] {
+//      override type HL = F[H] :: toHList.HL
+//      override def apply(kl: KCons[F, H, T]): F[H] :: toHList.HL = {
+//        kl.head :: toHList(kl.tail)
+//      }
+//    }
+
+//  implicit def hlast[KL <: KList[F, H :: HNil], F[_], H](
+//    implicit
+//    isKCons: ops.IsKCons[KL, F],
+//  ): KToHList.Aux[KL, F[H] :: HNil] =
+//    new KToHList[KList[F, H :: HNil]] {
+//      override type Out = F[H] :: HNil
+//      override def apply(kl: KL): F[H] :: HNil = isKCons.head(kl) :: HNil
+//    }
+
+//  implicit def toHLast[F[_], H]: KToHList.Aux[KList[F, H :: HNil], F[H] :: HNil] =
+//    new KToHList[KList[F, H :: HNil]] {
+//      override type HL = F[H] :: HNil
+//      override final def apply(kl: KList[F, H :: HNil]): F[H] :: HNil = kl.head :: HNil
+//    }
+
+}
+
+sealed trait LowPriorityKToHList {
+
+//  implicit def toHCons[F[_], H, T <: HList](
+//    implicit
+//    tailToHList: KToHList[KList[F, T]],
+//  ): KToHList.Aux[KCons[F, H, T], F[H] :: tailToHList.HL] =
+//    new KToHList[KCons[F, H, T]] {
+//      override type HL = F[H] :: tailToHList.HL
+//      override def apply(kl: KCons[F, H, T]): F[H] :: tailToHList.HL = {
+//        kl.head :: tailToHList(kl.tail)
+//      }
+//    }
+
+//  implicit def toKCons[F[_], H, T <: HList, KT <: KList[F, T]](
+//    implicit
+//    tailToHList: KToHList[KT],
+//  ): KToHList.Aux[KCons[F, H, T], F[H] :: tailToHList.HL] =
+//    new KToHList[KCons[F, H, T]] {
+//      override type HL = F[H] :: tailToHList.HL
+//      override def apply(kl: KCons[F, H, T]): F[H] :: tailToHList.HL = {
+////        val h = isKCons.head(kl)
+////        val t = isKCons.tail(kl)
+//        kl.head :: tailToHList(kl.tail)
+//        //        kl.head :: tailToHList(kl.tail)
+//      }
+//    }
+
+//  implicit def toKCons[KL <: KList[F, H :: T], F[_], H, T <: HList, KT <: KList[F, T]](
+//    implicit
+//    isKCons: IsKCons.Aux[KL, F, H, T],
+//    tailToHList: KToHList[KT],
+//  ): KToHList.Aux[KL, F[isKCons.H] :: tailToHList.HL] =
+//    new KToHList[KL] {
+//      override type HL = F[isKCons.H] :: tailToHList.HL
+//      override def apply(kl: KL): F[isKCons.H] :: tailToHList.HL = {
+//        val h = isKCons.head(kl)
+//        val t = isKCons.tail(kl)
+//        tailToHList(t)
+////        kl.head :: tailToHList(kl.tail)
+//      }
+//    }
+
+//  implicit def toHCons[KL <: KCons[F, H, T], F[_], H, T <: HList](
+//    implicit
+//    tailToHList: KToHList[KList[F, T]],
+//  ): KToHList.Aux[KL, F[H] :: tailToHList.HL] =
+//    new KToHList[KL] {
+//      override type HL = F[H] :: tailToHList.HL
+//      override def apply(kl: KL): F[H] :: tailToHList.HL = {
+//        kl.head :: tailToHList(kl.tail)
+//      }
+//    }
+}

--- a/core-v1/src/main/scala/klist/ZipWith.scala
+++ b/core-v1/src/main/scala/klist/ZipWith.scala
@@ -1,0 +1,7 @@
+package com.rallyhealth.vapors.v1
+
+package klist
+
+trait ZipWith[F[_]] {}
+
+object ZipWith {}

--- a/core-v1/src/main/scala/klist/ops.scala
+++ b/core-v1/src/main/scala/klist/ops.scala
@@ -1,0 +1,43 @@
+package com.rallyhealth.vapors.v1
+
+package klist
+
+import shapeless.{::, HList}
+
+object ops {
+
+  trait IsKCons[KL <: KList[F, _], F[_]] {
+    type H
+    type T <: HList
+
+    def head(l: KL): F[H]
+    def tail(l: KL): KList[F, T]
+
+    def cons(
+      h: F[H],
+      t: KList[F, T],
+    ): KL
+  }
+
+  object IsKCons {
+
+    type Aux[KL <: KList[F, _], F[_], H0, T0 <: HList] = IsKCons[KL, F] {
+      type H = H0
+      type T = T0
+    }
+
+    implicit def isKCons[F[_], H0, T0 <: HList]: IsKCons.Aux[KCons[F, H0, T0], F, H0, T0] =
+      new IsKCons[KCons[F, H0, T0], F] {
+        override type H = H0
+        override type T = T0
+
+        override def head(kl: KCons[F, H0, T0]): F[H] = kl.head
+        override def tail(kl: KCons[F, H0, T0]): KList[F, T] = kl.tail
+
+        override def cons(
+          h: F[H0],
+          t: KList[F, T],
+        ): KCons[F, H0, T0] = KCons(h, t)
+      }
+  }
+}

--- a/core-v1/src/main/scala/klist/package.scala
+++ b/core-v1/src/main/scala/klist/package.scala
@@ -1,0 +1,7 @@
+package com.rallyhealth.vapors.v1
+
+package object klist {
+
+  // nicer alias for pattern matching
+  final val :^: = KCons
+}

--- a/core-v1/src/main/scala/klist/transforms.scala
+++ b/core-v1/src/main/scala/klist/transforms.scala
@@ -1,0 +1,13 @@
+package com.rallyhealth.vapors.v1
+
+package klist
+
+import cats.{~>, Foldable, Id}
+
+object transforms {
+
+  trait Down[C[_]] extends (C ~> Id) {
+    override def apply[A](fa: C[A]): A
+  }
+
+}

--- a/core-v1/src/test/scala/SimpleConcatToHListSpec.scala
+++ b/core-v1/src/test/scala/SimpleConcatToHListSpec.scala
@@ -1,0 +1,21 @@
+package com.rallyhealth.vapors.v1
+
+import munit.FunSuite
+
+class SimpleConcatToHListSpec extends FunSuite {
+
+  import dsl.simple._
+
+  test("Expr.ConcatToHList works when chained with Expr.WrapAs") {
+    val expected = Person("Alice", 40)
+    val xhl = expected.name.const :: expected.age.const
+    val xp: Any ~:> Person = xhl.concatToHList.as[Person]
+    val observed = xp.run()
+    assertEquals(observed, expected)
+  }
+}
+
+final case class Person(
+  name: String,
+  age: Int,
+)

--- a/core-v1/src/test/scala/SimpleDebuggingSpec.scala
+++ b/core-v1/src/test/scala/SimpleDebuggingSpec.scala
@@ -3,6 +3,7 @@ package com.rallyhealth.vapors.v1
 import algebra.Expr
 
 import munit._
+import shapeless.HNil
 
 class SimpleDebuggingSpec extends FunSuite with CommonDebuggingSpec {
 
@@ -14,11 +15,11 @@ class SimpleDebuggingSpec extends FunSuite with CommonDebuggingSpec {
 
   private val anySeqExpr: Any ~:> Seq[String] = Seq("generic", "expression").const
 
-  test("debug any expr syntax produces the correct output type") {
-    anySeqExpr.debug { state =>
-      val o: Seq[String] = state.output
-    }
-  }
+//  test("debug any expr syntax produces the correct output type") {
+//    anySeqExpr.debug { state =>
+//      val o: Seq[String] = state.output
+//    }
+//  }
 
   private val constValue = 1
   private val constExpr = 1.const
@@ -185,11 +186,10 @@ class SimpleDebuggingSpec extends FunSuite with CommonDebuggingSpec {
   }
 
   test("debug map without initial input") {
-    val seq = Seq(1, 2)
     testExpr(mapEveryExpr).withNoInput.verifyDebuggerCalledWith { state =>
       val (i, ca) = state.input
       assertInputEquals(None, i)
-      assertEquals(ca, seq)
+      assertEquals(ca, mapEveryInput)
       assertEquals(state.output, mapEveryExprOutput)
     }
   }
@@ -200,4 +200,40 @@ class SimpleDebuggingSpec extends FunSuite with CommonDebuggingSpec {
       val o: Seq[Int] = state.output
     }
   }
+
+//  private val zipToHListExpr0 = ("a".const :: 1.const).toHList
+//  private val zipToHListOutput0 = "a" :: 1 :: HNil
+//
+//  test("debug toHList without initial input") {
+//    testExpr(zipToHListExpr0).withNoInput.verifyDebuggerCalledWith { state =>
+//      val i = state.input
+//      assertInputEquals(None, i)
+//      assertEquals(state.output, zipToHListOutput0)
+//    }
+//  }
+//
+//  test("debug toHList syntax works") {
+//    zipToHListExpr0.debug { state =>
+//      assertEquals(state.output, zipToHListOutput0)
+//    }
+//  }
+
+//  private val zipToHListInput1 = 1
+//  private val zipToHListExpr1 = (ident[Int] :: "bananas".const).toHList
+//  private val zipToHListOutput1 = zipToHListInput1 :: "bananas" :: HNil
+//
+//  test("debug toHList with input") {
+//    testExpr(zipToHListExpr1).withInput(zipToHListInput1).verifyDebuggerCalledWith { state =>
+//      val i = state.input
+//      assertInputEquals(Some(zipToHListInput1), i)
+//      assertEquals(state.output, zipToHListOutput1)
+//    }
+//  }
+//
+//  test("debug toHList with input syntax works") {
+//    zipToHListExpr1.debug { state =>
+//      assertEquals(state.input, zipToHListInput1)
+//      assertEquals(state.output, zipToHListOutput1)
+//    }
+//  }
 }

--- a/core-v1/src/test/scala/SimpleJustifiedConcatToHListSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedConcatToHListSpec.scala
@@ -1,0 +1,19 @@
+package com.rallyhealth.vapors.v1
+
+import data.Justified
+
+import munit.FunSuite
+import shapeless.HNil
+
+class SimpleJustifiedConcatToHListSpec extends FunSuite {
+
+  import dsl.simple.justified._
+
+  test("Expr.ConcatToHList returns individual justified values") {
+    val expected = Justified.byConst("Alice") :: Justified.byConst(40) :: HNil
+    val xhl = "Alice".const :: 40.const
+    val xp = xhl.concatToHList
+    val observed = xp.run()
+    assertEquals(observed, expected)
+  }
+}

--- a/core-v1/src/test/scala/SimpleJustifiedZipToHListSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedZipToHListSpec.scala
@@ -1,0 +1,35 @@
+package com.rallyhealth.vapors.v1
+
+import algebra.ZipToHList
+import data.{FactTable, Justified}
+import engine.SimpleEngine
+
+import cats.data.NonEmptyList
+import munit.FunSuite
+import shapeless.HNil
+
+class SimpleJustifiedZipToHListSpec extends FunSuite {
+
+  import dsl.simple.justified._
+
+  test("justified hcons") {
+    val x = 1.const :: "a".const
+    val compute = x.zipToHListWith(ZipToHList.proxy(SimpleEngine[OP](FactTable.empty)))
+    val res = compute(())
+    val expected = Justified.byInference(
+      "map",
+      1 :: "a" :: HNil,
+      NonEmptyList.of(
+        Justified.byInference(
+          "product",
+          (1, "a" :: HNil),
+          NonEmptyList.of(
+            Justified.byConst(1),
+            Justified.byConst("a" :: HNil),
+          ),
+        ),
+      ),
+    )
+    assertEquals(res, expected)
+  }
+}

--- a/core-v1/src/test/scala/SimpleZipToHListSpec.scala
+++ b/core-v1/src/test/scala/SimpleZipToHListSpec.scala
@@ -1,0 +1,21 @@
+package com.rallyhealth.vapors.v1
+
+import algebra.ZipToHList
+import data.FactTable
+import engine.SimpleEngine
+
+import munit.FunSuite
+import shapeless.HNil
+
+class SimpleZipToHListSpec extends FunSuite {
+
+  import dsl.simple._
+
+  test("hlist const") {
+    val x = 1.const :: "a".const
+    val compute = x.zipToHListWith(ZipToHList.proxy(SimpleEngine[OP](FactTable.empty)))
+    val res = compute(())
+    assertEquals(res, 1 :: "a" :: HNil)
+  }
+
+}


### PR DESCRIPTION
- Add support for converting an I ~:> HList into an I ~:> P
  for any product type that can be converted by shapeless.Generic
- Add NonEmptyExprHList for higher-kinded expression operations
- Add concatToHList for cons-ing all the wrapped results into an HList
- Add zipToHList for merging the results and mapping over the wrapper
  type to create an HList of the expression output types
- Separate debugging test from SimpleZipToHListSpec
- Add SimpleZipToHListSpec
- Add SimpleJustifiedZipToHListSpec
- Add SimpleConcatToHListSpec
- Add SimpleJustifiedConcatToHListSpec
- Skip implementation in StandardEngine
- Add Expr.ProxyVisitor