### PR TITLE
Use Select to implement conversion between collections / Add .slice, .filter, and .getOrElse operations

### DIFF
--- a/core-v1/src/main/scala/algebra/CombineHolder.scala
+++ b/core-v1/src/main/scala/algebra/CombineHolder.scala
@@ -70,15 +70,17 @@ object CombineHolder extends LowPriorityCombineHolderImplicits {
   /**
     * This is a hack to fix a reported error by IntelliJ.
     *
+    * @see [[SelectHolder.debugAnyHolder]]
+    *
     * IntelliJ's presentation compiler infers (wrongly) that the input type of the [[CombineHolder]]
     * is `Nothing`, when it should be `Any`. This hints to the compiler to use `Any` before trying any
     * other type, so this patches an error that prevents you from calling `.run()` on a debugged
     * [[CombineHolder]] produced expression.
     *
-    * If this can be removed, then [[LowPriorityCombineHolderImplicits.debugExpr]] can be moved back
-    * to this position (and possibly remove the low priority trait).
+    * If this can be removed, then [[LowPriorityCombineHolderImplicits.debugHolder]] can be moved back
+    * to this position (and remove the low priority trait if it is empty).
     */
-  implicit def debugAnyCombineHolder[LI, LO, RI, RO, O, OP[_]](
+  implicit def debugAnyHolder[LI, LO, RI, RO, O, OP[_]](
     holder: CombineHolder[Any, LI, LO, RI, RO, O, OP],
   )(implicit
     opO: OP[O],
@@ -89,7 +91,7 @@ object CombineHolder extends LowPriorityCombineHolderImplicits {
 
 trait LowPriorityCombineHolderImplicits {
 
-  implicit def debugExpr[I, LI, LO, RI, RO, O, OP[_]](
+  implicit def debugHolder[I, LI, LO, RI, RO, O, OP[_]](
     holder: CombineHolder[I, LI, LO, RI, RO, O, OP],
   )(implicit
     opO: OP[O],

--- a/core-v1/src/main/scala/algebra/SelectHolder.scala
+++ b/core-v1/src/main/scala/algebra/SelectHolder.scala
@@ -1,0 +1,79 @@
+package com.rallyhealth.vapors.v1
+
+package algebra
+
+import debug.DebugArgs
+import lens.VariantLens
+
+/**
+  * This class only exists because attempting to require an implicit [[OP]] on a slice or filter method
+  * conflicts with the implicit search for the [[dsl.SelectOutputType]]. It results in diverging implicit
+  * expansion because it can't decide whether to use the implicit `OP[O]` or to use the implicit
+  * `SelectOutputType.Aux[?, ?, O]` to determine the `O` type. This separation ensures that
+  * `SelectOutputType.Aux` is used first to fix the type of `O`, and only afterwards will the compiler
+  * search for an implicit `OP[O]` to use when converting this back to an [[Expr]].
+  *
+  * Similar to [[CombineHolder]], but for the result of [[Expr.Select]] operations.
+  *
+  * @param inputExpr  the expression to run before applying the [[lens]] and [[wrapSelected]] on the result
+  * @param wrapSelected a function that defines how to wrap the result of applying the [[lens]].
+  *                   If it is a higher-kinded Functor, wrap every element, otherwise wrap the single value directly.
+  * @param lens       a lens from the input type to some selected field
+  *
+  * @tparam I the input to the [[inputExpr]] that is required to produce the output of type [[A]]
+  * @tparam A the output of the input expression and the input to the lens
+  * @tparam B the output of the lens
+  * @tparam O the final computed output type with the wrapper type applied at the appropriate level
+  *           (computed using the [[dsl.SelectOutputType]] implicit)* @tparam I
+  * @tparam OP the custom output param (see [[dsl.DslTypes.OP]])
+  */
+final class SelectHolder[-I, A, B, O, OP[_]](
+  inputExpr: Expr[I, A, OP],
+  lens: VariantLens[A, B],
+  wrapSelected: (A, B) => O,
+) {
+
+  def toExpr(implicit opO: OP[O]): Expr.Select[I, A, B, O, OP] =
+    Expr.Select(inputExpr, lens, wrapSelected)
+}
+
+object SelectHolder extends LowPrioritySelectHolderImplicits {
+
+  implicit def asExpr[I, A, B, O, OP[_]](
+    holder: SelectHolder[I, A, B, O, OP],
+  )(implicit
+    opO: OP[O],
+  ): Expr.Select[I, A, B, O, OP] = holder.toExpr
+
+  /**
+    * This is a hack to fix a reported error by IntelliJ.
+    *
+    * @see [[CombineHolder.debugAnyHolder]]
+    *
+    * IntelliJ's presentation compiler infers (wrongly) that the input type of the [[SelectHolder]]
+    * is `Nothing`, when it should be `Any`. This hints to the compiler to use `Any` before trying any
+    * other type, so this patches an error that prevents you from calling `.run()` on a debugged
+    * [[SelectHolder]] produced expression.
+    *
+    * If this can be removed, then [[LowPrioritySelectHolderImplicits.debugHolder]] can be moved back
+    * to this position (and remove the low priority trait if it is empty).
+    */
+  implicit def debugAnyHolder[A, B, O, OP[_]](
+    holder: SelectHolder[Any, A, B, O, OP],
+  )(implicit
+    opO: OP[O],
+    debugArgs: DebugArgs[Expr.Select[Any, A, B, O, OP], OP],
+  ): DebugArgs.Attacher[Expr.Select[Any, A, B, O, OP], OP, debugArgs.In, debugArgs.Out] =
+    DebugArgs[OP].of(holder.toExpr)(debugArgs)
+}
+
+trait LowPrioritySelectHolderImplicits {
+
+  implicit def debugHolder[I, A, B, O, OP[_]](
+    holder: SelectHolder[I, A, B, O, OP],
+  )(implicit
+    opO: OP[O],
+    debugArgs: DebugArgs[Expr.Select[I, A, B, O, OP], OP],
+  ): DebugArgs.Attacher[Expr.Select[I, A, B, O, OP], OP, debugArgs.In, debugArgs.Out] =
+    DebugArgs[OP].of(holder.toExpr)(debugArgs)
+}

--- a/core-v1/src/main/scala/data/SliceRange.scala
+++ b/core-v1/src/main/scala/data/SliceRange.scala
@@ -1,0 +1,86 @@
+package com.rallyhealth.vapors.v1
+
+package data
+
+import cats.data.Ior
+
+/**
+  * Defines a slice of indexes into a collection that supports negative indexing.
+  *
+  * For example, `1 <-> -1` would be a [[SliceRange.Relative]] slice that would return a collection with all
+  * the elements of the original collection without the first or last element. If the collection has 2 elements
+  * or less, then the resulting collection will be empty.
+  *
+  * In order to reference the relative end of a collection, you can use the [[SliceRange.End]] (ex. `3 <-> End`)
+  *
+  * In order to have distinct indexes, you have to call [[SliceRange.Relative.toAbsolute]] and give the size
+  * of the collection that you want to slice.
+  */
+object SliceRange {
+
+  /**
+    * A relative slice with either a relative lower bound, upper bound, or both.
+    */
+  final case class Relative private (range: Ior[Int, Int]) {
+
+    def start: Option[Int] = range.left
+
+    def end: Option[Int] = range.right
+
+    def toAbsolute(size: Int): Absolute = {
+      val relative = range.bimap(
+        relativeStart => if (relativeStart < 0) size + relativeStart else relativeStart,
+        relativeEnd => if (relativeEnd < 0) size + relativeEnd else relativeEnd,
+      )
+      Absolute(this, relative.left.getOrElse(0), relative.right.getOrElse(size) - 1)
+    }
+  }
+
+  object Relative {
+
+    def fromEnd(relativeStart: Int): Relative = Relative(Ior.left(relativeStart))
+
+    def fromStart(relativeEnd: Int): Relative = Relative(Ior.right(relativeEnd))
+
+    def from(
+      relativeStart: Int,
+      relativeEnd: Int,
+    ): Relative = Relative(Ior.both(relativeStart, relativeEnd))
+  }
+
+  /**
+    * A [[Relative]] slice applied to a known size, with a calculated and fixed start and end.
+    *
+    * This could contain the total size as well, but I didn't see a need for it yet.
+    */
+  final case class Absolute private[SliceRange] (
+    relative: Relative,
+    start: Int,
+    end: Int,
+  ) {
+
+    val toRange: Range = Range.inclusive(start, end)
+
+    def contains(index: Int): Boolean = toRange.contains(index)
+  }
+
+  final class Syntax(private val num: Int) extends AnyVal {
+
+    def fromEnd: Relative = Relative.fromEnd(num)
+
+    def fromStart: Relative = Relative.fromStart(num)
+
+    def <->(relativeEnd: Int): Relative = Relative.from(num, relativeEnd)
+
+    def <->(end: End.type): Relative = Relative.fromEnd(num)
+  }
+
+  final case object End
+}
+
+trait SliceRangeSyntax {
+
+  final val End = SliceRange.End
+
+  implicit def range(num: Int): SliceRange.Syntax = new SliceRange.Syntax(num)
+}

--- a/core-v1/src/main/scala/debug/DebugArgs.scala
+++ b/core-v1/src/main/scala/debug/DebugArgs.scala
@@ -191,6 +191,12 @@ object DebugArgs {
       override type Out = W[Boolean]
     }
 
+  implicit def debugGetOrElse[I, O, OP[_]]: Aux[Expr.GetOrElse[I, O, OP], OP, (I, Option[O]), O] =
+    new DebugArgs[Expr.GetOrElse[I, O, OP], OP] {
+      override type In = (I, Option[O])
+      override type Out = O
+    }
+
   implicit def debugExists[
     C[_],
     A,

--- a/core-v1/src/main/scala/debug/DebugArgs.scala
+++ b/core-v1/src/main/scala/debug/DebugArgs.scala
@@ -3,7 +3,7 @@ package com.rallyhealth.vapors.v1
 package debug
 
 import algebra.{Expr, SizeComparison}
-import data.{ExprState, FactSet, TypedFact, Window}
+import data._
 import lens.VariantLens
 
 import cats.data.{NonEmptySeq, NonEmptyVector}
@@ -208,10 +208,10 @@ object DebugArgs {
       override type Out = B
     }
 
-  implicit def debugFilter[C[_], A, B, OP[_]]: Aux[Expr.Filter[C, A, B, OP], OP, C[A], C[A]] =
-    new DebugArgs[Expr.Filter[C, A, B, OP], OP] {
+  implicit def debugFilter[C[_], A, B, D[_], OP[_]]: Aux[Expr.Filter[C, A, B, D, OP], OP, C[A], D[A]] =
+    new DebugArgs[Expr.Filter[C, A, B, D, OP], OP] {
       override type In = C[A]
-      override type Out = C[A]
+      override type Out = D[A]
     }
 
   implicit def debugFlatten[C[_], A, OP[_]]: Aux[Expr.Flatten[C, A, OP], OP, C[C[A]], C[A]] =
@@ -259,6 +259,12 @@ object DebugArgs {
     new DebugArgs[Expr.SizeIs[I, N, B, OP], OP] {
       override type In = (I, SizeComparison, N)
       override type Out = B
+    }
+
+  implicit def debugSlice[C[_], A, D[_], OP[_]]: Aux[Expr.Slice[C, A, D, OP], OP, (C[A], SliceRange.Absolute), D[A]] =
+    new DebugArgs[Expr.Slice[C, A, D, OP], OP] {
+      override type In = (C[A], SliceRange.Absolute)
+      override type Out = D[A]
     }
 
   implicit def debugSorted[C[_], A, OP[_]]: Aux[Expr.Sorted[C, A, OP], OP, C[A], C[A]] =

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -4,7 +4,7 @@ package dsl
 
 import algebra._
 import data._
-import lens.VariantLens
+import lens.{IterableInto, VariantLens}
 import logic.{Conjunction, Disjunction, Logic, Negation}
 import math.Power
 
@@ -40,7 +40,7 @@ trait BuildExprDsl extends DebugExprDsl with WrapArityMethods with UsingDefiniti
   ): AndThen[I, Seq[Seq[A]], Seq[A]] = {
     Expr
       .Sequence(expressions.map {
-        Expr.Select(_, VariantLens.id[C[A]].asIterable.to[Seq], (_: C[A], sa: Seq[A]) => sa)
+        Expr.Select(_, VariantLens.id[C[A]].to[Seq], (_: C[A], sa: Seq[A]) => sa)
       })
       .andThen(Expr.Flatten())
   }
@@ -420,6 +420,12 @@ You should prefer put your declaration of dependency on definitions close to whe
       sortable: Sortable[C, W[A]],
       opAs: OP[C[W[A]]],
     ): AndThen[I, C[W[A]], C[W[A]]]
+
+    def to[S[_]](
+      implicit
+      foldableC: Foldable[C],
+      into: IterableInto[S, W[A]],
+    ): SelectHolder[I, C[W[A]], into.Out, into.Out, OP]
   }
 
   abstract class SizeIsBuilder[-I, C](proof: I ~:> C) {

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -316,6 +316,15 @@ You should prefer put your declaration of dependency on definitions close to whe
     }
   }
 
+  implicit def optionOps[I, O](optExpr: I ~:> Option[W[O]]): OptionExprBuilder[I, O] =
+    new OptionExprBuilder(optExpr)
+
+  class OptionExprBuilder[-I, +O](optExpr: I ~:> Option[W[O]]) {
+
+    def getOrElse[EI <: I, EO >: O](defaultExpr: EI ~:> W[EO])(implicit opO: OP[W[EO]]): Expr.GetOrElse[EI, W[EO], OP] =
+      Expr.GetOrElse(optExpr, defaultExpr)
+  }
+
   implicit def sizeOf[I, C](expr: I ~:> C): SizeOfExprBuilder[I, C]
 
   abstract class SizeOfExprBuilder[-I, C](proof: I ~:> C) {

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -337,6 +337,14 @@ You should prefer put your declaration of dependency on definitions close to whe
 
   abstract class HkExprBuilder[-I, C[_], A](proof: I ~:> C[W[A]]) {
 
+    def atIndex(
+      index: Long,
+    )(implicit
+      foldableC: Foldable[C],
+      opA: OP[A],
+      opO: OP[Option[W[A]]],
+    ): Expr.Select[I, C[W[A]], Option[W[A]], Option[W[A]], OP]
+
     def head(
       implicit
       reducibleC: Reducible[C],

--- a/core-v1/src/main/scala/dsl/RunExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/RunExprDsl.scala
@@ -2,7 +2,7 @@ package com.rallyhealth.vapors.v1
 
 package dsl
 
-import algebra.CombineHolder
+import algebra.{CombineHolder, SelectHolder}
 import data.{ExprState, FactTable}
 
 trait RunExprDsl {
@@ -25,6 +25,10 @@ trait RunExprDsl {
   implicit def runCombineWith[I, O : OP](
     builder: CombineHolder[I, Nothing, Any, Nothing, Any, O, OP],
   ): SpecificRunWithExpr[I, O]
+
+  implicit def runSelect[A, B, O : OP](builder: SelectHolder[Any, A, B, O, OP]): SpecificRunExpr[O]
+
+  implicit def runSelectWith[I, A, B, O : OP](builder: SelectHolder[I, A, B, O, OP]): SpecificRunWithExpr[I, O]
 
   type SpecificRunExpr[+O] <: RunExpr[O]
   type SpecificRunWithExpr[-I, +O] <: RunWithExpr[I, O]

--- a/core-v1/src/main/scala/dsl/SelectOutputType.scala
+++ b/core-v1/src/main/scala/dsl/SelectOutputType.scala
@@ -26,7 +26,7 @@ DSL wrapper type: ${W}
 Typically, this means that you are calling .select() and creating a lens to an empty collection (with an element type of Nothing) or a non-Traverse higher-kinded type.
 You can fix this by explicitly annotating the collection type parameter to something other than Nothing or convert the collection before selecting from it.""",
 )
-trait SelectOutputType[W[+_], I, A] {
+trait SelectOutputType[W[+_], -I, -A] {
   type Out
 
   /**
@@ -41,5 +41,5 @@ trait SelectOutputType[W[+_], I, A] {
 }
 
 object SelectOutputType {
-  type Aux[W[+_], I, A, B] = SelectOutputType[W, I, A] { type Out = B }
+  type Aux[W[+_], -I, -A, B] = SelectOutputType[W, I, A] { type Out = B }
 }

--- a/core-v1/src/main/scala/dsl/SimpleRunDsl.scala
+++ b/core-v1/src/main/scala/dsl/SimpleRunDsl.scala
@@ -2,7 +2,7 @@ package com.rallyhealth.vapors.v1
 
 package dsl
 
-import algebra.CombineHolder
+import algebra.{CombineHolder, SelectHolder}
 import data.{ExprState, FactTable}
 import engine.SimpleEngine
 
@@ -27,6 +27,12 @@ trait SimpleRunDsl extends RunExprDsl {
   override implicit final def runCombineWith[I, O : OP](
     builder: CombineHolder[I, Nothing, Any, Nothing, Any, O, OP],
   ): RunWithIdExpr[I, O] = new RunWithIdExpr(builder.toExpr)
+
+  override implicit def runSelect[A, B, O : OP](builder: SelectHolder[Any, A, B, O, OP]): RunIdExpr[O] =
+    new RunIdExpr(builder.toExpr)
+
+  override implicit def runSelectWith[I, A, B, O : OP](builder: SelectHolder[I, A, B, O, OP]): RunWithIdExpr[I, O] =
+    new RunWithIdExpr(builder.toExpr)
 
   override final type SpecificRunExpr[+O] = RunIdExpr[O]
   override final type SpecificRunWithExpr[-I, +O] = RunWithIdExpr[I, O]

--- a/core-v1/src/main/scala/dsl/StandardRunDsl.scala
+++ b/core-v1/src/main/scala/dsl/StandardRunDsl.scala
@@ -2,7 +2,7 @@ package com.rallyhealth.vapors.v1
 
 package dsl
 
-import algebra.{CombineHolder, ExprResult}
+import algebra.{CombineHolder, ExprResult, SelectHolder}
 import data.{ExprState, FactTable}
 import engine.StandardEngine
 
@@ -29,6 +29,14 @@ trait StandardRunDsl extends RunExprDsl {
   override implicit def runCombineWith[I, O : OP](
     builder: CombineHolder[I, Nothing, Any, Nothing, Any, O, OP],
   ): RunWithStandardExpr[I, O] = new RunWithStandardExpr(builder.toExpr)
+
+  override implicit def runSelect[A, B, O : OP](builder: SelectHolder[Any, A, B, O, OP]): RunStandardExpr[O] =
+    new RunStandardExpr(builder.toExpr)
+
+  override implicit def runSelectWith[I, A, B, O : OP](
+    builder: SelectHolder[I, A, B, O, OP],
+  ): RunWithStandardExpr[I, O] =
+    new RunWithStandardExpr(builder.toExpr)
 
   override type SpecificRunExpr[+O] = RunStandardExpr[O]
   override type SpecificRunWithExpr[-I, +O] = RunWithStandardExpr[I, O]

--- a/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
@@ -4,7 +4,7 @@ package dsl
 
 import algebra._
 import data.{Extract, FactType, FactTypeSet, TypedFact}
-import lens.VariantLens
+import lens.{IterableInto, VariantLens}
 import logic.Logic
 import math.Power
 
@@ -325,6 +325,15 @@ trait UnwrappedBuildExprDsl
       opAs: OP[C[A]],
     ): AndThen[I, C[A], C[A]] =
       inputExpr.andThen(Expr.Sorted())
+
+    override def to[S[_]](
+      implicit
+      foldableC: Foldable[C],
+      into: IterableInto[S, A],
+    ): SelectHolder[I, C[A], into.Out, into.Out, OP] = {
+      val lens = VariantLens.id[C[A]].to(into)
+      new SelectHolder(inputExpr, lens, (_, out) => out)
+    }
   }
 
   final class UnwrappedSizeIsBuilder[-I, C](inputExpr: I ~:> C) extends SizeIsBuilder(inputExpr) {

--- a/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
@@ -191,6 +191,15 @@ trait UnwrappedBuildExprDsl
       inputExpr.andThen(Expr.Convert(ExprConverter.asProductType)(opWP))(opWP)
   }
 
+  override implicit def optionOps[I, O](optExpr: I ~:> Option[O]): UnwrappedOptionExprBuilder[I, O] =
+    new UnwrappedOptionExprBuilder(optExpr)
+
+  final class UnwrappedOptionExprBuilder[-I, +O](optExpr: I ~:> Option[O]) extends OptionExprBuilder(optExpr) {
+
+    override def getOrElse[EI <: I, EO >: O](defaultExpr: EI ~:> EO)(implicit opO: OP[EO]): Expr.GetOrElse[EI, EO, OP] =
+      Expr.GetOrElse(optExpr, defaultExpr)
+  }
+
   override implicit def sizeOf[I, C](inputExpr: I ~:> C): UnwrappedSizeOfExprBuilder[I, C] =
     new UnwrappedSizeOfExprBuilder(inputExpr)
 

--- a/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
@@ -219,6 +219,17 @@ trait UnwrappedBuildExprDsl
 
   final class UnwrappedHkExprBuilder[-I, C[_], A](inputExpr: I ~:> C[A]) extends HkExprBuilder(inputExpr) {
 
+    override def atIndex(
+      index: Long,
+    )(implicit
+      foldableC: Foldable[C],
+      opA: OP[A],
+      opO: OP[Option[A]],
+    ): Expr.Select[I, C[A], Option[A], Option[A], OP] = {
+      val lens = VariantLens.id[C[A]].at(index)
+      Expr.Select(inputExpr, lens, (_, el) => el)
+    }
+
     override def head(
       implicit
       reducibleC: Reducible[C],

--- a/core-v1/src/main/scala/dsl/WrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/WrappedBuildExprDsl.scala
@@ -215,6 +215,17 @@ trait WrappedBuildExprDsl extends BuildExprDsl {
 
   class WrappedHkExprBuilder[-I, C[_], A](inputExpr: I ~:> C[W[A]]) extends HkExprBuilder(inputExpr) {
 
+    override def atIndex(
+      index: Long,
+    )(implicit
+      foldableC: Foldable[C],
+      opA: OP[A],
+      opO: OP[Option[W[A]]],
+    ): Expr.Select[I, C[W[A]], Option[W[A]], Option[W[A]], OP] = {
+      val lens = VariantLens.id[C[W[A]]].at(index)
+      Expr.Select(inputExpr, lens, (_, el) => el)
+    }
+
     override def head(
       implicit
       reducibleC: Reducible[C],

--- a/core-v1/src/main/scala/dsl/WrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/WrappedBuildExprDsl.scala
@@ -3,9 +3,8 @@ package com.rallyhealth.vapors.v1
 package dsl
 
 import algebra._
-import data.{Extract, ExtractValue, FactTypeSet}
 import data._
-import lens.VariantLens
+import lens.{IterableInto, VariantLens}
 import math.Power
 
 import cats.data.NonEmptySeq
@@ -339,6 +338,16 @@ trait WrappedBuildExprDsl extends BuildExprDsl {
       opAs: OP[C[W[A]]],
     ): AndThen[I, C[W[A]], C[W[A]]] =
       inputExpr.andThen(Expr.Sorted())
+
+    override def to[S[_]](
+      implicit
+      foldableC: Foldable[C],
+      into: IterableInto[S, W[A]],
+    ): SelectHolder[I, C[W[A]], into.Out, into.Out, OP] = {
+      val lens = VariantLens.id[C[W[A]]].to(into)
+      // This is an isomorphic operation at the container level, so there is no need to alter the wrapped elements
+      new SelectHolder(inputExpr, lens, (_, out) => out)
+    }
   }
 
   class WrappedSizeIsBuilder[-I, C](inputExpr: I ~:> C) extends SizeIsBuilder(inputExpr) {

--- a/core-v1/src/main/scala/engine/SimpleCachingEngine.scala
+++ b/core-v1/src/main/scala/engine/SimpleCachingEngine.scala
@@ -8,11 +8,12 @@ import data._
 import debug.DebugArgs
 import debug.DebugArgs.Invoker
 import dsl.{Sortable, ZipToShortest}
+import lens.CollectInto
 import logic.{Conjunction, Disjunction, Negation}
 
 import cats.arrow.Arrow
 import cats.data.NonEmptyVector
-import cats.{Applicative, Eval, FlatMap, Foldable, Functor, FunctorFilter, Traverse}
+import cats.{Applicative, Eval, FlatMap, Foldable, Functor, Traverse}
 import shapeless.HList
 
 object SimpleCachingEngine {
@@ -240,14 +241,15 @@ object SimpleCachingEngine {
       debugging(expr).invokeAndReturn(state((ca, results), cached(o, finalState.cacheState)))
     }
 
-    override def visitFilter[C[_] : FunctorFilter, A, B : ExtractValue.AsBoolean : OP](
-      expr: Expr.Filter[C, A, B, OP],
+    override def visitFilter[C[_], A, B : ExtractValue.AsBoolean, D[_]](
+      expr: Expr.Filter[C, A, B, D, OP],
     )(implicit
-      opO: OP[C[A]],
-    ): C[A] => CachedResult[C[A]] = memoize(expr, _) { input =>
+      filter: CollectInto.Filter[C, A, D],
+      opO: OP[D[A]],
+    ): C[A] => CachedResult[D[A]] = memoize(expr, _) { input =>
       // TODO: Is it possible to use cache between elements in the functor?
       val isMatchingResult = expr.conditionExpr.visit(this).andThen(r => ExtractValue.asBoolean(r.value))
-      val o = input.filter(isMatchingResult)
+      val o = filter.filter(input, isMatchingResult)
       debugging(expr).invokeAndReturn(state(input, cached(o)))
     }
 
@@ -380,6 +382,17 @@ object SimpleCachingEngine {
       val CachedResult(comparedTo, cacheState) = expr.comparedTo.visit(this)(i)
       val o = compare.sizeCompare(i, expr.comparison, comparedTo)
       debugging(expr).invokeAndReturn(state((i, expr.comparison, comparedTo), cached(o, cacheState)))
+    }
+
+    override def visitSlice[C[_] : Traverse, A, D[_]](
+      expr: Expr.Slice[C, A, D, OP],
+    )(implicit
+      filter: CollectInto.Filter[C, A, D],
+      opO: OP[D[A]],
+    ): C[A] => CachedResult[D[A]] = memoize(expr, _) { ca =>
+      val absRange = expr.range.toAbsolute(ca.size.toInt)
+      val slice = filter.collectSomeWithIndex(ca, (a, idx) => Option.when(absRange contains idx)(a))
+      debugging(expr).invokeAndReturn(state((ca, absRange), cached(slice)))
     }
 
     override def visitSorted[C[_], A](

--- a/core-v1/src/main/scala/engine/SimpleEngine.scala
+++ b/core-v1/src/main/scala/engine/SimpleEngine.scala
@@ -163,6 +163,14 @@ object SimpleEngine {
       debugging(expr).invokeAndReturn(state((i, left, right), isEqual))
     }
 
+    override def visitGetOrElse[I, O : OP](expr: Expr.GetOrElse[I, O, OP]): I => O = { i =>
+      val opt = expr.optionExpr.visit(this)(i)
+      val o = opt.getOrElse {
+        expr.defaultExpr.visit(this)(i)
+      }
+      debugging(expr).invokeAndReturn(state((i, opt), o))
+    }
+
     override def visitMapEvery[C[_] : Functor, A, B](
       expr: Expr.MapEvery[C, A, B, OP],
     )(implicit

--- a/core-v1/src/main/scala/engine/StandardEngine.scala
+++ b/core-v1/src/main/scala/engine/StandardEngine.scala
@@ -212,6 +212,8 @@ object StandardEngine {
       ExprResult.IsEqual(expr, finalState)
     }
 
+    override def visitGetOrElse[I, O : OP](expr: Expr.GetOrElse[I, O, OP]): PO <:< I => ExprResult[PO, I, O, OP] = ???
+
     override def visitMapEvery[C[_] : Functor, A, B](
       expr: Expr.MapEvery[C, A, B, OP],
     )(implicit

--- a/core-v1/src/main/scala/lens/CollectInto.scala
+++ b/core-v1/src/main/scala/lens/CollectInto.scala
@@ -1,0 +1,96 @@
+package com.rallyhealth.vapors.v1
+
+package lens
+
+import cats.data.{NonEmptyList, NonEmptySeq, NonEmptyVector}
+
+import scala.collection.Factory
+
+/**
+  * Defines the ability to map over elements of [[A]] to produce a value of [[Some]] new type [[B]],
+  * as well as the ability to filter the element out by returning [[None]]. This also allows changing
+  * the collection type in the process.
+  *
+  * For example, if you filter elements from a non-empty collection, you might end up with an empty
+  * collection, so calling .filter or .collect on a [[NonEmptyList]] would produce a [[List]].
+  *
+  * @note if you set type [[A]] to the same as type [[B]], then this operation becomes a filter.
+  *
+  * @see [[CollectInto.Filter]]
+  *
+  * @tparam C the collection type
+  * @tparam A the original element type
+  * @tparam B the new element type
+  */
+trait CollectInto[C[_], A, B] {
+  type Out[_]
+
+  def filter(
+    collection: C[A],
+    collector: A => Boolean,
+  )(implicit
+    ev: A <:< B,
+  ): Out[B]
+
+  def collectSome(
+    collection: C[A],
+    collector: A => Option[B],
+  ): Out[B] = collectSomeWithIndex(collection, (a, _) => collector(a))
+
+  def collectSomeWithIndex(
+    collection: C[A],
+    collector: (A, Int) => Option[B],
+  ): Out[B]
+}
+
+object CollectInto {
+  type Aux[C[_], A, B, D[_]] = CollectInto[C, A, B] { type Out[a] = D[a] }
+  type Filter[C[_], A, D[_]] = CollectInto[C, A, A] { type Out[a] = D[a] }
+
+  private final class CollectUsingFactory[C[_], A, B, D[_]](
+    asIterableOnce: C[A] => IterableOnce[A],
+  )(implicit
+    factory: Factory[B, D[B]],
+  ) extends CollectInto[C, A, B] {
+
+    override type Out[b] = D[b]
+
+    override def filter(
+      collection: C[A],
+      predicate: A => Boolean,
+    )(implicit
+      ev: A <:< B,
+    ): D[B] = {
+      factory.fromSpecific(asIterableOnce(collection).iterator.collect {
+        case a if predicate(a) => ev(a)
+      })
+    }
+
+    override def collectSome(
+      collection: C[A],
+      collector: A => Option[B],
+    ): D[B] = factory.fromSpecific(asIterableOnce(collection).iterator.collect(Function.unlift(collector)))
+
+    override def collectSomeWithIndex(
+      collection: C[A],
+      collector: (A, Int) => Option[B],
+    ): D[B] =
+      factory.fromSpecific(asIterableOnce(collection).iterator.zipWithIndex.collect(Function.unlift(collector.tupled)))
+  }
+
+  implicit def iterable[C[a] <: IterableOnce[a], A, B](
+    implicit
+    factory: Factory[B, C[B]],
+  ): CollectInto.Aux[C, A, B, C] =
+    new CollectUsingFactory[C, A, B, C](identity)
+
+  implicit def nonEmptySeq[A, B]: CollectInto.Aux[NonEmptySeq, A, B, Seq] =
+    new CollectUsingFactory[NonEmptySeq, A, B, Seq](_.toSeq)
+
+  implicit def nonEmptyList[A, B]: CollectInto.Aux[NonEmptyList, A, B, List] =
+    new CollectUsingFactory[NonEmptyList, A, B, List](_.toList)
+
+  implicit def nonEmptyVector[A, B]: CollectInto.Aux[NonEmptyVector, A, B, Vector] =
+    new CollectUsingFactory[NonEmptyVector, A, B, Vector](_.toVector)
+
+}

--- a/core-v1/src/main/scala/lens/IterableInto.scala
+++ b/core-v1/src/main/scala/lens/IterableInto.scala
@@ -1,0 +1,62 @@
+package com.rallyhealth.vapors.v1
+
+package lens
+
+import cats.data.{NonEmptyList, NonEmptySeq, NonEmptyVector}
+
+import scala.collection.{mutable, Factory}
+
+trait IterableInto[C[_], -A] {
+  type Out
+
+  def fromIterable(iterable: IterableOnce[A]): Out
+
+  def intoFactory: Factory[A, Out]
+}
+
+object IterableInto {
+
+  type Aux[C[_], -A, O] = IterableInto[C, A] { type Out = O }
+
+  implicit def convertFactory[C[_], A](factory: Factory[A, C[A]]): IterableInto.Aux[C, A, C[A]] = intoFactory(factory)
+
+  private final class IterableIntoFactory[C[_], A](
+    implicit
+    sourceFactory: Factory[A, C[A]],
+  ) extends IterableInto[C, A] {
+    override type Out = C[A]
+    override def fromIterable(iterable: IterableOnce[A]): C[A] = sourceFactory.fromSpecific(iterable)
+    override def intoFactory: Factory[A, C[A]] = sourceFactory
+  }
+
+  implicit def intoFactory[C[_], A](implicit factory: Factory[A, C[A]]): IterableInto.Aux[C, A, C[A]] =
+    new IterableIntoFactory[C, A]
+
+  private final class IterableIntoNonEmpty[C[_], S[_], A](
+    fromSource: S[A] => Option[C[A]],
+  )(implicit
+    sourceFactory: Factory[A, S[A]],
+  ) extends IterableInto[C, A] {
+    override type Out = Option[C[A]]
+    override def fromIterable(iterable: IterableOnce[A]): Option[C[A]] = intoFactory.fromSpecific(iterable)
+    override val intoFactory: Factory[A, Option[C[A]]] = new IterableIntoNonEmptyFactory(fromSource)
+  }
+
+  private final class IterableIntoNonEmptyFactory[C[_], S[_], A](
+    fromSource: S[A] => Option[C[A]],
+  )(implicit
+    sourceFactory: Factory[A, S[A]],
+  ) extends Factory[A, Option[C[A]]] {
+    override def fromSpecific(it: IterableOnce[A]): Option[C[A]] = fromSource(sourceFactory.fromSpecific(it))
+    override def newBuilder: mutable.Builder[A, Option[C[A]]] = sourceFactory.newBuilder.mapResult(fromSource)
+  }
+
+  implicit def intoNonEmptySeq[A]: IterableInto.Aux[NonEmptySeq, A, Option[NonEmptySeq[A]]] =
+    new IterableIntoNonEmpty[NonEmptySeq, Seq, A](NonEmptySeq.fromSeq)
+
+  implicit def intoNonEmptyList[A]: IterableInto.Aux[NonEmptyList, A, Option[NonEmptyList[A]]] =
+    new IterableIntoNonEmpty[NonEmptyList, List, A](NonEmptyList.fromList)
+
+  implicit def intoNonEmptyVector[A]: IterableInto.Aux[NonEmptyVector, A, Option[NonEmptyVector[A]]] =
+    new IterableIntoNonEmpty[NonEmptyVector, Vector, A](NonEmptyVector.fromVector)
+}

--- a/core-v1/src/main/scala/lens/IterableInto.scala
+++ b/core-v1/src/main/scala/lens/IterableInto.scala
@@ -6,6 +6,15 @@ import cats.data.{NonEmptyList, NonEmptySeq, NonEmptyVector}
 
 import scala.collection.{mutable, Factory}
 
+/**
+  * Defines the ability to convert from an [[IterableOnce]] into the deferred type member.
+  *
+  * This is useful for representing constraint validation, such as converting to a non-empty collection
+  * only returning an [[Option]] of [[NonEmptySeq]].
+  *
+  * @tparam C the starting collection type
+  * @tparam A the element type
+  */
 trait IterableInto[C[_], -A] {
   type Out
 

--- a/core-v1/src/main/scala/lens/VariantLens.scala
+++ b/core-v1/src/main/scala/lens/VariantLens.scala
@@ -11,6 +11,7 @@ import cats.{Eval, Foldable, Reducible}
 import shapeless.ops.hlist
 import shapeless.{Generic, HList}
 
+import scala.annotation.nowarn
 import scala.collection.{Factory, View}
 
 // TODO: Rename to NamedLens after old algebra removed
@@ -126,13 +127,13 @@ object VariantLens extends VariantLensLowPriorityImplicits {
       )
 
     /**
-      * Use the given Scala collection companion object to convert this [[IterableOnce]] into the desired output.
+      * Use the given higher-kinded type to convert the resulting [[IterableOnce]] into the desired output.
       *
       * TODO: Should there be any path information for conversion?
       *       List => Map seems important information as values with duplicate keys could be dropped
       */
-    def to[C[_]](implicit factory: Factory[E, C[E]]): VariantLens[A, C[E]] =
-      lens.copy(get = lens.get.andThen(factory.fromSpecific))
+    def to[C[_]](implicit into: IterableInto[C, E]): VariantLens[A, into.Out] =
+      lens.copy(get = lens.get.andThen(into.fromIterable(_): @nowarn))
   }
 
   implicit final class AsHListBuilder[A, L <: HList](private val lens: VariantLens[A, L]) extends AnyVal {

--- a/core-v1/src/main/scala/lens/VariantLens.scala
+++ b/core-v1/src/main/scala/lens/VariantLens.scala
@@ -149,7 +149,7 @@ object VariantLens extends VariantLensLowPriorityImplicits {
   }
 }
 
-sealed trait VariantLensLowPriorityImplicits {
+private[lens] sealed trait VariantLensLowPriorityImplicits {
 
   /**
     * Wrap the result of this lens with an [[VariantLens.AsIterableBuilder]] for helper operations

--- a/core-v1/src/test/scala/SimpleFilterSpec.scala
+++ b/core-v1/src/test/scala/SimpleFilterSpec.scala
@@ -1,5 +1,6 @@
 package com.rallyhealth.vapors.v1
 
+import cats.data.{NonEmptyList, NonEmptySeq, NonEmptyVector}
 import munit.FunSuite
 
 class SimpleFilterSpec extends FunSuite {
@@ -16,5 +17,41 @@ class SimpleFilterSpec extends FunSuite {
     compileErrors {
       "Seq().const.filter(_ < 3.const)"
     }
+  }
+
+  test("NonEmptySeq[Int].filter returns a Seq[Int]") {
+    val expr = NonEmptySeq.of(1, 2, 3, 4).const.filter(_ > 2.const)
+    val res = expr.run()
+    assertEquals(res, Seq(3, 4))
+  }
+
+  test("NonEmptySeq[Int].filter returns an empty Seq[Int]") {
+    val expr = NonEmptySeq.of(1, 2, 3, 4).const.filter(_ > 4.const)
+    val res = expr.run()
+    assertEquals(res, Seq())
+  }
+
+  test("NonEmptyList[Int].filter returns a List[Int]") {
+    val expr = NonEmptyList.of(1, 2, 3, 4).const.filter(_ > 2.const)
+    val res = expr.run()
+    assertEquals(res, List(3, 4))
+  }
+
+  test("NonEmptyList[Int].filter returns an empty List[Int]") {
+    val expr = NonEmptyList.of(1, 2, 3, 4).const.filter(_ > 4.const)
+    val res = expr.run()
+    assertEquals(res, Nil)
+  }
+
+  test("NonEmptyVector[Int].filter returns a Vector[Int]") {
+    val expr = NonEmptyVector.of(1, 2, 3, 4).const.filter(_ > 2.const)
+    val res = expr.run()
+    assertEquals(res, Vector(3, 4))
+  }
+
+  test("NonEmptyVector[Int].filter returns an empty Vector[Int]") {
+    val expr = NonEmptyVector.of(1, 2, 3, 4).const.filter(_ > 4.const)
+    val res = expr.run()
+    assertEquals(res, Vector())
   }
 }

--- a/core-v1/src/test/scala/SimpleGetOrElseSpec.scala
+++ b/core-v1/src/test/scala/SimpleGetOrElseSpec.scala
@@ -1,0 +1,26 @@
+package com.rallyhealth.vapors.v1
+
+import munit.FunSuite
+
+class SimpleGetOrElseSpec extends FunSuite {
+
+  import dsl.simple._
+
+  test("Some().const.getOrElse returns the wrapped value") {
+    val input = 1
+    val expr = Some(input).const.getOrElse(2.const)
+    assertEquals(expr.run(), input)
+  }
+
+  test("some().getOrElse returns the wrapped value") {
+    val input = 1
+    val expr = some(input.const).getOrElse(2.const)
+    assertEquals(expr.run(), input)
+  }
+
+  test("none.getOrElse returns the default value") {
+    val input = 2
+    val expr = none[Int].getOrElse(input.const)
+    assertEquals(expr.run(), input)
+  }
+}

--- a/core-v1/src/test/scala/SimpleJustifiedFilterSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedFilterSpec.scala
@@ -1,7 +1,9 @@
 package com.rallyhealth.vapors.v1
 
 import data.Justified
+import lens.DataPath
 
+import cats.data.{NonEmptyList, NonEmptySeq, NonEmptyVector}
 import munit.FunSuite
 
 class SimpleJustifiedFilterSpec extends FunSuite {
@@ -20,5 +22,65 @@ class SimpleJustifiedFilterSpec extends FunSuite {
     compileErrors {
       "Seq().const.filter(_ < 3.const)"
     }
+  }
+
+  test("NonEmptySeq[Int].filter returns a Seq[Int]") {
+    val input = NonEmptySeq.of(1, 2, 3, 4)
+    val expr = input.const.filter(_ > 2.const)
+    val res = expr.run()
+    val justifiedInput = Justified.byConst(input)
+    assertEquals(
+      res,
+      Seq(
+        Justified.bySelection(3, DataPath.empty.atIndex(2), justifiedInput),
+        Justified.bySelection(4, DataPath.empty.atIndex(3), justifiedInput),
+      ),
+    )
+  }
+
+  test("NonEmptySeq[Int].filter returns an empty Seq[Int]") {
+    val expr = NonEmptySeq.of(1, 2, 3, 4).const.filter(_ > 4.const)
+    val res = expr.run()
+    assertEquals(res, Seq())
+  }
+
+  test("NonEmptyList[Int].filter returns a List[Int]") {
+    val input = NonEmptyList.of(1, 2, 3, 4)
+    val expr = input.const.filter(_ > 2.const)
+    val res = expr.run()
+    val justifiedInput = Justified.byConst(input)
+    assertEquals(
+      res,
+      List(
+        Justified.bySelection(3, DataPath.empty.atIndex(2), justifiedInput),
+        Justified.bySelection(4, DataPath.empty.atIndex(3), justifiedInput),
+      ),
+    )
+  }
+
+  test("NonEmptyList[Int].filter returns an empty List[Int]") {
+    val expr = NonEmptyList.of(1, 2, 3, 4).const.filter(_ > 4.const)
+    val res = expr.run()
+    assertEquals(res, Nil)
+  }
+
+  test("NonEmptyVector[Int].filter returns a Vector[Int]") {
+    val input = NonEmptyVector.of(1, 2, 3, 4)
+    val expr = input.const.filter(_ > 2.const)
+    val res = expr.run()
+    val justifiedInput = Justified.byConst(input)
+    assertEquals(
+      res,
+      Vector(
+        Justified.bySelection(3, DataPath.empty.atIndex(2), justifiedInput),
+        Justified.bySelection(4, DataPath.empty.atIndex(3), justifiedInput),
+      ),
+    )
+  }
+
+  test("NonEmptyVector[Int].filter returns an empty Vector[Int]") {
+    val expr = NonEmptyVector.of(1, 2, 3, 4).const.filter(_ > 4.const)
+    val res = expr.run()
+    assertEquals(res, Vector())
   }
 }

--- a/core-v1/src/test/scala/SimpleJustifiedGetOrElseSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedGetOrElseSpec.scala
@@ -1,0 +1,32 @@
+package com.rallyhealth.vapors.v1
+
+import data.Justified
+import lens.DataPath
+
+import munit.FunSuite
+
+class SimpleJustifiedGetOrElseSpec extends FunSuite {
+
+  import dsl.simple.justified._
+
+  test("Some().const.getOrElse returns the wrapped value") {
+    val input = 1
+    val expr = Some(input).const.getOrElse(2.const)
+    val expected = Justified.bySelection(1, DataPath.empty.atIndex(0), Justified.byConst(Some(input)))
+    assertEquals(expr.run(), expected)
+  }
+
+  test("some().getOrElse returns the wrapped value") {
+    val input = 1
+    val expr = some(input.const).getOrElse(2.const)
+    val expected = Justified.byConst(input)
+    assertEquals(expr.run(), expected)
+  }
+
+  test("none.getOrElse returns the default value") {
+    val input = 2
+    val expr = none[Int].getOrElse(input.const)
+    val expected = Justified.byConst(input)
+    assertEquals(expr.run(), expected)
+  }
+}

--- a/core-v1/src/test/scala/SimpleJustifiedSelectSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedSelectSpec.scala
@@ -183,13 +183,15 @@ class SimpleJustifiedSelectSpec extends FunSuite {
     val fixture = Seq(1, 2, 3)
     val expr = fixture.const.atIndex(1)
     val observed = expr.run()
-    assertEquals(observed, Some(Justified.byConst(fixture(1))))
+    val expected = Some(Justified.bySelection(2, DataPath.empty.atIndex(1), Justified.byConst(fixture)))
+    assertEquals(observed, expected)
   }
 
   test("Select an element by index from a NonEmptySeq") {
     val fixture = NonEmptySeq.of(1, 2, 3)
     val expr = fixture.const.atIndex(1)
     val observed = expr.run()
-    assertEquals(observed, fixture.get(1).map(Justified.byConst))
+    val expected = Some(Justified.bySelection(2, DataPath.empty.atIndex(1), Justified.byConst(fixture)))
+    assertEquals(observed, expected)
   }
 }

--- a/core-v1/src/test/scala/SimpleJustifiedSelectSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedSelectSpec.scala
@@ -178,4 +178,18 @@ class SimpleJustifiedSelectSpec extends FunSuite {
     }
     assert(message contains "Could not find an instance of Reducible for Seq")
   }
+
+  test("Select an element by index from a Seq") {
+    val fixture = Seq(1, 2, 3)
+    val expr = fixture.const.atIndex(1)
+    val observed = expr.run()
+    assertEquals(observed, Some(Justified.byConst(fixture(1))))
+  }
+
+  test("Select an element by index from a NonEmptySeq") {
+    val fixture = NonEmptySeq.of(1, 2, 3)
+    val expr = fixture.const.atIndex(1)
+    val observed = expr.run()
+    assertEquals(observed, fixture.get(1).map(Justified.byConst))
+  }
 }

--- a/core-v1/src/test/scala/SimpleJustifiedSelectSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedSelectSpec.scala
@@ -183,7 +183,7 @@ class SimpleJustifiedSelectSpec extends FunSuite {
     val fixture = Seq(1, 2, 3)
     val expr = fixture.const.atIndex(1)
     val observed = expr.run()
-    val expected = Some(Justified.bySelection(2, DataPath.empty.atIndex(1), Justified.byConst(fixture)))
+    val expected = Some(Justified.bySelection(fixture(1), DataPath.empty.atIndex(1), Justified.byConst(fixture)))
     assertEquals(observed, expected)
   }
 
@@ -191,7 +191,8 @@ class SimpleJustifiedSelectSpec extends FunSuite {
     val fixture = NonEmptySeq.of(1, 2, 3)
     val expr = fixture.const.atIndex(1)
     val observed = expr.run()
-    val expected = Some(Justified.bySelection(2, DataPath.empty.atIndex(1), Justified.byConst(fixture)))
+    val expected =
+      Some(Justified.bySelection(fixture.getUnsafe(1), DataPath.empty.atIndex(1), Justified.byConst(fixture)))
     assertEquals(observed, expected)
   }
 }

--- a/core-v1/src/test/scala/SimpleJustifiedSliceSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedSliceSpec.scala
@@ -1,0 +1,50 @@
+package com.rallyhealth.vapors.v1
+
+import data.Justified
+
+import munit.FunSuite
+
+class SimpleJustifiedSliceSpec extends FunSuite {
+
+  import dsl.simple.justified._
+
+  test("Seq[Justified[Int]](1..5).slice(1 <-> 3)") {
+    val input = Seq(1, 2, 3, 4, 5)
+    val expr = input.const.slice(1 <-> 3)
+    val observed = expr.run()
+    val expected = Justified.elements(Justified.byConst(input)).slice(1, 3)
+    assertEquals(observed, expected)
+  }
+
+  test("Seq[Justified[Int]](1..5).slice(-3 <-> -1)") {
+    val input = Seq(1, 2, 3, 4, 5)
+    val expr = input.const.slice(-3 <-> -1)
+    val observed = expr.run()
+    val expected = Justified.elements(Justified.byConst(input)).slice(2, 4)
+    assertEquals(observed, expected)
+  }
+
+  test("Seq[Justified[Int]](1..5).slice(1 <-> -1)") {
+    val input = Seq(1, 2, 3, 4, 5)
+    val expr = input.const.slice(1 <-> -1)
+    val observed = expr.run()
+    val expected = Justified.elements(Justified.byConst(input)).slice(1, 4)
+    assertEquals(observed, expected)
+  }
+
+  test("Seq[Justified[Int]](1..5).slice(2 <-> End)") {
+    val input = Seq(1, 2, 3, 4, 5)
+    val expr = input.const.slice(2 <-> End)
+    val observed = expr.run()
+    val expected = Justified.elements(Justified.byConst(input)).slice(2, 5)
+    assertEquals(observed, expected)
+  }
+
+  test("Seq[Justified[Int]](1..5).slice(-2 <-> End)") {
+    val input = Seq(1, 2, 3, 4, 5)
+    val expr = input.const.slice(-2 <-> End)
+    val observed = expr.run()
+    val expected = Justified.elements(Justified.byConst(input)).slice(3, 5)
+    assertEquals(observed, expected)
+  }
+}

--- a/core-v1/src/test/scala/SimpleSelectSpec.scala
+++ b/core-v1/src/test/scala/SimpleSelectSpec.scala
@@ -132,4 +132,18 @@ class SimpleSelectSpec extends FunSuite {
     }
     assert(message contains "Could not find an instance of Reducible for Seq")
   }
+
+  test("Select an element by index from a Seq") {
+    val fixture = Seq(1, 2, 3)
+    val expr = fixture.const.atIndex(1)
+    val observed = expr.run()
+    assertEquals(observed, Some(fixture(1)))
+  }
+
+  test("Select an element by index from a NonEmptySeq") {
+    val fixture = NonEmptySeq.of(1, 2, 3)
+    val expr = fixture.const.atIndex(1)
+    val observed = expr.run()
+    assertEquals(observed, fixture.get(1))
+  }
 }

--- a/core-v1/src/test/scala/SimpleSliceSpec.scala
+++ b/core-v1/src/test/scala/SimpleSliceSpec.scala
@@ -1,0 +1,48 @@
+package com.rallyhealth.vapors.v1
+
+import munit.FunSuite
+
+class SimpleSliceSpec extends FunSuite {
+
+  import dsl.simple._
+
+  test("[1..5].slice(1 <-> 3)") {
+    val input = Seq(1, 2, 3, 4, 5)
+    val expr = input.const.slice(1 <-> 3)
+    val observed = expr.run()
+    val expected = input.slice(1, 3)
+    assertEquals(observed, expected)
+  }
+
+  test("[1..5].slice(-3 <-> -1)") {
+    val input = Seq(1, 2, 3, 4, 5)
+    val expr = input.const.slice(-3 <-> -1)
+    val observed = expr.run()
+    val expected = input.slice(2, 4)
+    assertEquals(observed, expected)
+  }
+
+  test("[1..5].slice(1 <-> -1)") {
+    val input = Seq(1, 2, 3, 4, 5)
+    val expr = input.const.slice(1 <-> -1)
+    val observed = expr.run()
+    val expected = input.slice(1, 4)
+    assertEquals(observed, expected)
+  }
+
+  test("[1..5].slice(2 <-> End)") {
+    val input = Seq(1, 2, 3, 4, 5)
+    val expr = input.const.slice(2 <-> End)
+    val observed = expr.run()
+    val expected = input.slice(2, 5)
+    assertEquals(observed, expected)
+  }
+
+  test("[1..5].slice(-2 <-> End)") {
+    val input = Seq(1, 2, 3, 4, 5)
+    val expr = input.const.slice(-2 <-> End)
+    val observed = expr.run()
+    val expected = input.slice(3, 5)
+    assertEquals(observed, expected)
+  }
+}


### PR DESCRIPTION
* Update VariantLens to use IterableInto instead of Factory
  - Support lens.to[NonEmptySeq]
* Add a SelectHolder to mimic the pattern for CombineHolder
  - Support conversion of Foldable types into other collections via Select
* Add .atIndex operator for selecting an element by index
* Add Expr.GetOrElse and DSL method
  - Use contravariance for `SelectOutputType` to support `Some(x).const` better
* Add Expr.Slice, DSL method, and simple unit tests
  - Add CollectInto type-level calculation for .filter and .slice
  - Support .filter and .slice for NonEmpty collection types
  - Add SliceRange and support relative ranges
  - Add unit tests for all types of collections