### PR TITLE
Add Expr.Define and Expr.UsingDefinitions, DSL, and unit tests

### DIFF
--- a/core-v1/src/main/scala/algebra/Expr.scala
+++ b/core-v1/src/main/scala/algebra/Expr.scala
@@ -731,7 +731,7 @@ object Expr {
     * @tparam A the type of every element of the input
     * @tparam B the condition result type, which must define a way to be viewed as a `Boolean`
     */
-  final case class Exists[C[_] : Foldable, A, B : ExtractValue.AsBoolean : OP, OP[_]](
+  final case class Exists[-C[_] : Foldable, A, B : ExtractValue.AsBoolean : OP, OP[_]](
     conditionExpr: Expr[A, B, OP],
     combineTrue: NonEmptySeq[B] => B,
     combineFalse: Seq[B] => B,
@@ -755,7 +755,7 @@ object Expr {
     * @tparam A the type of every element of the input
     * @tparam B the condition result type, which must define a way to be viewed as a `Boolean`
     */
-  final case class ForAll[C[_] : Foldable, A, B : ExtractValue.AsBoolean : OP, OP[_]](
+  final case class ForAll[-C[_] : Foldable, A, B : ExtractValue.AsBoolean : OP, OP[_]](
     conditionExpr: Expr[A, B, OP],
     combineTrue: Seq[B] => B,
     combineFalse: NonEmptySeq[B] => B,
@@ -911,7 +911,7 @@ object Expr {
     * @param expressions the sequence of expressions to evaluate in order to create the same sequence of results
     * @tparam C the traversable collection
     */
-  final case class Sequence[C[+_] : Traverse, -I, +O, OP[_]](
+  final case class Sequence[+C[+_] : Traverse, -I, +O, OP[_]](
     expressions: C[Expr[I, O, OP]],
     override private[v1] val debugging: Debugging[Nothing, Nothing] = NoDebugging,
   )(implicit
@@ -943,7 +943,7 @@ object Expr {
     * @tparam A the element type
     * @tparam O the accumulator type, initial value, and output type
     */
-  final case class FoldLeft[-I, C[_] : Foldable, A, O : OP, OP[_]](
+  final case class FoldLeft[-I, +C[_] : Foldable, A, O : OP, OP[_]](
     inputExpr: Expr[I, C[A], OP],
     initExpr: Expr[I, O, OP],
     foldExpr: Expr[(O, A), O, OP],
@@ -1057,7 +1057,7 @@ object Expr {
     * @tparam C a [[Foldable]] collection type that can be used to fold the resulting [[Fact]]s into a single List
     * @tparam T the type of values used to produce [[TypedFact]] instances of the given [[factType]]
     */
-  final case class Define[-I, C[_] : Foldable, T, OP[_]](
+  final case class Define[-I, +C[_] : Foldable, T, OP[_]](
     factType: FactType[T],
     defnExpr: Expr[I, C[T], OP],
     override private[v1] val debugging: Debugging[Nothing, Nothing] = NoDebugging,

--- a/core-v1/src/main/scala/data/FactTable.scala
+++ b/core-v1/src/main/scala/data/FactTable.scala
@@ -20,7 +20,7 @@ final case class FactTable(factsByName: SortedMap[String, FactSet]) extends AnyV
 
   def addAll(facts: Iterable[Fact]): FactTable = {
     import cats.syntax.semigroup._
-    val newFactTable = FactTable(facts)
+    val newFactTable = FactTable.fromSet(facts.toSet)
     new FactTable(this.factsByName |+| newFactTable.factsByName)
   }
 
@@ -55,6 +55,10 @@ object FactTable {
 
   def apply(facts: FactOrFactSet*): FactTable = {
     val factSet = FactOrFactSet.flatten(facts)
+    fromSet(factSet)
+  }
+
+  def fromSet(factSet: FactSet): FactTable = {
     if (factSet.isEmpty) empty
     else new FactTable(SortedMap.from(factSet.groupBy(_.typeInfo.nameAndFullType)))
   }

--- a/core-v1/src/main/scala/debug/DebugArgs.scala
+++ b/core-v1/src/main/scala/debug/DebugArgs.scala
@@ -3,7 +3,7 @@ package com.rallyhealth.vapors.v1
 package debug
 
 import algebra.{Expr, SizeComparison}
-import data.{ExprState, Window}
+import data.{ExprState, FactSet, TypedFact, Window}
 import lens.VariantLens
 
 import cats.data.{NonEmptySeq, NonEmptyVector}
@@ -173,6 +173,12 @@ object DebugArgs {
       override type Out = O
     }
 
+  implicit def debugDefine[I, C[_], T, OP[_]]: Aux[Expr.Define[I, C, T, OP], OP, (I, C[T]), Seq[TypedFact[T]]] =
+    new DebugArgs[Expr.Define[I, C, T, OP], OP] {
+      override type In = (I, C[T])
+      override type Out = Seq[TypedFact[T]]
+    }
+
   implicit def debugIdent[I, OP[_]]: Aux[Expr.Identity[I, OP], OP, I, I] =
     new DebugArgs[Expr.Identity[I, OP], OP] {
       override type In = I
@@ -253,6 +259,12 @@ object DebugArgs {
     new DebugArgs[Expr.Sorted[C, A, OP], OP] {
       override type In = C[A]
       override type Out = C[A]
+    }
+
+  implicit def debugUsingDefinitions[I, O, OP[_]]: Aux[Expr.UsingDefinitions[I, O, OP], OP, (I, FactSet), O] =
+    new DebugArgs[Expr.UsingDefinitions[I, O, OP], OP] {
+      override type In = (I, FactSet)
+      override type Out = O
     }
 
   implicit def debugValuesOfType[T, O, OP[_]]: Aux[Expr.ValuesOfType[T, O, OP], OP, Any, Seq[O]] =

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -12,7 +12,7 @@ import cats.data.{NonEmptySeq, NonEmptyVector}
 import cats.{FlatMap, Foldable, Functor, FunctorFilter, Id, Order, Reducible, Traverse}
 import shapeless.{Generic, HList}
 
-trait BuildExprDsl extends DebugExprDsl with WrapArityMethods {
+trait BuildExprDsl extends DebugExprDsl with WrapArityMethods with UsingDefinitionArityMethods {
   self: DslTypes with ExprHListDslImplicits with OutputTypeImplicits =>
 
   /**
@@ -56,8 +56,6 @@ trait BuildExprDsl extends DebugExprDsl with WrapArityMethods {
   def define[T](factType: FactType[T]): DefineBuilder[T]
 
   abstract class DefineBuilder[T](factType: FactType[T]) {
-
-    // TODO: fromSources() with arity function support
 
     def oneFrom(
       defnExpr: Any ~:> W[T],
@@ -103,7 +101,11 @@ trait BuildExprDsl extends DebugExprDsl with WrapArityMethods {
       Expr.Define(factType, Expr.Const(Foldable[C].toList(values): Seq[T]))
   }
 
-  // TODO: Support function builder syntax
+  @deprecated(
+    """You should use the using().thenReturn(...) DSL method instead.
+    
+You should prefer put your declaration of dependency on definitions close to where you actually use them.""",
+  )
   final def usingDefinitions[I, O](
     definitions: Expr.Definition[I, OP]*,
   )(

--- a/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
@@ -14,6 +14,7 @@ import shapeless.{Generic, HList, Nat}
 
 trait UnwrappedBuildExprDsl
   extends BuildExprDsl
+  with UnwrappedUsingDefinitionArityMethods
   with DefaultUnwrappedExprHListImplicits
   with DefaultUnwrappedOutputTypeImplicits
   with UnwrappedDslTypes {

--- a/core-v1/src/main/scala/dsl/UnwrappedUsingDefinitionArityMethods.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedUsingDefinitionArityMethods.scala
@@ -1,0 +1,226 @@
+package com.rallyhealth.vapors.v1
+
+package dsl
+import algebra.Expr
+
+trait UnwrappedUsingDefinitionArityMethods extends UsingDefinitionArityMethods with UnwrappedDslTypes {
+
+  override def using[I, A : OP](a: Expr.Define[I, Any, A, OP])(implicit opSA: OP[Seq[A]]): UsingFn1[I, A, OP] =
+    new UsingFn1(Seq(a), valuesOfType(a.factType))
+
+  override def using[I, A : OP, B : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+  )(implicit
+    opSA: OP[Seq[A]],
+    opSB: OP[Seq[B]],
+  ): UsingFn2[I, A, B, OP] =
+    new UsingFn2(Seq(a, b), valuesOfType(a.factType), valuesOfType(b.factType))
+
+  override def using[I, A : OP, B : OP, C : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+  )(implicit
+    opSA: OP[Seq[A]],
+    opSB: OP[Seq[B]],
+    opSC: OP[Seq[C]],
+  ): UsingFn3[I, A, B, C, OP] =
+    new UsingFn3(Seq(a, b, c), valuesOfType(a.factType), valuesOfType(b.factType), valuesOfType(c.factType))
+
+  override def using[I, A : OP, B : OP, C : OP, D : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+  )(implicit
+    opSA: OP[Seq[A]],
+    opSB: OP[Seq[B]],
+    opSC: OP[Seq[C]],
+    opSD: OP[Seq[D]],
+  ): UsingFn4[I, A, B, C, D, OP] =
+    new UsingFn4(
+      Seq(a, b, c, d),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+    )
+
+  override def using[I, A : OP, B : OP, C : OP, D : OP, E : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+    e: Expr.Define[I, Any, E, OP],
+  )(implicit
+    opSA: OP[Seq[A]],
+    opSB: OP[Seq[B]],
+    opSC: OP[Seq[C]],
+    opSD: OP[Seq[D]],
+    opSE: OP[Seq[E]],
+  ): UsingFn5[I, A, B, C, D, E, OP] =
+    new UsingFn5(
+      Seq(a, b, c, d, e),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+      valuesOfType(e.factType),
+    )
+
+  override def using[I, A : OP, B : OP, C : OP, D : OP, E : OP, F : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+    e: Expr.Define[I, Any, E, OP],
+    f: Expr.Define[I, Any, F, OP],
+  )(implicit
+    opSA: OP[Seq[A]],
+    opSB: OP[Seq[B]],
+    opSC: OP[Seq[C]],
+    opSD: OP[Seq[D]],
+    opSE: OP[Seq[E]],
+    opSF: OP[Seq[F]],
+  ): UsingFn6[I, A, B, C, D, E, F, OP] =
+    new UsingFn6(
+      Seq(a, b, c, d, e, f),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+      valuesOfType(e.factType),
+      valuesOfType(f.factType),
+    )
+
+  override def using[I, A : OP, B : OP, C : OP, D : OP, E : OP, F : OP, G : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+    e: Expr.Define[I, Any, E, OP],
+    f: Expr.Define[I, Any, F, OP],
+    g: Expr.Define[I, Any, G, OP],
+  )(implicit
+    opSA: OP[Seq[A]],
+    opSB: OP[Seq[B]],
+    opSC: OP[Seq[C]],
+    opSD: OP[Seq[D]],
+    opSE: OP[Seq[E]],
+    opSF: OP[Seq[F]],
+    opSG: OP[Seq[G]],
+  ): UsingFn7[I, A, B, C, D, E, F, G, OP] =
+    new UsingFn7(
+      Seq(a, b, c, d, e, f, g),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+      valuesOfType(e.factType),
+      valuesOfType(f.factType),
+      valuesOfType(g.factType),
+    )
+
+  override def using[I, A : OP, B : OP, C : OP, D : OP, E : OP, F : OP, G : OP, H : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+    e: Expr.Define[I, Any, E, OP],
+    f: Expr.Define[I, Any, F, OP],
+    g: Expr.Define[I, Any, G, OP],
+    h: Expr.Define[I, Any, H, OP],
+  )(implicit
+    opSA: OP[Seq[A]],
+    opSB: OP[Seq[B]],
+    opSC: OP[Seq[C]],
+    opSD: OP[Seq[D]],
+    opSE: OP[Seq[E]],
+    opSF: OP[Seq[F]],
+    opSG: OP[Seq[G]],
+    opSH: OP[Seq[H]],
+  ): UsingFn8[I, A, B, C, D, E, F, G, H, OP] =
+    new UsingFn8(
+      Seq(a, b, c, d, e, f, g, h),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+      valuesOfType(e.factType),
+      valuesOfType(f.factType),
+      valuesOfType(g.factType),
+      valuesOfType(h.factType),
+    )
+
+  override def using[I, A : OP, B : OP, C : OP, D : OP, E : OP, F : OP, G : OP, H : OP, J : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+    e: Expr.Define[I, Any, E, OP],
+    f: Expr.Define[I, Any, F, OP],
+    g: Expr.Define[I, Any, G, OP],
+    h: Expr.Define[I, Any, H, OP],
+    j: Expr.Define[I, Any, J, OP],
+  )(implicit
+    opSA: OP[Seq[A]],
+    opSB: OP[Seq[B]],
+    opSC: OP[Seq[C]],
+    opSD: OP[Seq[D]],
+    opSE: OP[Seq[E]],
+    opSF: OP[Seq[F]],
+    opSG: OP[Seq[G]],
+    opSH: OP[Seq[H]],
+    opSJ: OP[Seq[J]],
+  ): UsingFn9[I, A, B, C, D, E, F, G, H, J, OP] =
+    new UsingFn9(
+      Seq(a, b, c, d, e, f, g, h, j),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+      valuesOfType(e.factType),
+      valuesOfType(f.factType),
+      valuesOfType(g.factType),
+      valuesOfType(h.factType),
+      valuesOfType(j.factType),
+    )
+
+  override def using[I, A : OP, B : OP, C : OP, D : OP, E : OP, F : OP, G : OP, H : OP, J : OP, K : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+    e: Expr.Define[I, Any, E, OP],
+    f: Expr.Define[I, Any, F, OP],
+    g: Expr.Define[I, Any, G, OP],
+    h: Expr.Define[I, Any, H, OP],
+    j: Expr.Define[I, Any, J, OP],
+    k: Expr.Define[I, Any, K, OP],
+  )(implicit
+    opSA: OP[Seq[A]],
+    opSB: OP[Seq[B]],
+    opSC: OP[Seq[C]],
+    opSD: OP[Seq[D]],
+    opSE: OP[Seq[E]],
+    opSF: OP[Seq[F]],
+    opSG: OP[Seq[G]],
+    opSH: OP[Seq[H]],
+    opSJ: OP[Seq[J]],
+    opSK: OP[Seq[K]],
+  ): UsingFn10[I, A, B, C, D, E, F, G, H, J, K, OP] =
+    new UsingFn10(
+      Seq(a, b, c, d, e, f, g, h, j, k),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+      valuesOfType(e.factType),
+      valuesOfType(f.factType),
+      valuesOfType(g.factType),
+      valuesOfType(h.factType),
+      valuesOfType(j.factType),
+      valuesOfType(k.factType),
+    )
+}

--- a/core-v1/src/main/scala/dsl/UsingDefinitionArityMethods.scala
+++ b/core-v1/src/main/scala/dsl/UsingDefinitionArityMethods.scala
@@ -1,0 +1,237 @@
+package com.rallyhealth.vapors.v1
+
+package dsl
+
+import algebra.Expr
+import data.FactTypeSet
+
+trait UsingDefinitionArityMethods {
+  self: DslTypes =>
+
+  // For some reason, IntelliJ highlights errors in this file unless this method is defined here as well
+  protected def valuesOfType[T](
+    factTypeSet: FactTypeSet[T],
+  )(implicit
+    opT: OP[T],
+    opTs: OP[Seq[W[T]]],
+  ): Expr.ValuesOfType[T, W[T], OP]
+
+  def using[I, A : OP](a: Expr.Define[I, Any, A, OP])(implicit opSA: OP[Seq[W[A]]]): UsingFn1[I, W[A], OP] =
+    new UsingFn1(Seq(a), valuesOfType(a.factType))
+
+  def using[I, A : OP, B : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+  )(implicit
+    opSA: OP[Seq[W[A]]],
+    opSB: OP[Seq[W[B]]],
+  ): UsingFn2[I, W[A], W[B], OP] =
+    new UsingFn2(Seq(a, b), valuesOfType(a.factType), valuesOfType(b.factType))
+
+  def using[I, A : OP, B : OP, C : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+  )(implicit
+    opSA: OP[Seq[W[A]]],
+    opSB: OP[Seq[W[B]]],
+    opSC: OP[Seq[W[C]]],
+  ): UsingFn3[I, W[A], W[B], W[C], OP] =
+    new UsingFn3(Seq(a, b, c), valuesOfType(a.factType), valuesOfType(b.factType), valuesOfType(c.factType))
+
+  def using[I, A : OP, B : OP, C : OP, D : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+  )(implicit
+    opSA: OP[Seq[W[A]]],
+    opSB: OP[Seq[W[B]]],
+    opSC: OP[Seq[W[C]]],
+    opSD: OP[Seq[W[D]]],
+  ): UsingFn4[I, W[A], W[B], W[C], W[D], OP] =
+    new UsingFn4(
+      Seq(a, b, c, d),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+    )
+
+  def using[I, A : OP, B : OP, C : OP, D : OP, E : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+    e: Expr.Define[I, Any, E, OP],
+  )(implicit
+    opSA: OP[Seq[W[A]]],
+    opSB: OP[Seq[W[B]]],
+    opSC: OP[Seq[W[C]]],
+    opSD: OP[Seq[W[D]]],
+    opSE: OP[Seq[W[E]]],
+  ): UsingFn5[I, W[A], W[B], W[C], W[D], W[E], OP] =
+    new UsingFn5(
+      Seq(a, b, c, d, e),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+      valuesOfType(e.factType),
+    )
+
+  def using[I, A : OP, B : OP, C : OP, D : OP, E : OP, F : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+    e: Expr.Define[I, Any, E, OP],
+    f: Expr.Define[I, Any, F, OP],
+  )(implicit
+    opSA: OP[Seq[W[A]]],
+    opSB: OP[Seq[W[B]]],
+    opSC: OP[Seq[W[C]]],
+    opSD: OP[Seq[W[D]]],
+    opSE: OP[Seq[W[E]]],
+    opSF: OP[Seq[W[F]]],
+  ): UsingFn6[I, W[A], W[B], W[C], W[D], W[E], W[F], OP] =
+    new UsingFn6(
+      Seq(a, b, c, d, e, f),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+      valuesOfType(e.factType),
+      valuesOfType(f.factType),
+    )
+
+  def using[I, A : OP, B : OP, C : OP, D : OP, E : OP, F : OP, G : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+    e: Expr.Define[I, Any, E, OP],
+    f: Expr.Define[I, Any, F, OP],
+    g: Expr.Define[I, Any, G, OP],
+  )(implicit
+    opSA: OP[Seq[W[A]]],
+    opSB: OP[Seq[W[B]]],
+    opSC: OP[Seq[W[C]]],
+    opSD: OP[Seq[W[D]]],
+    opSE: OP[Seq[W[E]]],
+    opSF: OP[Seq[W[F]]],
+    opSG: OP[Seq[W[G]]],
+  ): UsingFn7[I, W[A], W[B], W[C], W[D], W[E], W[F], W[G], OP] =
+    new UsingFn7(
+      Seq(a, b, c, d, e, f, g),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+      valuesOfType(e.factType),
+      valuesOfType(f.factType),
+      valuesOfType(g.factType),
+    )
+
+  def using[I, A : OP, B : OP, C : OP, D : OP, E : OP, F : OP, G : OP, H : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+    e: Expr.Define[I, Any, E, OP],
+    f: Expr.Define[I, Any, F, OP],
+    g: Expr.Define[I, Any, G, OP],
+    h: Expr.Define[I, Any, H, OP],
+  )(implicit
+    opSA: OP[Seq[W[A]]],
+    opSB: OP[Seq[W[B]]],
+    opSC: OP[Seq[W[C]]],
+    opSD: OP[Seq[W[D]]],
+    opSE: OP[Seq[W[E]]],
+    opSF: OP[Seq[W[F]]],
+    opSG: OP[Seq[W[G]]],
+    opSH: OP[Seq[W[H]]],
+  ): UsingFn8[I, W[A], W[B], W[C], W[D], W[E], W[F], W[G], W[H], OP] =
+    new UsingFn8(
+      Seq(a, b, c, d, e, f, g, h),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+      valuesOfType(e.factType),
+      valuesOfType(f.factType),
+      valuesOfType(g.factType),
+      valuesOfType(h.factType),
+    )
+
+  def using[I, A : OP, B : OP, C : OP, D : OP, E : OP, F : OP, G : OP, H : OP, J : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+    e: Expr.Define[I, Any, E, OP],
+    f: Expr.Define[I, Any, F, OP],
+    g: Expr.Define[I, Any, G, OP],
+    h: Expr.Define[I, Any, H, OP],
+    j: Expr.Define[I, Any, J, OP],
+  )(implicit
+    opSA: OP[Seq[W[A]]],
+    opSB: OP[Seq[W[B]]],
+    opSC: OP[Seq[W[C]]],
+    opSD: OP[Seq[W[D]]],
+    opSE: OP[Seq[W[E]]],
+    opSF: OP[Seq[W[F]]],
+    opSG: OP[Seq[W[G]]],
+    opSH: OP[Seq[W[H]]],
+    opSJ: OP[Seq[W[J]]],
+  ): UsingFn9[I, W[A], W[B], W[C], W[D], W[E], W[F], W[G], W[H], W[J], OP] =
+    new UsingFn9(
+      Seq(a, b, c, d, e, f, g, h, j),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+      valuesOfType(e.factType),
+      valuesOfType(f.factType),
+      valuesOfType(g.factType),
+      valuesOfType(h.factType),
+      valuesOfType(j.factType),
+    )
+
+  def using[I, A : OP, B : OP, C : OP, D : OP, E : OP, F : OP, G : OP, H : OP, J : OP, K : OP](
+    a: Expr.Define[I, Any, A, OP],
+    b: Expr.Define[I, Any, B, OP],
+    c: Expr.Define[I, Any, C, OP],
+    d: Expr.Define[I, Any, D, OP],
+    e: Expr.Define[I, Any, E, OP],
+    f: Expr.Define[I, Any, F, OP],
+    g: Expr.Define[I, Any, G, OP],
+    h: Expr.Define[I, Any, H, OP],
+    j: Expr.Define[I, Any, J, OP],
+    k: Expr.Define[I, Any, K, OP],
+  )(implicit
+    opSA: OP[Seq[W[A]]],
+    opSB: OP[Seq[W[B]]],
+    opSC: OP[Seq[W[C]]],
+    opSD: OP[Seq[W[D]]],
+    opSE: OP[Seq[W[E]]],
+    opSF: OP[Seq[W[F]]],
+    opSG: OP[Seq[W[G]]],
+    opSH: OP[Seq[W[H]]],
+    opSJ: OP[Seq[W[J]]],
+    opSK: OP[Seq[W[K]]],
+  ): UsingFn10[I, W[A], W[B], W[C], W[D], W[E], W[F], W[G], W[H], W[J], W[K], OP] =
+    new UsingFn10(
+      Seq(a, b, c, d, e, f, g, h, j, k),
+      valuesOfType(a.factType),
+      valuesOfType(b.factType),
+      valuesOfType(c.factType),
+      valuesOfType(d.factType),
+      valuesOfType(e.factType),
+      valuesOfType(f.factType),
+      valuesOfType(g.factType),
+      valuesOfType(h.factType),
+      valuesOfType(j.factType),
+      valuesOfType(k.factType),
+    )
+}

--- a/core-v1/src/main/scala/dsl/UsingFn.scala
+++ b/core-v1/src/main/scala/dsl/UsingFn.scala
@@ -1,0 +1,266 @@
+package com.rallyhealth.vapors.v1
+
+package dsl
+
+import algebra.Expr
+
+sealed abstract class UsingFn[-I, Fn[-_, +_], OP[_]](definitions: Seq[Expr.Definition[I, OP]]) {
+
+  protected def supply[NI <: I, O](buildExpr: Fn[NI, O]): Expr[NI, O, OP]
+
+  final def thenReturn[O : OP](buildExpr: Fn[Any, O]): Expr.UsingDefinitions[I, O, OP] =
+    Expr.UsingDefinitions[I, O, OP](definitions, supply(buildExpr))
+
+  // This can be removed in Scala 3 with the use of dependent function types
+  abstract class UsingFnWithInput[NI] private[UsingFn] {
+    def apply[O](buildExpr: Fn[NI, O])(implicit opO: OP[O]): Expr.UsingDefinitions[NI, O, OP]
+  }
+
+  final def usingInput[NI <: I]: UsingFnWithInput[NI] =
+    new UsingFnWithInput[NI] {
+      override def apply[O](buildExpr: Fn[NI, O])(implicit opO: OP[O]): Expr.UsingDefinitions[NI, O, OP] =
+        Expr.UsingDefinitions(definitions, supply(buildExpr))
+    }
+}
+
+final class UsingFn1[I, A, OP[_]] private[dsl] (
+  definitions: Seq[Expr.Definition[I, OP]],
+  a: Expr[Any, Seq[A], OP],
+) extends UsingFn[I, Lambda[(`-i`, `+o`) => Expr[Any, Seq[A], OP] => Expr[i, o, OP]], OP](definitions) {
+  override protected def supply[NI <: I, O](buildExpr: Expr[Any, Seq[A], OP] => Expr[NI, O, OP]): Expr[NI, O, OP] =
+    buildExpr(a)
+}
+
+final class UsingFn2[I, A, B, OP[_]] private[dsl] (
+  definitions: Seq[Expr.Definition[I, OP]],
+  a: Expr[Any, Seq[A], OP],
+  b: Expr[Any, Seq[B], OP],
+) extends UsingFn[I, Lambda[(`-i`, `+o`) => (Expr[Any, Seq[A], OP], Expr[Any, Seq[B], OP]) => Expr[i, o, OP]], OP](
+    definitions,
+  ) {
+  override protected def supply[NI <: I, O](
+    buildExpr: (Expr[Any, Seq[A], OP], Expr[Any, Seq[B], OP]) => Expr[NI, O, OP],
+  ): Expr[NI, O, OP] =
+    buildExpr(a, b)
+}
+
+final class UsingFn3[I, A, B, C, OP[_]] private[dsl] (
+  definitions: Seq[Expr.Definition[I, OP]],
+  a: Expr[Any, Seq[A], OP],
+  b: Expr[Any, Seq[B], OP],
+  c: Expr[Any, Seq[C], OP],
+) extends UsingFn[I, Lambda[
+    (`-i`, `+o`) => (Expr[Any, Seq[A], OP], Expr[Any, Seq[B], OP], Expr[Any, Seq[C], OP]) => Expr[i, o, OP],
+  ], OP](
+    definitions,
+  ) {
+  override protected def supply[NI <: I, O](
+    buildExpr: (Expr[Any, Seq[A], OP], Expr[Any, Seq[B], OP], Expr[Any, Seq[C], OP]) => Expr[NI, O, OP],
+  ): Expr[NI, O, OP] =
+    buildExpr(a, b, c)
+}
+
+final class UsingFn4[I, A, B, C, D, OP[_]] private[dsl] (
+  definitions: Seq[Expr.Definition[I, OP]],
+  a: Expr[Any, Seq[A], OP],
+  b: Expr[Any, Seq[B], OP],
+  c: Expr[Any, Seq[C], OP],
+  d: Expr[Any, Seq[D], OP],
+) extends UsingFn[I, Lambda[
+    (`-i`, `+o`) => (
+      Expr[Any, Seq[A], OP],
+      Expr[Any, Seq[B], OP],
+      Expr[Any, Seq[C], OP],
+      Expr[Any, Seq[D], OP],
+    ) => Expr[i, o, OP],
+  ], OP](
+    definitions,
+  ) {
+  override protected def supply[NI <: I, O](
+    buildExpr: (Expr[Any, Seq[A], OP], Expr[Any, Seq[B], OP], Expr[Any, Seq[C], OP],
+      Expr[Any, Seq[D], OP]) => Expr[NI, O, OP],
+  ): Expr[NI, O, OP] =
+    buildExpr(a, b, c, d)
+}
+
+final class UsingFn5[I, A, B, C, D, E, OP[_]] private[dsl] (
+  definitions: Seq[Expr.Definition[I, OP]],
+  a: Expr[Any, Seq[A], OP],
+  b: Expr[Any, Seq[B], OP],
+  c: Expr[Any, Seq[C], OP],
+  d: Expr[Any, Seq[D], OP],
+  e: Expr[Any, Seq[E], OP],
+) extends UsingFn[I, Lambda[
+    (`-i`, `+o`) => (
+      Expr[Any, Seq[A], OP],
+      Expr[Any, Seq[B], OP],
+      Expr[Any, Seq[C], OP],
+      Expr[Any, Seq[D], OP],
+      Expr[Any, Seq[E], OP],
+    ) => Expr[i, o, OP],
+  ], OP](
+    definitions,
+  ) {
+  override protected def supply[NI <: I, O](
+    buildExpr: (Expr[Any, Seq[A], OP], Expr[Any, Seq[B], OP], Expr[Any, Seq[C], OP], Expr[Any, Seq[D], OP],
+      Expr[Any, Seq[E], OP]) => Expr[NI, O, OP],
+  ): Expr[NI, O, OP] =
+    buildExpr(a, b, c, d, e)
+}
+
+final class UsingFn6[I, A, B, C, D, E, F, OP[_]] private[dsl] (
+  definitions: Seq[Expr.Definition[I, OP]],
+  a: Expr[Any, Seq[A], OP],
+  b: Expr[Any, Seq[B], OP],
+  c: Expr[Any, Seq[C], OP],
+  d: Expr[Any, Seq[D], OP],
+  e: Expr[Any, Seq[E], OP],
+  f: Expr[Any, Seq[F], OP],
+) extends UsingFn[I, Lambda[
+    (`-i`, `+o`) => (
+      Expr[Any, Seq[A], OP],
+      Expr[Any, Seq[B], OP],
+      Expr[Any, Seq[C], OP],
+      Expr[Any, Seq[D], OP],
+      Expr[Any, Seq[E], OP],
+      Expr[Any, Seq[F], OP],
+    ) => Expr[i, o, OP],
+  ], OP](
+    definitions,
+  ) {
+  override protected def supply[NI <: I, O](
+    buildExpr: (Expr[Any, Seq[A], OP], Expr[Any, Seq[B], OP], Expr[Any, Seq[C], OP], Expr[Any, Seq[D], OP],
+      Expr[Any, Seq[E], OP], Expr[Any, Seq[F], OP]) => Expr[NI, O, OP],
+  ): Expr[NI, O, OP] =
+    buildExpr(a, b, c, d, e, f)
+}
+
+final class UsingFn7[I, A, B, C, D, E, F, G, OP[_]] private[dsl] (
+  definitions: Seq[Expr.Definition[I, OP]],
+  a: Expr[Any, Seq[A], OP],
+  b: Expr[Any, Seq[B], OP],
+  c: Expr[Any, Seq[C], OP],
+  d: Expr[Any, Seq[D], OP],
+  e: Expr[Any, Seq[E], OP],
+  f: Expr[Any, Seq[F], OP],
+  g: Expr[Any, Seq[G], OP],
+) extends UsingFn[I, Lambda[
+    (`-i`, `+o`) => (
+      Expr[Any, Seq[A], OP],
+      Expr[Any, Seq[B], OP],
+      Expr[Any, Seq[C], OP],
+      Expr[Any, Seq[D], OP],
+      Expr[Any, Seq[E], OP],
+      Expr[Any, Seq[F], OP],
+      Expr[Any, Seq[G], OP],
+    ) => Expr[i, o, OP],
+  ], OP](
+    definitions,
+  ) {
+  override protected def supply[NI <: I, O](
+    buildExpr: (Expr[Any, Seq[A], OP], Expr[Any, Seq[B], OP], Expr[Any, Seq[C], OP], Expr[Any, Seq[D], OP],
+      Expr[Any, Seq[E], OP], Expr[Any, Seq[F], OP], Expr[Any, Seq[G], OP]) => Expr[NI, O, OP],
+  ): Expr[NI, O, OP] =
+    buildExpr(a, b, c, d, e, f, g)
+}
+
+final class UsingFn8[I, A, B, C, D, E, F, G, H, OP[_]] private[dsl] (
+  definitions: Seq[Expr.Definition[I, OP]],
+  a: Expr[Any, Seq[A], OP],
+  b: Expr[Any, Seq[B], OP],
+  c: Expr[Any, Seq[C], OP],
+  d: Expr[Any, Seq[D], OP],
+  e: Expr[Any, Seq[E], OP],
+  f: Expr[Any, Seq[F], OP],
+  g: Expr[Any, Seq[G], OP],
+  h: Expr[Any, Seq[H], OP],
+) extends UsingFn[I, Lambda[
+    (`-i`, `+o`) => (
+      Expr[Any, Seq[A], OP],
+      Expr[Any, Seq[B], OP],
+      Expr[Any, Seq[C], OP],
+      Expr[Any, Seq[D], OP],
+      Expr[Any, Seq[E], OP],
+      Expr[Any, Seq[F], OP],
+      Expr[Any, Seq[G], OP],
+      Expr[Any, Seq[H], OP],
+    ) => Expr[i, o, OP],
+  ], OP](
+    definitions,
+  ) {
+  override protected def supply[NI <: I, O](
+    buildExpr: (Expr[Any, Seq[A], OP], Expr[Any, Seq[B], OP], Expr[Any, Seq[C], OP], Expr[Any, Seq[D], OP],
+      Expr[Any, Seq[E], OP], Expr[Any, Seq[F], OP], Expr[Any, Seq[G], OP], Expr[Any, Seq[H], OP]) => Expr[NI, O, OP],
+  ): Expr[NI, O, OP] =
+    buildExpr(a, b, c, d, e, f, g, h)
+}
+
+final class UsingFn9[I, A, B, C, D, E, F, G, H, J, OP[_]] private[dsl] (
+  definitions: Seq[Expr.Definition[I, OP]],
+  a: Expr[Any, Seq[A], OP],
+  b: Expr[Any, Seq[B], OP],
+  c: Expr[Any, Seq[C], OP],
+  d: Expr[Any, Seq[D], OP],
+  e: Expr[Any, Seq[E], OP],
+  f: Expr[Any, Seq[F], OP],
+  g: Expr[Any, Seq[G], OP],
+  h: Expr[Any, Seq[H], OP],
+  j: Expr[Any, Seq[J], OP],
+) extends UsingFn[I, Lambda[
+    (`-i`, `+o`) => (
+      Expr[Any, Seq[A], OP],
+      Expr[Any, Seq[B], OP],
+      Expr[Any, Seq[C], OP],
+      Expr[Any, Seq[D], OP],
+      Expr[Any, Seq[E], OP],
+      Expr[Any, Seq[F], OP],
+      Expr[Any, Seq[G], OP],
+      Expr[Any, Seq[H], OP],
+      Expr[Any, Seq[J], OP],
+    ) => Expr[i, o, OP],
+  ], OP](
+    definitions,
+  ) {
+  override protected def supply[NI <: I, O](
+    buildExpr: (Expr[Any, Seq[A], OP], Expr[Any, Seq[B], OP], Expr[Any, Seq[C], OP], Expr[Any, Seq[D], OP],
+      Expr[Any, Seq[E], OP], Expr[Any, Seq[F], OP], Expr[Any, Seq[G], OP], Expr[Any, Seq[H], OP],
+      Expr[Any, Seq[J], OP]) => Expr[NI, O, OP],
+  ): Expr[NI, O, OP] =
+    buildExpr(a, b, c, d, e, f, g, h, j)
+}
+
+final class UsingFn10[I, A, B, C, D, E, F, G, H, J, K, OP[_]] private[dsl] (
+  definitions: Seq[Expr.Definition[I, OP]],
+  a: Expr[Any, Seq[A], OP],
+  b: Expr[Any, Seq[B], OP],
+  c: Expr[Any, Seq[C], OP],
+  d: Expr[Any, Seq[D], OP],
+  e: Expr[Any, Seq[E], OP],
+  f: Expr[Any, Seq[F], OP],
+  g: Expr[Any, Seq[G], OP],
+  h: Expr[Any, Seq[H], OP],
+  j: Expr[Any, Seq[J], OP],
+  k: Expr[Any, Seq[K], OP],
+) extends UsingFn[I, Lambda[
+    (`-i`, `+o`) => (
+      Expr[Any, Seq[A], OP],
+      Expr[Any, Seq[B], OP],
+      Expr[Any, Seq[C], OP],
+      Expr[Any, Seq[D], OP],
+      Expr[Any, Seq[E], OP],
+      Expr[Any, Seq[F], OP],
+      Expr[Any, Seq[G], OP],
+      Expr[Any, Seq[H], OP],
+      Expr[Any, Seq[J], OP],
+      Expr[Any, Seq[K], OP],
+    ) => Expr[i, o, OP],
+  ], OP](
+    definitions,
+  ) {
+  override protected def supply[NI <: I, O](
+    buildExpr: (Expr[Any, Seq[A], OP], Expr[Any, Seq[B], OP], Expr[Any, Seq[C], OP], Expr[Any, Seq[D], OP],
+      Expr[Any, Seq[E], OP], Expr[Any, Seq[F], OP], Expr[Any, Seq[G], OP], Expr[Any, Seq[H], OP], Expr[Any, Seq[J], OP],
+      Expr[Any, Seq[K], OP]) => Expr[NI, O, OP],
+  ): Expr[NI, O, OP] =
+    buildExpr(a, b, c, d, e, f, g, h, j, k)
+}

--- a/core-v1/src/main/scala/engine/StandardEngine.scala
+++ b/core-v1/src/main/scala/engine/StandardEngine.scala
@@ -3,7 +3,7 @@ package com.rallyhealth.vapors.v1
 package engine
 
 import algebra._
-import data.{ExprState, ExtractValue, Window}
+import data.{ExprState, ExtractValue, TypedFact, Window}
 import debug.DebugArgs
 import dsl.{Sortable, ZipToShortest}
 import logic.{Conjunction, Disjunction, Negation}
@@ -121,6 +121,12 @@ object StandardEngine {
       debugging(expr).invokeDebugger(finalState)
       ExprResult.CustomFunction(expr, finalState)
     }
+
+    override def visitDefine[I, C[_] : Foldable, T](
+      expr: Expr.Define[I, C, T, OP],
+    )(implicit
+      opF: OP[Seq[TypedFact[T]]],
+    ): PO <:< I => ExprResult[PO, I, Seq[TypedFact[T]], OP] = ???
 
     override def visitExists[C[_] : Foldable, A, B : ExtractValue.AsBoolean : OP](
       expr: Expr.Exists[C, A, B, OP],
@@ -294,6 +300,10 @@ object StandardEngine {
       debugging(expr).invokeDebugger(finalState)
       ExprResult.Sorted(expr, finalState)
     }
+
+    override def visitUsingDefinitions[I, O : OP](
+      expr: Expr.UsingDefinitions[I, O, OP],
+    ): PO <:< I => ExprResult[PO, I, O, OP] = ???
 
     override def visitValuesOfType[T, O](
       expr: Expr.ValuesOfType[T, O, OP],

--- a/core-v1/src/test/scala/SimpleJustifiedUsingDefinitionsSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedUsingDefinitionsSpec.scala
@@ -1,5 +1,6 @@
 package com.rallyhealth.vapors.v1
 
+import algebra.Expr
 import data.{FactTable, Justified}
 import example.FactTypes
 
@@ -14,13 +15,13 @@ class SimpleJustifiedUsingDefinitionsSpec extends FunSuite {
   test("Derive Kg from Lbs") {
     val weightLbs = FactTypes.WeightLbs(150)
     val lbsPerKg = 2.205
-    val defineWeightKg = define(FactTypes.WeightKg).from {
+    val defineWeightKg: Expr.Define[Any, Seq, Double, OP] = define(FactTypes.WeightKg).from {
       valuesOfType(FactTypes.WeightLbs).map { lbs =>
         lbs / lbsPerKg.const
       }
     }
-    val expr = usingDefinitions(defineWeightKg) {
-      valuesOfType(FactTypes.WeightKg).map(_ * 2d.const)
+    val expr = using(defineWeightKg).thenReturn {
+      _.map(_ * 2d.const)
     }
     val observedWrapped = expr.run(FactTable(weightLbs))
     inside(observedWrapped) {

--- a/core-v1/src/test/scala/SimpleJustifiedUsingDefinitionsSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedUsingDefinitionsSpec.scala
@@ -1,0 +1,37 @@
+package com.rallyhealth.vapors.v1
+
+import data.{FactTable, Justified}
+import example.FactTypes
+
+import cats.data.NonEmptySeq
+import munit.FunSuite
+import org.scalatest.Inside.inside
+
+class SimpleJustifiedUsingDefinitionsSpec extends FunSuite {
+
+  import dsl.simple.justified._
+
+  test("Derive Kg from Lbs") {
+    val weightLbs = FactTypes.WeightLbs(150)
+    val lbsPerKg = 2.205
+    val defineWeightKg = define(FactTypes.WeightKg).from {
+      valuesOfType(FactTypes.WeightLbs).map { lbs =>
+        lbs / lbsPerKg.const
+      }
+    }
+    val expr = usingDefinitions(defineWeightKg) {
+      valuesOfType(FactTypes.WeightKg).map(_ * 2d.const)
+    }
+    val observedWrapped = expr.run(FactTable(weightLbs))
+    inside(observedWrapped) {
+      case Seq(Justified.ByInference(reason, observed, justification)) =>
+        val expected = (weightLbs.value / lbsPerKg) * 2
+        assertEquals(observed, expected)
+        assertEquals(reason, "multiply")
+        assertEquals(
+          justification,
+          NonEmptySeq.of(Justified.byFact(FactTypes.WeightKg(68.02721088435374)), Justified.byConst(2.0)),
+        )
+    }
+  }
+}

--- a/core-v1/src/test/scala/SimpleUsingAritySpec.scala
+++ b/core-v1/src/test/scala/SimpleUsingAritySpec.scala
@@ -1,0 +1,48 @@
+package com.rallyhealth.vapors.v1
+
+import example.FactTypes
+import dsl.simple._
+
+import munit.FunSuite
+
+class SimpleUsingAritySpec extends FunSuite {
+
+  import SimpleUsingAritySpec._
+
+  test("using 1") {
+    val isMatch = using(defineAge25).thenReturn { ages =>
+      ages.exists(_ > 18.const)
+    }
+    assert(isMatch.run())
+  }
+
+  test("using 2") {
+    val isMatch = using(defineAge25, defineWeightLbs150).thenReturn { (ages, weights) =>
+      ages.exists(_ > 18.const) && weights.forall(_ < 200d.const)
+    }
+    assert(isMatch.run())
+  }
+
+  test("using 3 repeat 1") {
+    val isMatch = using(defineAge25, defineWeightLbs150, defineAge16).thenReturn { (ages, weights, _) =>
+      ages.exists(_ > 18.const) && weights.forall(_ < 200d.const)
+    }
+    assert(isMatch.run())
+  }
+
+  test("using 4 repeat 2") {
+    val isMatch = using(defineAge25, defineWeightLbs150, defineAge16, defineWeightLbs250).thenReturn {
+      (ages, weights, _, _) =>
+        ages.exists(_ > 18.const) && weights.forall(_ < 200d.const)
+    }
+    assert(!isMatch.run())
+  }
+}
+
+object SimpleUsingAritySpec {
+
+  final val defineAge16 = define(FactTypes.Age).oneFromConst(16)
+  final val defineAge25 = define(FactTypes.Age).oneFromConst(25)
+  final val defineWeightLbs150 = define(FactTypes.WeightLbs).oneFromConst(150)
+  final val defineWeightLbs250 = define(FactTypes.WeightLbs).oneFromConst(250)
+}

--- a/core-v1/src/test/scala/SimpleUsingDefinitionsSpec.scala
+++ b/core-v1/src/test/scala/SimpleUsingDefinitionsSpec.scala
@@ -1,0 +1,29 @@
+package com.rallyhealth.vapors.v1
+
+import data.FactTable
+import example.FactTypes
+
+import munit.FunSuite
+
+class SimpleUsingDefinitionsSpec extends FunSuite {
+
+  import dsl.simple._
+
+  test("Derive Kg from Lbs") {
+    val weightLbs = FactTypes.WeightLbs(150)
+    val lbsPerKg = 2.205
+    val defineWeightKg = define(FactTypes.WeightKg).from {
+      valuesOfType(FactTypes.WeightLbs).map { lbs =>
+        lbs / lbsPerKg.const
+      }
+    }
+    val expr = usingDefinitions(defineWeightKg) {
+      valuesOfType(FactTypes.WeightKg).map(_ * 2d.const)
+    }
+    val observed = expr.run(FactTable(weightLbs))
+    val expected = (weightLbs.value / lbsPerKg) * 2
+    assert(observed.sizeIs == 1)
+    assertEqualsDouble(observed.head, expected, 0.0000001)
+  }
+
+}

--- a/core-v1/src/test/scala/example/FactTypes.scala
+++ b/core-v1/src/test/scala/example/FactTypes.scala
@@ -6,15 +6,22 @@ import data.FactType
 
 import cats.Order
 
-import java.time.{Clock, Instant}
+import java.time.{Clock, Instant, LocalDate}
 import scala.collection.immutable.SortedSet
 
-object FactTypes {
+object FactTypes extends OrderTimeImplicits {
 
   final val Age = FactType[Int]("age")
+  final val DateOfBirth = FactType[LocalDate]("date_of_birth")
   final val CombinedTags = FactType[CombinedTags]("combined_tags")
   final val GeoLocation = FactType[GeoLocation]("geolocation")
-  final val Weight = FactType[Int]("weight")
+  final val WeightLbs = FactType[Double]("weight_lbs")
+  final val WeightKg = FactType[Double]("weight_kg")
+}
+
+trait OrderTimeImplicits {
+
+  implicit val recentFirstLocalDate: Order[LocalDate] = Order.reverse(Order.fromLessThan(_.isBefore(_)))
 }
 
 final case class CombinedTags(


### PR DESCRIPTION
- Add Expr.Define and Expr.UsingDefinitions, DSL, and unit tests
- Add using syntax for building a dependency on definitions
  - Add UsingFn classes for building expressions from captured function types
  - Add using methods for wrapped and unwrapped cases