### PR TITLE
Add support for Justification of elements using a DataPath with index

### DIFF
--- a/core-v1/src/main/scala/data/Justified.scala
+++ b/core-v1/src/main/scala/data/Justified.scala
@@ -3,13 +3,11 @@ package com.rallyhealth.vapors.v1
 package data
 
 import algebra.EqualComparable
+
 import cats.data.{NonEmptyList, NonEmptySeq, NonEmptySet, NonEmptyVector}
-import cats.{Eq, Order}
-import cats.data.{NonEmptyList, NonEmptySeq, NonEmptySet}
-import cats.{Eq, Functor, Order}
-import cats.syntax.show._
-import data.ExtractValue.AsBoolean
-import dsl.{WrapConst, WrapFact, WrapQuantifier, WrapSelected}
+import cats.implicits._
+import cats.{Eq, Functor, Order, Traverse}
+import dsl.{SelectOutputType, WrapConst, WrapFact, WrapQuantifier, WrapSelected}
 import lens.{DataPath, VariantLens}
 import logic.Logic
 import math.Add
@@ -187,6 +185,12 @@ object Justified {
     override lazy val evidence: Evidence =
       sources.foldLeft(Evidence.none)(_ | _.evidence) // TODO: Is this even valid?
     override def visit[G[+_]](v: Visitor[G]): G[V] = v.visitInference(this)
+  }
+
+  def elements[C[_] : Traverse, A](collection: Justified[C[A]]): C[Justified[A]] = {
+    collection.value.mapWithIndex { (a, idx) =>
+      Justified.bySelection(a, DataPath.empty.atIndex(idx), collection)
+    }
   }
 
   implicit def eq[V : Eq, OP[_]]: EqualComparable[Justified, V, OP] =

--- a/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
@@ -3,9 +3,10 @@ package com.rallyhealth.vapors.v1
 package dsl
 
 import algebra._
-import cats.{Functor, Traverse}
 import data.{Extract, ExtractValue, Justified}
 import logic.Logic
+
+import cats.Traverse
 import shapeless.<:!<
 
 trait JustifiedBuildExprDsl extends WrappedExprDsl with WrapJustifiedImplicits with JustifiedDslTypes {
@@ -35,10 +36,11 @@ trait JustifiedBuildExprDsl extends WrappedExprDsl with WrapJustifiedImplicits w
 
 sealed trait WrapJustifiedImplicits extends WrapImplicits with MidPriorityJustifiedWrapImplicits {
 
-  override implicit def constFunctor[C[_] : Functor, O : OP](
+  override implicit def constTraverse[C[_] : Traverse, O](
     implicit
-    cot: ConstOutputType[Justified, O],
-  ): ConstOutputType.Aux[Justified, C[O], C[cot.Out]] = defn.constFunctor(cot)
+    sot: SelectOutputType[Justified, C[O], O],
+    opCO: OP[C[O]],
+  ): ConstOutputType.Aux[Justified, C[O], C[sot.Out]] = defn.constTraverse(sot)
 
   override implicit def selectOption[I : OP, O : OP](
     implicit

--- a/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
@@ -8,6 +8,7 @@ import lens.VariantLens
 import logic.Logic
 
 import cats.{Foldable, Functor, FunctorFilter, Traverse}
+import com.rallyhealth.vapors.v1.dsl.ConstOutputType.Aux
 import shapeless.<:!<
 
 trait UnwrappedBuildExprDsl extends BuildExprDsl with UnwrappedImplicits with UnwrappedDslTypes {
@@ -138,10 +139,11 @@ trait UnwrappedBuildExprDsl extends BuildExprDsl with UnwrappedImplicits with Un
 
 sealed trait UnwrappedImplicits extends MidPriorityUnwrappedImplicits with WrapImplicits {
 
-  override implicit final def constFunctor[C[_] : Functor, O : OP](
+  override implicit def constTraverse[C[_] : Traverse, O](
     implicit
-    cot: ConstOutputType[W, O],
-  ): ConstOutputType.Aux[W, C[O], C[cot.Out]] = defn.constFunctor[C, O](cot)
+    sot: SelectOutputType[W, C[O], O],
+    opCO: OP[C[O]],
+  ): Aux[W, C[O], C[sot.Out]] = defn.constTraverse(sot)
 
   override implicit final def selectOption[I : OP, O : OP](
     implicit

--- a/core-v1/src/test/scala/SimpleJustifiedFilterSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedFilterSpec.scala
@@ -1,6 +1,7 @@
 package com.rallyhealth.vapors.v1
 
-import com.rallyhealth.vapors.v1.data.Justified
+import data.Justified
+
 import munit.FunSuite
 
 class SimpleJustifiedFilterSpec extends FunSuite {
@@ -8,9 +9,11 @@ class SimpleJustifiedFilterSpec extends FunSuite {
   import dsl.simple.justified._
 
   test("Seq[Justified[Int]].filter") {
-    val expr = Seq(1, 2, 3, 4).const.filter(_ < 3.const)
+    val input = Seq(1, 2, 3, 4)
+    val expr = input.const.filter(_ < 3.const)
+    val expected = Justified.elements(Justified.byConst(input)).filter(_.value < 3)
     val res = expr.run()
-    assertEquals(res, Seq(Justified.byConst(1), Justified.byConst(2)))
+    assertEquals(res, expected)
   }
 
   test("Seq[Justified[Nothing]].filter doesn't compile") {

--- a/core-v1/src/test/scala/SimpleJustifiedSortedSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedSortedSpec.scala
@@ -11,15 +11,15 @@ class SimpleJustifiedSortedSpec extends FunSuite {
 
   test("Seq[Int].sorted") {
     val value = Seq(2, 4, 3, 1)
-    val expected = value.sorted
+    val expected = Justified.elements(Justified.byConst(value)).sorted
     val expr = value.const.sorted
     val result = expr.run()
-    assertEquals(result, expected.map(Justified.byConst))
+    assertEquals(result, expected)
   }
 
   test("NonEmptySeq[Int].sorted") {
     val value = NonEmptySeq.of(4, 2, 3, 1)
-    val expected = value.sorted.map(Justified.byConst)
+    val expected = Justified.elements(Justified.byConst(value)).sorted
     val expr = value.const.sorted
     val result = expr.run()
     assertEquals(result, expected)
@@ -27,7 +27,7 @@ class SimpleJustifiedSortedSpec extends FunSuite {
 
   test("NonEmptyList[Int].sorted") {
     val value = NonEmptyList.of(4, 2, 3, 1)
-    val expected = value.sorted.map(Justified.byConst)
+    val expected = Justified.elements(Justified.byConst(value)).sorted
     val expr = value.const.sorted
     val result = expr.run()
     assertEquals(result, expected)
@@ -35,7 +35,7 @@ class SimpleJustifiedSortedSpec extends FunSuite {
 
   test("NonEmptyVector[Int].sorted") {
     val value = NonEmptyVector.of(4, 2, 3, 1)
-    val expected = value.sorted.map(Justified.byConst)
+    val expected = Justified.elements(Justified.byConst(value)).sorted
     val expr = value.const.sorted
     val result = expr.run()
     assertEquals(result, expected)


### PR DESCRIPTION
**Motivation**

When tracking justification for a selection into a constant or result, we should be able to track the index of the value used.