### PR TITLE
Various minor cleanup items that were missed from previous PRs

### DIFF
--- a/circe-v1/src/main/scala/engine/InterpretExprResultAsJson.scala
+++ b/circe-v1/src/main/scala/engine/InterpretExprResultAsJson.scala
@@ -2,8 +2,8 @@ package com.rallyhealth.vapors.v1
 
 package engine
 
-import algebra.{EqualComparable, ExprResult, Extract, WindowComparable}
-import data.ExprState
+import algebra.{EqualComparable, ExprResult, WindowComparable}
+import data.{ExprState, Extract}
 import data.ExtractValue.AsBoolean
 import debug.HasSourceCodeInfo
 import dsl.circe.HasEncoder

--- a/core-v1/src/main/scala/algebra/EqualComparable.scala
+++ b/core-v1/src/main/scala/algebra/EqualComparable.scala
@@ -8,20 +8,20 @@ import shapeless.Id
 /**
   * Defines equality over an effect type `F` with a provided param `OP`
   *
-  * @tparam F the wrapper (or effect) type over which equality is computed
+  * @tparam W the wrapper (or effect) type over which equality is computed
   * @tparam V the value type to compare for equality
   * @tparam OP the custom output parameter type constructor (defined by the imported DSL).
   *            See [[dsl.DslTypes.OP]] for more details.
   */
-trait EqualComparable[F[_], V, OP[_]] {
+trait EqualComparable[W[_], V, OP[_]] {
 
   def isEqual(
-    left: F[V],
-    right: F[V],
+    left: W[V],
+    right: W[V],
   )(implicit
-    opV: OP[F[V]],
-    opO: OP[F[Boolean]],
-  ): F[Boolean]
+    opV: OP[W[V]],
+    opO: OP[W[Boolean]],
+  ): W[Boolean]
 }
 
 object EqualComparable extends LowPriorityEqualComparable {
@@ -40,15 +40,15 @@ object EqualComparable extends LowPriorityEqualComparable {
 
 sealed trait LowPriorityEqualComparable {
 
-  implicit def semigroupalFunctorEq[F[_] : Functor : Semigroupal, V : Eq, OP[_]]: EqualComparable[F, V, OP] =
-    new EqualComparable[F, V, OP] {
+  implicit def semigroupalFunctorEq[W[_] : Functor : Semigroupal, V : Eq, OP[_]]: EqualComparable[W, V, OP] =
+    new EqualComparable[W, V, OP] {
       override final def isEqual(
-        left: F[V],
-        right: F[V],
+        left: W[V],
+        right: W[V],
       )(implicit
-        opV: OP[F[V]],
-        opO: OP[F[Boolean]],
-      ): F[Boolean] = {
+        opV: OP[W[V]],
+        opO: OP[W[Boolean]],
+      ): W[Boolean] = {
         import cats.syntax.apply._
         (left, right).mapN(Eq[V].eqv)
       }

--- a/core-v1/src/main/scala/algebra/Expr.scala
+++ b/core-v1/src/main/scala/algebra/Expr.scala
@@ -4,7 +4,7 @@ package algebra
 
 import cats.data.{NonEmptyList, NonEmptyVector}
 import cats.{Foldable, Functor}
-import data.{ExtractValue, FactTypeSet, TypedFact, Window}
+import data.{Extract, ExtractValue, FactTypeSet, TypedFact, Window}
 import debug.{DebugArgs, Debugging, NoDebugging}
 import lens.{DataPath, VariantLens}
 import logic.{Conjunction, Disjunction, Negation}

--- a/core-v1/src/main/scala/algebra/Expr.scala
+++ b/core-v1/src/main/scala/algebra/Expr.scala
@@ -549,7 +549,7 @@ object Expr {
   final case class IsEqual[-I, +V : OP, W[+_], OP[_]](
     leftExpr: Expr[I, W[V], OP],
     rightExpr: Expr[I, W[V], OP],
-    private[v1] val debugging: Debugging[Nothing, Nothing] = NoDebugging,
+    override private[v1] val debugging: Debugging[Nothing, Nothing] = NoDebugging,
   )(implicit
     eq: EqualComparable[W, V, OP],
     opV: OP[W[V]],

--- a/core-v1/src/main/scala/algebra/ExprResult.scala
+++ b/core-v1/src/main/scala/algebra/ExprResult.scala
@@ -3,9 +3,8 @@ package com.rallyhealth.vapors.v1
 package algebra
 
 import data.ExtractValue.AsBoolean
-import data.{ExprState, Window}
+import data.{ExprState, Extract, Window}
 import logic.{Conjunction, Disjunction, Negation}
-
 import cats.data.NonEmptyVector
 import cats.{Foldable, Functor}
 

--- a/core-v1/src/main/scala/algebra/Extract.scala
+++ b/core-v1/src/main/scala/algebra/Extract.scala
@@ -2,8 +2,6 @@ package com.rallyhealth.vapors.v1
 
 package algebra
 
-import data.Justified
-
 import shapeless.Id
 
 /**
@@ -25,9 +23,5 @@ object Extract {
 
   implicit val identity: Extract[Id] = new Extract[Id] {
     override def extract[A](fa: A): A = fa
-  }
-
-  implicit val justified: Extract[Justified] = new Extract[Justified] {
-    override def extract[A](fa: Justified[A]): A = fa.value
   }
 }

--- a/core-v1/src/main/scala/data/Extract.scala
+++ b/core-v1/src/main/scala/data/Extract.scala
@@ -1,16 +1,14 @@
-package com.rallyhealth.vapors.v1
-
-package algebra
+package com.rallyhealth.vapors.v1.data
 
 import shapeless.Id
 
 /**
-  * Extract the value from a context `F`.
+  * Extract the value from a context [[W]].
   *
   * Although this typeclass exists in alleycats, I don't want to force a dependency on it.
-  *
   * It is simple enough to implement and it is required at the DSL import level, so it won't
-  * be implemented very often by end users.
+  * be implemented very often by end users. Also it may need to evolve in a manner that doesn't
+  * align with the cats typeclass.
   */
 trait Extract[W[_]] {
 

--- a/core-v1/src/main/scala/data/Fact.scala
+++ b/core-v1/src/main/scala/data/Fact.scala
@@ -73,7 +73,7 @@ object Fact {
   * @see [[Fact]]
   */
 sealed trait TypedFact[A] extends Fact {
-  type Value = A
+  override final type Value = A
 }
 
 object TypedFact {

--- a/core-v1/src/main/scala/data/Justified.scala
+++ b/core-v1/src/main/scala/data/Justified.scala
@@ -2,7 +2,7 @@ package com.rallyhealth.vapors.v1
 
 package data
 
-import algebra.{EqualComparable, Extract}
+import algebra.EqualComparable
 import cats.data.{NonEmptyList, NonEmptySet}
 import cats.{Eq, Order}
 import data.ExtractValue.AsBoolean

--- a/core-v1/src/main/scala/data/Justified.scala
+++ b/core-v1/src/main/scala/data/Justified.scala
@@ -206,9 +206,11 @@ object Justified {
 
   implicit def extractValue[V]: ExtractValue[Justified[V], V] = _.value
 
-  implicit val wrapConst: WrapConst[Justified] = new WrapConst[Justified] {
-    override def wrapConst[A](value: A): Justified[A] = Justified.byConst(value)
+  private final case object WrapConstJustified extends WrapConst[Justified, Any] {
+    override def wrapConst[A](value: A)(implicit opA: Any): Justified[A] = Justified.byConst(value)
   }
+
+  implicit def wrapConst[OP[_]]: WrapConst[Justified, OP] = WrapConstJustified.asInstanceOf[WrapConst[Justified, OP]]
 
   private final case object WrapSelectedJustified extends WrapSelected[Justified, Any] {
     override def wrapSelected[I, O](

--- a/core-v1/src/main/scala/data/Justified.scala
+++ b/core-v1/src/main/scala/data/Justified.scala
@@ -2,7 +2,7 @@ package com.rallyhealth.vapors.v1
 
 package data
 
-import algebra.EqualComparable
+import algebra.{EqualComparable, Extract}
 import cats.data.{NonEmptyList, NonEmptySet}
 import cats.{Eq, Order}
 import data.ExtractValue.AsBoolean
@@ -203,6 +203,12 @@ object Justified {
   implicit def orderingByValue[V : Ordering]: Ordering[Justified[V]] = Ordering.by(_.value)
 
   implicit def orderByValue[V : Order]: Order[Justified[V]] = Order.by(_.value)
+
+  private final case object ExtractJustified extends Extract[Justified] {
+    override def extract[A](fa: Justified[A]): A = fa.value
+  }
+
+  implicit def extract: Extract[Justified] = ExtractJustified
 
   implicit def extractValue[V]: ExtractValue[Justified[V], V] = _.value
 

--- a/core-v1/src/main/scala/debug/DebugArgs.scala
+++ b/core-v1/src/main/scala/debug/DebugArgs.scala
@@ -172,10 +172,10 @@ object DebugArgs {
       override type Out = I
     }
 
-  implicit def debugIsEqual[I, V, F[+_], OP[_]]: Aux[Expr.IsEqual[I, V, F, OP], OP, (I, F[V], F[V]), F[Boolean]] =
-    new DebugArgs[Expr.IsEqual[I, V, F, OP], OP] {
-      override type In = (I, F[V], F[V])
-      override type Out = F[Boolean]
+  implicit def debugIsEqual[I, V, W[+_], OP[_]]: Aux[Expr.IsEqual[I, V, W, OP], OP, (I, W[V], W[V]), W[Boolean]] =
+    new DebugArgs[Expr.IsEqual[I, V, W, OP], OP] {
+      override type In = (I, W[V], W[V])
+      override type Out = W[Boolean]
     }
 
   implicit def debugExists[

--- a/core-v1/src/main/scala/debug/HasShow.scala
+++ b/core-v1/src/main/scala/debug/HasShow.scala
@@ -30,10 +30,16 @@ object HasShow extends LowPriorityHasShow {
 
   private final case class Impl[V](show: Show[V]) extends HasShow[V]
 
-  implicit def hasShow[V](implicit show: Show[V]): HasShow[V] = Impl(show)
+  implicit def show[V](implicit s: Show[V]): HasShow[V] = Impl(s)
 }
 
 private[debug] sealed abstract class LowPriorityHasShow {
 
-  implicit def noShow[V]: HasShow[V] = HasShow.none
+  /**
+    * There is no [[Show]] instance available for this type, so just use `.toString`
+    *
+    * Similar to [[dsl.NoOP.~]], this method name is short because it will show up in a lot of places and
+    * it means that you can effectively ignore this parameter.
+    */
+  implicit def ~[V]: HasShow[V] = HasShow.none
 }

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -5,7 +5,7 @@ package dsl
 import algebra._
 import cats.data.NonEmptyVector
 import cats.{Foldable, Functor, Order}
-import data.{FactTypeSet, Window}
+import data.{Extract, FactTypeSet, Window}
 import lens.VariantLens
 import logic.{Conjunction, Disjunction, Logic, Negation}
 

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -24,7 +24,12 @@ trait BuildExprDsl extends DebugExprDsl {
 
   def ident[I](implicit opI: OP[W[I]]): Expr.Identity[W[I], OP]
 
-  def valuesOfType[T](factTypeSet: FactTypeSet[T])(implicit opTs: OP[Seq[W[T]]]): Expr.ValuesOfType[T, W[T], OP]
+  def valuesOfType[T](
+    factTypeSet: FactTypeSet[T],
+  )(implicit
+    opT: OP[T],
+    opTs: OP[Seq[W[T]]],
+  ): Expr.ValuesOfType[T, W[T], OP]
 
   implicit final def logical[I, B](expr: I ~:> W[B]): LogicalExprOps[I, B, W, OP] = new LogicalExprOps(expr)
 
@@ -64,7 +69,7 @@ trait BuildExprDsl extends DebugExprDsl {
 
   implicit def in[I, T](expr: I ~:> W[T]): SelectExprBuilder[I, T]
 
-  trait SelectExprBuilder[-I, A] {
+  abstract class SelectExprBuilder[-I, A](proof: I ~:> W[A]) {
 
     def get[B : Wrappable, O](
       selector: VariantLens.FromTo[A, B],

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -18,7 +18,7 @@ trait BuildExprDsl extends DebugExprDsl {
 
   protected implicit def extract: Extract[W]
 
-  protected implicit def wrapConst: WrapConst[W]
+  protected implicit def wrapConst: WrapConst[W, OP]
 
   protected implicit def wrapSelected: WrapSelected[W, OP]
 
@@ -149,7 +149,7 @@ trait BuildExprDsl extends DebugExprDsl {
           case Expr.Const(wv, _) =>
             val v = Extract[W].extract(wv)
             val window = using(v)
-            val wrappedWindow = WrapConst.wrap(window)
+            val wrappedWindow = wrapConst.wrapConst(window)
             Expr.Const[W[Window[V]], OP](wrappedWindow)
           case _ =>
             Expr.Select[I, W[V], V, W[Window[V]], OP](
@@ -171,7 +171,8 @@ trait BuildExprDsl extends DebugExprDsl {
 
     def within(window: Window[V]): I >=< V = this >=< window
 
-    def >=<(window: Window[V]): I >=< V = Expr.WithinWindow(valueExpr, Expr.Const(WrapConst.wrap(window)))
+    def >=<(window: Window[V]): I >=< V =
+      Expr.WithinWindow(valueExpr, Expr.Const(wrapConst.wrapConst(window)))
 
     def within(expr: I ~:> W[Window[V]]): I >=< V = this >=< expr
 

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -174,11 +174,6 @@ trait BuildExprDsl extends DebugExprDsl {
 
     def >=(expr: I ~:> W[V]): I >=< V = compareExpr(">=", expr)(Window.greaterThanOrEqual(_))
 
-    def within(window: Window[V]): I >=< V = this >=< window
-
-    def >=<(window: Window[V]): I >=< V =
-      Expr.WithinWindow(valueExpr, Expr.Const(wrapConst.wrapConst(window)))
-
     def within(expr: I ~:> W[Window[V]]): I >=< V = this >=< expr
 
     def >=<(expr: I ~:> W[Window[V]]): I >=< V = Expr.WithinWindow(valueExpr, expr)

--- a/core-v1/src/main/scala/dsl/GetAsWrapper.scala
+++ b/core-v1/src/main/scala/dsl/GetAsWrapper.scala
@@ -2,7 +2,8 @@ package com.rallyhealth.vapors.v1
 
 package dsl
 
-import algebra.{Expr, Extract}
+import algebra.Expr
+import data.Extract
 import com.rallyhealth.vapors.v1.lens.VariantLens.FromTo
 import lens.VariantLens
 import shapeless.Id

--- a/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
@@ -4,7 +4,7 @@ package dsl
 
 import algebra._
 import cats.{Functor, Traverse}
-import data.{ExtractValue, Justified}
+import data.{Extract, ExtractValue, Justified}
 import logic.Logic
 import shapeless.<:!<
 

--- a/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
@@ -18,7 +18,7 @@ trait JustifiedBuildExprDsl extends BuildExprDsl with WrapJustifiedImplicits wit
 
   override protected implicit final def extract: Extract[Justified] = Extract.justified
 
-  override protected implicit final def wrapConst: WrapConst[Justified] = Justified.wrapConst
+  override protected implicit final def wrapConst: WrapConst[Justified, OP] = Justified.wrapConst
 
   override protected implicit final def wrapSelected: WrapSelected[Justified, OP] = Justified.wrapSelected
 

--- a/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
@@ -14,7 +14,7 @@ trait JustifiedBuildExprDsl extends WrappedExprDsl with WrapJustifiedImplicits w
 
   override protected implicit final def windowComparable: WindowComparable[Justified, OP] = WindowComparable.justified
 
-  override protected implicit final def extract: Extract[Justified] = Extract.justified
+  override protected implicit final def extract: Extract[Justified] = Justified.extract
 
   override protected implicit final def extractBool[
     B : ExtractValue.AsBoolean,

--- a/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
@@ -3,14 +3,12 @@ package com.rallyhealth.vapors.v1
 package dsl
 
 import algebra._
-import cats.data.NonEmptyList
-import cats.{Foldable, Functor, Traverse}
-import data.{FactTypeSet, Justified}
-import lens.VariantLens
+import cats.{Functor, Traverse}
+import data.{ExtractValue, Justified}
 import logic.Logic
 import shapeless.<:!<
 
-trait JustifiedBuildExprDsl extends BuildExprDsl with WrapJustifiedImplicits with JustifiedDslTypes {
+trait JustifiedBuildExprDsl extends WrappedExprDsl with WrapJustifiedImplicits with JustifiedDslTypes {
 
   override protected implicit final def boolLogic: Logic[Justified, Boolean, OP] = Justified.bool[OP]
 
@@ -18,136 +16,21 @@ trait JustifiedBuildExprDsl extends BuildExprDsl with WrapJustifiedImplicits wit
 
   override protected implicit final def extract: Extract[Justified] = Extract.justified
 
+  override protected implicit final def extractBool[
+    B : ExtractValue.AsBoolean,
+  ]: ExtractValue.AsBoolean[Justified[B]] = { b =>
+    ExtractValue.asBoolean(b.value)
+  }
+
   override protected implicit final def wrapConst: WrapConst[Justified, OP] = Justified.wrapConst
+
+  override protected implicit final def wrapFact: WrapFact[Justified, OP] = Justified.wrapFact
 
   override protected implicit final def wrapSelected: WrapSelected[Justified, OP] = Justified.wrapSelected
 
+  override protected implicit final def wrapQuantifier: WrapQuantifier[Justified, OP] = Justified.wrapQuantifier
+
   override protected final val defn: WrapDefinitions[Justified, OP] = new WrapDefinitions[Justified, OP]
-
-  // TODO: Should this be visible outside this trait?
-  protected def dontShortCircuit: Boolean = false
-
-  override final def ident[I](implicit opI: OP[Justified[I]]): Expr.Identity[Justified[I], OP] = Expr.Identity()
-
-  override final def valuesOfType[T](
-    factTypeSet: FactTypeSet[T],
-  )(implicit
-    opTs: OP[Seq[Justified[T]]],
-  ): Expr.ValuesOfType[T, Justified[T], OP] =
-    Expr.ValuesOfType[T, Justified[T], OP](factTypeSet, Justified.byFact)
-
-  override implicit def const[A](
-    value: A,
-  )(implicit
-    constType: ConstOutputType[Justified, A],
-  ): ConstExprBuilder[constType.Out, OP] =
-    new ConstExprBuilder(constType.wrapConst(value))
-
-  override implicit final def in[I, T](expr: I ~:> Justified[T]): JustifiedSelectExprBuilder[I, T] =
-    new JustifiedSelectExprBuilder(expr)
-
-  final class JustifiedSelectExprBuilder[-I, A](inputExpr: I ~:> Justified[A]) extends SelectExprBuilder[I, A] {
-
-    override def get[B : Wrappable, O](
-      selector: VariantLens.FromTo[A, B],
-    )(implicit
-      sot: SelectOutputType.Aux[Justified, A, B, O],
-      opO: OP[O],
-    ): Expr.Select[I, Justified[A], B, O, OP] = {
-      val lens = VariantLens.id[Justified[A]].extractValue.andThen(selector(VariantLens.id[A]))
-      Expr.Select(inputExpr, lens, sot.wrapSelected(_, lens.path, _))
-    }
-
-    override def getAs[C[_]]: GetAsWrapper[I, Justified, A, C, OP] =
-      new GetAsWrapper(inputExpr)
-
-  }
-
-  override implicit final def hk[I, C[_], A](
-    expr: I ~:> C[Justified[A]],
-  )(implicit
-    ne: NotEmpty[C, A],
-  ): JustifiedHkExprBuilder[I, C, A] =
-    new JustifiedHkExprBuilder(expr)
-
-  override final type SpecificHkExprBuilder[-I, C[_], A] = JustifiedHkExprBuilder[I, C, A]
-
-  final class JustifiedHkExprBuilder[-I, C[_], A](inputExpr: I ~:> C[Justified[A]]) extends HkExprBuilder(inputExpr) {
-
-    override def headOption(
-      implicit
-      foldableC: Foldable[C],
-      opA: OP[A],
-      opO: OP[Option[Justified[A]]],
-    ): Expr.Select[I, C[Justified[A]], Option[Justified[A]], Option[Justified[A]], OP] = {
-      val lens = VariantLens.id[C[Justified[A]]].at(0)
-      Expr.Select(inputExpr, lens, (cwa, opt) => opt)
-    }
-
-    override def exists(
-      conditionExprBuilder: Justified[A] =~:> Justified[Boolean],
-    )(implicit
-      opO: OP[C[Justified[A]]],
-      opA: OP[Justified[A]],
-      opB: OP[Justified[Boolean]],
-      foldC: Foldable[C],
-    ): AndThen[I, C[Justified[A]], Justified[Boolean]] =
-      inputExpr.andThen {
-        Expr.Exists[C, Justified[A], Justified[Boolean], OP](
-          conditionExprBuilder(Expr.Identity()),
-          combineTrue = Justified.byInference("exists", true, _),
-          combineFalse = NonEmptyList
-            .fromList(_)
-            .map { justified =>
-              Justified.byInference("exists", false, justified)
-            }
-            .getOrElse {
-              // exists in an empty collection is false
-              // TODO: Should I put a reason instead of just a const?
-              //       Maybe I should pass the original value in these functions?
-              Justified.byConst(false)
-            },
-          dontShortCircuit,
-        )
-      }
-
-    override def forall(
-      conditionExprBuilder: Justified[A] =~:> Justified[Boolean],
-    )(implicit
-      opO: OP[C[Justified[A]]],
-      opA: OP[Justified[A]],
-      opB: OP[Justified[Boolean]],
-      foldC: Foldable[C],
-    ): AndThen[I, C[Justified[A]], Justified[Boolean]] =
-      inputExpr.andThen {
-        Expr.ForAll[C, Justified[A], Justified[Boolean], OP](
-          conditionExprBuilder(Expr.Identity()),
-          combineTrue = NonEmptyList
-            .fromList(_)
-            .map { justified =>
-              Justified.byInference("forall", true, justified)
-            }
-            .getOrElse {
-              // forall in an empty collection is true
-              // TODO: Should I put a reason instead of just a const?
-              Justified.byConst(true)
-            },
-          combineFalse = Justified.byInference("forall", false, _),
-          dontShortCircuit,
-        )
-      }
-
-    override def map[B](
-      mapExprBuilder: Justified[A] =~:> Justified[B],
-    )(implicit
-      opI: OP[Justified[A]],
-      opA: OP[C[Justified[A]]],
-      opB: OP[C[Justified[B]]],
-      functorC: Functor[C],
-    ): AndThen[I, C[Justified[A]], C[Justified[B]]] =
-      inputExpr.andThen(Expr.MapEvery[C, Justified[A], Justified[B], OP](mapExprBuilder(ident)))
-
-  }
 }
 
 sealed trait WrapJustifiedImplicits extends WrapImplicits with MidPriorityJustifiedWrapImplicits {

--- a/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
@@ -31,6 +31,7 @@ trait UnwrappedBuildExprDsl extends BuildExprDsl with UnwrappedImplicits with Un
   override final def valuesOfType[T](
     factTypeSet: FactTypeSet[T],
   )(implicit
+    opT: OP[T],
     opTs: OP[Seq[T]],
   ): Expr.ValuesOfType[T, T, OP] =
     Expr.ValuesOfType(factTypeSet, _.value)
@@ -45,7 +46,7 @@ trait UnwrappedBuildExprDsl extends BuildExprDsl with UnwrappedImplicits with Un
   override implicit final def in[I, T](expr: I ~:> T): UnwrappedSelectExprBuilder[I, T] =
     new UnwrappedSelectExprBuilder(expr)
 
-  final class UnwrappedSelectExprBuilder[-I, A](inputExpr: I ~:> A) extends SelectExprBuilder[I, A] {
+  final class UnwrappedSelectExprBuilder[-I, A](inputExpr: I ~:> A) extends SelectExprBuilder(inputExpr) {
 
     override def get[B : Wrappable, O](
       selector: VariantLens.FromTo[A, B],

--- a/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
@@ -42,9 +42,10 @@ trait UnwrappedBuildExprDsl extends BuildExprDsl with UnwrappedImplicits with Un
   ): ConstExprBuilder[constType.Out, OP] =
     new ConstExprBuilder(constType.wrapConst(value))
 
-  override implicit final def in[I, T](expr: I ~:> T): SelectIdExprBuilder[I, T] = new SelectIdExprBuilder(expr)
+  override implicit final def in[I, T](expr: I ~:> T): UnwrappedSelectExprBuilder[I, T] =
+    new UnwrappedSelectExprBuilder(expr)
 
-  final class SelectIdExprBuilder[-I, A](inputExpr: I ~:> A) extends SelectExprBuilder[I, A] {
+  final class UnwrappedSelectExprBuilder[-I, A](inputExpr: I ~:> A) extends SelectExprBuilder[I, A] {
 
     override def get[B : Wrappable, O](
       selector: VariantLens.FromTo[A, B],
@@ -59,12 +60,16 @@ trait UnwrappedBuildExprDsl extends BuildExprDsl with UnwrappedImplicits with Un
     override def getAs[C[_]]: GetAsUnwrapped[I, A, C, OP] = new GetAsUnwrapped(inputExpr)
   }
 
-  override implicit final def hk[I, C[_], A](expr: I ~:> C[A])(implicit ne: NotEmpty[C, A]): HkIdExprBuilder[I, C, A] =
-    new HkIdExprBuilder(expr)
+  override implicit final def hk[I, C[_], A](
+    expr: I ~:> C[A],
+  )(implicit
+    ne: NotEmpty[C, A],
+  ): UnwrappedHkExprBuilder[I, C, A] =
+    new UnwrappedHkExprBuilder(expr)
 
-  override final type SpecificHkExprBuilder[-I, C[_], A] = HkIdExprBuilder[I, C, A]
+  override final type SpecificHkExprBuilder[-I, C[_], A] = UnwrappedHkExprBuilder[I, C, A]
 
-  final class HkIdExprBuilder[-I, C[_], A](inputExpr: I ~:> C[A]) extends HkExprBuilder(inputExpr) {
+  final class UnwrappedHkExprBuilder[-I, C[_], A](inputExpr: I ~:> C[A]) extends HkExprBuilder(inputExpr) {
 
     override def headOption(
       implicit

--- a/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
@@ -17,7 +17,7 @@ trait UnwrappedBuildExprDsl extends BuildExprDsl with UnwrappedImplicits with Un
 
   override protected implicit final def extract: Extract[W] = Extract.identity
 
-  override protected implicit final def wrapConst: WrapConst[W] = WrapConst.identity
+  override protected implicit final def wrapConst: WrapConst[W, OP] = WrapConst.unwrapped
 
   override protected implicit final def wrapSelected: WrapSelected[W, OP] = WrapSelected.unwrapped
 

--- a/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
@@ -4,7 +4,7 @@ package dsl
 
 import algebra._
 import cats.{Foldable, Functor, Traverse}
-import data.FactTypeSet
+import data.{Extract, FactTypeSet}
 import lens.VariantLens
 import logic.Logic
 import shapeless.<:!<

--- a/core-v1/src/main/scala/dsl/WrapConst.scala
+++ b/core-v1/src/main/scala/dsl/WrapConst.scala
@@ -14,18 +14,16 @@ import shapeless.Id
   *
   * @tparam W the wrapper type to place the constant values into
   */
-trait WrapConst[W[_]] {
+trait WrapConst[W[_], OP[_]] {
 
-  def wrapConst[A](value: A): W[A]
+  def wrapConst[A](value: A)(implicit opA: OP[A]): W[A]
 }
 
 object WrapConst {
 
-  @inline final def apply[W[_] : WrapConst]: WrapConst[W] = implicitly
-
-  def wrap[W[_], V](value: V)(implicit wrap: WrapConst[W]): W[V] = wrap.wrapConst(value)
-
-  implicit val identity: WrapConst[Id] = new WrapConst[Id] {
-    override def wrapConst[A](value: A): A = value
+  private final object Unwrapped extends WrapConst[Id, Any] {
+    override def wrapConst[A](value: A)(implicit opA: Any): A = value
   }
+
+  implicit final def unwrapped[OP[_]]: WrapConst[Id, OP] = Unwrapped.asInstanceOf[WrapConst[Id, OP]]
 }

--- a/core-v1/src/main/scala/dsl/WrapFact.scala
+++ b/core-v1/src/main/scala/dsl/WrapFact.scala
@@ -1,0 +1,20 @@
+package com.rallyhealth.vapors.v1
+
+package dsl
+
+import com.rallyhealth.vapors.v1.data.TypedFact
+import shapeless.Id
+
+trait WrapFact[W[_], OP[_]] {
+
+  def wrapFact[O](fact: TypedFact[O])(implicit opO: OP[O]): W[O]
+}
+
+object WrapFact {
+
+  private final object Unwrapped extends WrapFact[Id, Any] {
+    override def wrapFact[O](fact: TypedFact[O])(implicit opO: Any): O = fact.value
+  }
+
+  implicit def unwrapped[OP[_]]: WrapFact[Id, OP] = Unwrapped.asInstanceOf[WrapFact[Id, OP]]
+}

--- a/core-v1/src/main/scala/dsl/WrapImplicits.scala
+++ b/core-v1/src/main/scala/dsl/WrapImplicits.scala
@@ -60,9 +60,11 @@ trait LowPriorityWrapImplicits {
   protected def defn: WrapDefinitions[W, OP]
 }
 
-final class WrapDefinitions[W[+_] : WrapConst, OP[_]](implicit wrapElementW: WrapSelected[W, OP]) {
-
-  private val wrapConstW: WrapConst[W] = implicitly
+final class WrapDefinitions[W[+_], OP[_]](
+  implicit
+  wrapElementW: WrapSelected[W, OP],
+  wrapConstW: WrapConst[W, OP],
+) {
 
   def constFunctor[C[_] : Functor, O : OP](cot: ConstOutputType[W, O]): ConstOutputType.Aux[W, C[O], C[cot.Out]] =
     new ConstOutputType[W, C[O]] {

--- a/core-v1/src/main/scala/dsl/WrapQuantifier.scala
+++ b/core-v1/src/main/scala/dsl/WrapQuantifier.scala
@@ -1,0 +1,16 @@
+package com.rallyhealth.vapors.v1.dsl
+
+import cats.data.NonEmptyList
+
+trait WrapQuantifier[W[+_], OP[_]] {
+
+  def shortCircuit: Boolean
+
+  def wrapFalseForAll(falseResults: NonEmptyList[W[Boolean]])(implicit opB: OP[W[Boolean]]): W[Boolean]
+
+  def wrapTrueForAll(trueResults: List[W[Boolean]])(implicit opB: OP[W[Boolean]]): W[Boolean]
+
+  def wrapFalseExists(falseResults: List[W[Boolean]])(implicit opB: OP[W[Boolean]]): W[Boolean]
+
+  def wrapTrueExists(trueResults: NonEmptyList[W[Boolean]])(implicit opB: OP[W[Boolean]]): W[Boolean]
+}

--- a/core-v1/src/main/scala/dsl/WrappedExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/WrappedExprDsl.scala
@@ -1,0 +1,126 @@
+package com.rallyhealth.vapors.v1
+
+package dsl
+
+import algebra.{Expr, Extract}
+import cats.{Foldable, Functor}
+import data.{ExtractValue, FactTypeSet}
+import dsl.SelectOutputType.Aux
+import lens.VariantLens
+
+trait WrappedExprDsl extends BuildExprDsl {
+  self: DslTypes with WrapImplicits =>
+
+  protected implicit def extract: Extract[W]
+
+  protected implicit def extractBool[B : ExtractValue.AsBoolean]: ExtractValue.AsBoolean[W[B]]
+
+  protected implicit def wrapQuantifier: WrapQuantifier[W, OP]
+
+  protected implicit def wrapFact: WrapFact[W, OP]
+
+  protected implicit def wrapSelected: WrapSelected[W, OP]
+
+  override def ident[I](implicit opI: OP[W[I]]): Expr.Identity[W[I], OP] = Expr.Identity()
+
+  override def valuesOfType[T](
+    factTypeSet: FactTypeSet[T],
+  )(implicit
+    opT: OP[T],
+    opTs: OP[Seq[W[T]]],
+  ): Expr.ValuesOfType[T, W[T], OP] =
+    Expr.ValuesOfType(factTypeSet, wrapFact.wrapFact(_))
+
+  override implicit def const[A](
+    value: A,
+  )(implicit
+    constType: ConstOutputType[W, A],
+  ): ConstExprBuilder[constType.Out, OP] =
+    new ConstExprBuilder(constType.wrapConst(value))
+
+  override implicit def in[I, T](expr: I ~:> W[T]): WrappedSelectExprBuilder[I, T] = new WrappedSelectExprBuilder(expr)
+
+  class WrappedSelectExprBuilder[-I, A](inputExpr: I ~:> W[A]) extends SelectExprBuilder(inputExpr) {
+
+    override def get[B : Wrappable, O](
+      selector: VariantLens.FromTo[A, B],
+    )(implicit
+      sot: Aux[W, A, B, O],
+      opO: OP[O],
+    ): Expr.Select[I, W[A], B, O, OP] = {
+      val lens = VariantLens.id[W[A]].extractValue.andThen(selector(VariantLens.id[A]))
+      Expr.Select(inputExpr, lens, sot.wrapSelected(_, lens.path, _))
+    }
+
+    override def getAs[C[_]]: GetAsWrapper[I, W, A, C, OP] = new GetAsWrapper(inputExpr)
+  }
+
+  override implicit def hk[I, C[_], A](
+    expr: I ~:> C[W[A]],
+  )(implicit
+    ne: NotEmpty[C, A],
+  ): WrappedHkExprBuilder[I, C, A] = new WrappedHkExprBuilder(expr)
+
+  override type SpecificHkExprBuilder[-I, C[_], A] = WrappedHkExprBuilder[I, C, A]
+
+  class WrappedHkExprBuilder[-I, C[_], A](inputExpr: I ~:> C[W[A]]) extends HkExprBuilder(inputExpr) {
+
+    override def headOption(
+      implicit
+      foldableC: Foldable[C],
+      opA: OP[A],
+      opO: OP[Option[W[A]]],
+    ): Expr.Select[I, C[W[A]], Option[W[A]], Option[W[A]], OP] = {
+      val lens = VariantLens.id[C[W[A]]].at(0)
+      Expr.Select(inputExpr, lens, (cwa, opt) => opt)
+    }
+
+    override def exists(
+      conditionExprBuilder: W[A] =~:> W[Boolean],
+    )(implicit
+      opO: OP[C[W[A]]],
+      opA: OP[W[A]],
+      opB: OP[W[Boolean]],
+      foldC: Foldable[C],
+    ): AndThen[I, C[W[A]], W[Boolean]] = {
+      val condExpr = conditionExprBuilder(Expr.Identity())
+      inputExpr.andThen(
+        Expr.Exists[C, W[A], W[Boolean], OP](
+          condExpr,
+          wrapQuantifier.wrapTrueExists(_),
+          wrapQuantifier.wrapFalseExists(_),
+          wrapQuantifier.shortCircuit,
+        ),
+      )
+    }
+
+    override def forall(
+      conditionExprBuilder: W[A] =~:> W[Boolean],
+    )(implicit
+      opO: OP[C[W[A]]],
+      opA: OP[W[A]],
+      opB: OP[W[Boolean]],
+      foldC: Foldable[C],
+    ): AndThen[I, C[W[A]], W[Boolean]] = {
+      val condExpr = conditionExprBuilder(Expr.Identity())
+      inputExpr.andThen(
+        Expr.ForAll[C, W[A], W[Boolean], OP](
+          condExpr,
+          wrapQuantifier.wrapTrueForAll(_),
+          wrapQuantifier.wrapFalseForAll(_),
+          wrapQuantifier.shortCircuit,
+        ),
+      )
+    }
+
+    override def map[B](
+      mapExprBuilder: W[A] =~:> W[B],
+    )(implicit
+      opI: OP[W[A]],
+      opA: OP[C[W[A]]],
+      opB: OP[C[W[B]]],
+      functorC: Functor[C],
+    ): AndThen[I, C[W[A]], C[W[B]]] =
+      inputExpr.andThen(Expr.MapEvery(mapExprBuilder(ident)))
+  }
+}

--- a/core-v1/src/main/scala/dsl/WrappedExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/WrappedExprDsl.scala
@@ -2,9 +2,9 @@ package com.rallyhealth.vapors.v1
 
 package dsl
 
-import algebra.{Expr, Extract}
+import algebra.Expr
 import cats.{Foldable, Functor}
-import data.{ExtractValue, FactTypeSet}
+import data.{Extract, ExtractValue, FactTypeSet}
 import dsl.SelectOutputType.Aux
 import lens.VariantLens
 

--- a/core-v1/src/main/scala/engine/SimpleEngine.scala
+++ b/core-v1/src/main/scala/engine/SimpleEngine.scala
@@ -2,9 +2,9 @@ package com.rallyhealth.vapors.v1
 
 package engine
 
-import algebra.{EqualComparable, Expr, Extract, WindowComparable}
+import algebra.{EqualComparable, Expr, WindowComparable}
 import cats.{Foldable, Functor}
-import data.{ExprState, ExtractValue, FactTable, Window}
+import data.{ExprState, Extract, ExtractValue, FactTable, Window}
 import debug.DebugArgs
 import debug.DebugArgs.Invoker
 import logic.{Conjunction, Disjunction, Negation}

--- a/core-v1/src/main/scala/engine/StandardEngine.scala
+++ b/core-v1/src/main/scala/engine/StandardEngine.scala
@@ -3,7 +3,7 @@ package com.rallyhealth.vapors.v1
 package engine
 
 import algebra._
-import data.{ExprState, ExtractValue, Window}
+import data.{ExprState, Extract, ExtractValue, Window}
 import debug.DebugArgs
 import logic.{Conjunction, Disjunction, Negation}
 import cats.{Foldable, Functor}

--- a/core-v1/src/main/scala/lens/VariantLens.scala
+++ b/core-v1/src/main/scala/lens/VariantLens.scala
@@ -2,14 +2,14 @@ package com.rallyhealth.vapors.v1
 
 package lens
 
-import algebra.Extract
 import cats.arrow.Compose
 import cats.data.NonEmptySet
 import cats.kernel.Semigroup
+import data.Extract
 import shapeless.ops.hlist
 import shapeless.{Generic, HList}
 
-import scala.collection.{Factory, MapView, View}
+import scala.collection.{Factory, View}
 
 // TODO: Rename to NamedLens after old algebra removed
 /**

--- a/core-v1/src/main/scala/logic/Conjunction.scala
+++ b/core-v1/src/main/scala/logic/Conjunction.scala
@@ -7,28 +7,30 @@ import shapeless.Id
 import scala.annotation.implicitNotFound
 
 /**
-  * Defines the `AND` operation for values of the same type [[B]] over some wrapper (or effect) type [[F]], while
+  * Defines the `AND` operation for values of the same type [[B]] over some wrapper (or effect) type [[W]], while
   * being provided a custom output parameter of type [[OP]].
   *
   * TODO: Should this allow short-circuiting? Maybe return an Option or Eval?
   *
-  * @tparam F the wrapper (or effect) type over which equality is computed
+  * @tparam W the wrapper (or effect) type over which equality is computed
   * @tparam B the boolean-like value type to perform conjunction
   * @tparam OP a custom output parameter type used by visitors to enable post-processing operations.
   *            See [[dsl.DslTypes.OP]] for more details.
   */
 @implicitNotFound(
-  """Cannot perform a logical AND operation on values of type ${F}[${B}] with an output parameter of ${OP}. 
-To define conjunction for a custom type (aka the AND operation), you must define or import an instance of Conjunction[${F}, ${B}, ${OP}]""",
+  """
+Cannot perform a logical AND operation on values of type ${W}[${B}] with an output parameter of ${OP}.
+
+To define conjunction for a custom type (aka the AND operation), you must define or import an instance of Conjunction[${W}, ${B}, ${OP}]""",
 )
-trait Conjunction[F[_], B, OP[_]] {
+trait Conjunction[W[_], B, OP[_]] {
 
   def and(
-    left: F[B],
-    right: F[B],
+    left: W[B],
+    right: W[B],
   )(implicit
-    opB: OP[F[B]],
-  ): F[B]
+    opB: OP[W[B]],
+  ): W[B]
 }
 
 object Conjunction {

--- a/core-v1/src/main/scala/logic/Disjunction.scala
+++ b/core-v1/src/main/scala/logic/Disjunction.scala
@@ -7,28 +7,30 @@ import shapeless.Id
 import scala.annotation.implicitNotFound
 
 /**
-  * Defines the `OR` operation for values of the same type [[B]] over some wrapper (or effect) type [[F]], while
+  * Defines the `OR` operation for values of the same type [[B]] over some wrapper (or effect) type [[W]], while
   * being provided a custom output parameter of type [[OP]].
   *
   * TODO: Should this allow short-circuiting? Maybe return an Option or Eval?
   *
-  * @tparam F the wrapper (or effect) type over which equality is computed
+  * @tparam W the wrapper (or effect) type over which equality is computed
   * @tparam B the boolean-like value type to perform conjunction
   * @tparam OP a custom output parameter type used by visitors to enable post-processing operations.
   *            See [[dsl.DslTypes.OP]] for more details.
   */
 @implicitNotFound(
-  """Cannot perform a logical OR operation on values of type ${F}[${B}] with an output parameter of ${OP}. 
-To define disjunction for a custom type (aka the OR operation), you must define or import an instance of Disjunction[${F}, ${B}, ${OP}]""",
+  """
+Cannot perform a logical OR operation on values of type ${W}[${B}] with an output parameter of ${OP}.
+
+To define disjunction for a custom type (aka the OR operation), you must define or import an instance of Disjunction[${W}, ${B}, ${OP}]""",
 )
-trait Disjunction[F[_], B, OP[_]] {
+trait Disjunction[W[_], B, OP[_]] {
 
   def or(
-    left: F[B],
-    right: F[B],
+    left: W[B],
+    right: W[B],
   )(implicit
-    opB: OP[F[B]],
-  ): F[B]
+    opB: OP[W[B]],
+  ): W[B]
 }
 
 object Disjunction {

--- a/core-v1/src/main/scala/logic/Logic.scala
+++ b/core-v1/src/main/scala/logic/Logic.scala
@@ -10,16 +10,18 @@ import scala.annotation.implicitNotFound
   * Combines all the logical operations (`AND` / `OR` / `NOT`) into a single trait to make it easier
   * to define without having to pass 3 type parameters to 3 separate traits.
   *
-  * @tparam F the wrapper (or effect) type over which equality is computed
+  * @tparam W the wrapper (or effect) type over which equality is computed
   * @tparam B the boolean-like value type to perform the logical operations
   * @tparam OP a custom output parameter type used by visitors to enable post-processing operations.
   *            See [[dsl.DslTypes.OP]] for more details.
   */
 @implicitNotFound(
-  """Cannot perform a logical operations (like AND / OR / NOT) on values of type ${F}[${B}] with an output parameter of ${OP}. 
-To define the operations, you must define or import an instance of Logic[${F}, ${B}, ${OP}]""",
+  """
+Cannot perform a logical operations (like AND / OR / NOT) on values of type ${W}[${B}] with an output parameter of ${OP}.
+
+To define the operations, you must define or import an instance of Logic[${W}, ${B}, ${OP}]""",
 )
-trait Logic[F[_], B, OP[_]] extends Conjunction[F, B, OP] with Disjunction[F, B, OP] with Negation[F, B, OP]
+trait Logic[W[_], B, OP[_]] extends Conjunction[W, B, OP] with Disjunction[W, B, OP] with Negation[W, B, OP]
 
 object Logic {
 

--- a/core-v1/src/main/scala/logic/Negation.scala
+++ b/core-v1/src/main/scala/logic/Negation.scala
@@ -2,7 +2,6 @@ package com.rallyhealth.vapors.v1
 
 package logic
 
-import cats.{Invariant, Semigroupal}
 import shapeless.Id
 
 import scala.annotation.implicitNotFound
@@ -13,20 +12,22 @@ import scala.annotation.implicitNotFound
   * @note this is different from defining how to get the negative value of a number.
   */
 @implicitNotFound(
-  """Cannot negate a value of type ${F}[${B}] with an output parameter of ${OP}. 
-To define negation for a custom type (aka the NOT operation), you must define or import an instance of Negation[${F}, ${B}, ${OP}]""",
+  """
+Cannot negate a value of type ${W}[${B}] with an output parameter of ${OP}.
+
+To define negation for a custom type (aka the NOT operation), you must define or import an instance of Negation[${W}, ${B}, ${OP}]""",
 )
-trait Negation[F[_], B, OP[_]] {
+trait Negation[W[_], B, OP[_]] {
 
   /**
     * Negates the logical interpretation of a given value of type [[B]].
     *
-    * In other words, if the value of `F[B]` is "truthy", then the negation of that value must be "falsy" and, likewise,
-    * if the value of `F[B]` is "falsy", then the negation of that value must by "truthy." If the given value is neither
+    * In other words, if the value of `W[B]` is "truthy", then the negation of that value must be "falsy" and, likewise,
+    * if the value of `W[B]` is "falsy", then the negation of that value must by "truthy." If the given value is neither
     * "truthy" nor "falsy," then this should return that value unchanged. However, you should consider why you want
     * to allow negating a type that contains non-boolean values.
     */
-  def not(value: F[B])(implicit opB: OP[F[B]]): F[B]
+  def not(value: W[B])(implicit opB: OP[W[B]]): W[B]
 }
 
 object Negation {


### PR DESCRIPTION
Did some cleanup that was missed in previous PRs

- Rename "Id" builders to Unwrapped
- Rename F[_] to W[_] everywhere to be consistent
- Add override to IsEqual to be consistent
- Convert WrapConst to take OP[_] type
- Create WrappedExprDsl and add missing behavior traits
  - Move Extract to WrappedExprDsl
  - Move WrapSelected to WrappedExprDsl
  - Add WrapFact
  - Add WrapQuantifier
- Move Extract.justified to Justified companion object
- Move Extract typeclass to data package
- Shorten names of implicit methods for HasShow