### PR TITLE
Support current time operations and converting an HList value using ExprConverter

### DIFF
--- a/core-v1/src/main/scala/algebra/Expr.scala
+++ b/core-v1/src/main/scala/algebra/Expr.scala
@@ -527,6 +527,9 @@ object Expr {
       compare: SizeComparable[I, N, B],
     ): H[I, B] = proxy(underlying.visitSizeIs(expr))
 
+    override def visitToHList[I, L <: HList : OP](expr: ToHList[I, L, OP])(implicit toHL: ConvertToHList[L]): H[I, L] =
+      proxy(underlying.visitToHList(expr))
+
     override def visitUsingDefinitions[I, O : OP](expr: UsingDefinitions[I, O, OP]): H[I, O] =
       proxy(underlying.visitUsingDefinitions(expr))
 

--- a/core-v1/src/main/scala/data/Justified.scala
+++ b/core-v1/src/main/scala/data/Justified.scala
@@ -7,6 +7,7 @@ import dsl.{WrapConst, WrapFact, WrapQuantifier, WrapSelected}
 import lens.{DataPath, VariantLens}
 import logic.Logic
 import math._
+import time.CountTime
 
 import cats.data.{NonEmptySeq, NonEmptySet}
 import cats.implicits._
@@ -224,6 +225,17 @@ object Justified extends LowPriorityJustifiedImplicits {
   implicit def orderingByValue[V : Ordering]: Ordering[Justified[V]] = Ordering.by(_.value)
 
   implicit def orderByValue[V : Order]: Order[Justified[V]] = Order.by(_.value)
+
+  implicit def countTime[T, U, O](
+    implicit
+    underlying: CountTime[T, U, O],
+  ): CountTime[Justified[T], Justified[U], Justified[O]] = { (start, end, truncateToUnit) =>
+    Justified.byInference(
+      "date_diff",
+      underlying.between(start.value, end.value, truncateToUnit.value),
+      NonEmptySeq.of(start, end, truncateToUnit),
+    )
+  }
 
   private final case object ExtractJustified extends Extract[Justified] {
     override def extract[A](fa: Justified[A]): A = fa.value

--- a/core-v1/src/main/scala/data/TimeOrder.scala
+++ b/core-v1/src/main/scala/data/TimeOrder.scala
@@ -8,29 +8,44 @@ import cats.Order
 import java.time._
 import java.time.chrono.{ChronoLocalDate, ChronoLocalDateTime, ChronoZonedDateTime}
 
-abstract class TimeOrder {
+class TimeOrder {
 
-  def modify[T](order: Order[T]): Order[T]
+  protected def modify[T](order: Order[T]): Order[T] = order
 
-  implicit val latestLocalDateFirst: Order[LocalDate] = modify {
+  @deprecated("Use orderLocalDate instead.", "1.0.0")
+  def latestLocalDateFirst: Order[LocalDate] = orderLocalDate
+
+  implicit val orderLocalDate: Order[LocalDate] = modify {
     Order.fromComparable[ChronoLocalDate].contramap(identity[ChronoLocalDate])
   }
 
-  implicit val latestLocalDateTimeFirst: Order[LocalDateTime] = modify {
+  @deprecated("Use orderLocalDate instead.", "1.0.0")
+  def latestLocalDateTimeFirst: Order[LocalDateTime] = orderLocalDateTime
+
+  implicit val orderLocalDateTime: Order[LocalDateTime] = modify {
     Order
       .fromComparable[ChronoLocalDateTime[_ <: ChronoLocalDate]]
       .contramap(identity[ChronoLocalDateTime[_ <: ChronoLocalDate]])
   }
 
-  implicit val latestLocalTimeFirst: Order[LocalTime] = modify {
+  @deprecated("Use orderLocalDate instead.", "1.0.0")
+  def latestLocalTimeFirst: Order[LocalTime] = orderLocalTime
+
+  implicit val orderLocalTime: Order[LocalTime] = modify {
     Order.fromComparable
   }
 
-  implicit val latestInstantFirst: Order[Instant] = modify {
+  @deprecated("Use orderLocalDate instead.", "1.0.0")
+  def latestInstantFirst: Order[Instant] = orderInstant
+
+  implicit val orderInstant: Order[Instant] = modify {
     Order.fromComparable
   }
 
-  implicit val latestZonedDateTimeFirst: Order[ZonedDateTime] = modify {
+  @deprecated("Use orderLocalDate instead.", "1.0.0")
+  def latestZonedDateTimeFirst: Order[ZonedDateTime] = orderZonedDateTime
+
+  implicit val orderZonedDateTime: Order[ZonedDateTime] = modify {
     Order
       .fromComparable[ChronoZonedDateTime[_ <: ChronoLocalDate]]
       .contramap(identity[ChronoZonedDateTime[_ <: ChronoLocalDate]])
@@ -40,10 +55,8 @@ abstract class TimeOrder {
 object TimeOrder {
 
   final object YoungestFirst extends TimeOrder {
-    override def modify[T](order: Order[T]): Order[T] = Order.reverse(order)
+    override protected def modify[T](order: Order[T]): Order[T] = Order.reverse(order)
   }
 
-  final object OldestFirst extends TimeOrder {
-    override def modify[T](order: Order[T]): Order[T] = Order.reverse(order)
-  }
+  final object OldestFirst extends TimeOrder
 }

--- a/core-v1/src/main/scala/data/TimeOrder.scala
+++ b/core-v1/src/main/scala/data/TimeOrder.scala
@@ -1,0 +1,49 @@
+package com.rallyhealth.vapors.v1
+
+package data
+
+import cats.syntax.contravariant._
+import cats.Order
+
+import java.time._
+import java.time.chrono.{ChronoLocalDate, ChronoLocalDateTime, ChronoZonedDateTime}
+
+abstract class TimeOrder {
+
+  def modify[T](order: Order[T]): Order[T]
+
+  implicit val latestLocalDateFirst: Order[LocalDate] = modify {
+    Order.fromComparable[ChronoLocalDate].contramap(identity[ChronoLocalDate])
+  }
+
+  implicit val latestLocalDateTimeFirst: Order[LocalDateTime] = modify {
+    Order
+      .fromComparable[ChronoLocalDateTime[_ <: ChronoLocalDate]]
+      .contramap(identity[ChronoLocalDateTime[_ <: ChronoLocalDate]])
+  }
+
+  implicit val latestLocalTimeFirst: Order[LocalTime] = modify {
+    Order.fromComparable
+  }
+
+  implicit val latestInstantFirst: Order[Instant] = modify {
+    Order.fromComparable
+  }
+
+  implicit val latestZonedDateTimeFirst: Order[ZonedDateTime] = modify {
+    Order
+      .fromComparable[ChronoZonedDateTime[_ <: ChronoLocalDate]]
+      .contramap(identity[ChronoZonedDateTime[_ <: ChronoLocalDate]])
+  }
+}
+
+object TimeOrder {
+
+  final object YoungestFirst extends TimeOrder {
+    override def modify[T](order: Order[T]): Order[T] = Order.reverse(order)
+  }
+
+  final object OldestFirst extends TimeOrder {
+    override def modify[T](order: Order[T]): Order[T] = Order.reverse(order)
+  }
+}

--- a/core-v1/src/main/scala/debug/DebugArgs.scala
+++ b/core-v1/src/main/scala/debug/DebugArgs.scala
@@ -302,6 +302,12 @@ object DebugArgs {
       override type Out = W[Boolean]
     }
 
+  implicit def debugToHList[I, L <: HList, OP[_]]: Aux[Expr.ToHList[I, L, OP], OP, I, L] =
+    new DebugArgs[Expr.ToHList[I, L, OP], OP] {
+      override type In = I
+      override type Out = L
+    }
+
   implicit def debugZipToShortestHList[
     I,
     F[+_],

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -12,7 +12,12 @@ import cats.data.{NonEmptySeq, NonEmptyVector}
 import cats.{FlatMap, Foldable, Functor, Id, Order, Reducible, Traverse}
 import shapeless.{Generic, HList}
 
-trait BuildExprDsl extends DebugExprDsl with SliceRangeSyntax with WrapArityMethods with UsingDefinitionArityMethods {
+trait BuildExprDsl
+  extends DebugExprDsl
+  with SliceRangeSyntax
+  with TimeFunctions
+  with WrapArityMethods
+  with UsingDefinitionArityMethods {
   self: DslTypes with ExprHListDslImplicits with OutputTypeImplicits =>
 
   /**

--- a/core-v1/src/main/scala/dsl/ConvertToHList.scala
+++ b/core-v1/src/main/scala/dsl/ConvertToHList.scala
@@ -1,0 +1,42 @@
+package com.rallyhealth.vapors.v1
+
+package dsl
+
+import algebra.Expr
+
+import cats.arrow.Arrow
+import cats.implicits._
+import shapeless.{::, HList, HNil}
+
+trait ConvertToHList[L <: HList] {
+
+  def convertToHListWith[G[-_, +_] : Arrow, I, OP[_]](
+    xhl: ExprHList[I, L, OP],
+    v: Expr.Visitor[G, OP],
+  ): G[I, L]
+}
+
+object ConvertToHList {
+
+  implicit def toHNil: ConvertToHList[HNil] =
+    new ConvertToHList[HNil] {
+      override def convertToHListWith[G[-_, +_] : Arrow, I, OP[_]](
+        xhl: ExprHList[I, HNil, OP],
+        v: Expr.Visitor[G, OP],
+      ): G[I, HNil] =
+        Arrow[G].lift(_ => HNil)
+    }
+
+  implicit def toHCons[H, T <: HList](implicit toHL: ConvertToHList[T]): ConvertToHList[H :: T] =
+    new ConvertToHList[H :: T] {
+      override def convertToHListWith[G[-_, +_] : Arrow, I, OP[_]](
+        xhl: ExprHList[I, H :: T, OP],
+        v: Expr.Visitor[G, OP],
+      ): G[I, H :: T] = {
+        val G = Arrow[G]
+        val gh = xhl.head.visit(v)
+        val gt = toHL.convertToHListWith(xhl.tail, v)
+        (gh &&& gt) >>> G.lift { case (h, t) => h :: t }
+      }
+    }
+}

--- a/core-v1/src/main/scala/dsl/ExprHList.scala
+++ b/core-v1/src/main/scala/dsl/ExprHList.scala
@@ -31,6 +31,9 @@ sealed trait ExprHList[-I, +L <: HList, OP[_]] {
 
 object ExprHList {
 
+  implicit def asExpr[I, L <: HList : ConvertToHList : OP, OP[_]](xhl: ExprHList[I, L, OP]): Expr.ToHList[I, L, OP] =
+    Expr.ToHList(xhl)
+
   implicit class Ops[I, L <: HList, OP[_]](private val xhl: ExprHList[I, L, OP]) {
 
     /**
@@ -42,6 +45,12 @@ object ExprHList {
       * Return the tail elements of this non-empty [[ExprHList]].
       */
     def tail(implicit c: IsExprHCons[L]): ExprHList[I, c.T, OP] = c.tail(xhl)
+
+    def toExpr(
+      implicit
+      c: ConvertToHList[L],
+      opL: OP[L],
+    ): Expr.ToHList[I, L, OP] = Expr.ToHList(xhl)
   }
 }
 

--- a/core-v1/src/main/scala/dsl/TimeFunctions.scala
+++ b/core-v1/src/main/scala/dsl/TimeFunctions.scala
@@ -1,0 +1,101 @@
+package com.rallyhealth.vapors.v1
+
+package dsl
+
+import algebra.Expr
+import time.CountTime
+
+import shapeless._
+
+import java.time.{Clock, Instant, LocalDate}
+
+/**
+  * Provides common functions work working with time.
+  *
+  * This works by providing an escape hatch for evaluating a custom Scala function (rather than building
+  * all the operations out of [[Expr]] nodes).
+  *
+  * @see [[Expr.CustomFunction]]
+  */
+trait TimeFunctions {
+  self: DslTypes =>
+
+  protected def wrapConst: WrapConst[W, OP]
+
+  /**
+    * Computes the difference between the `lhsExpr` and the `rhsExpr` as an integral value of the given unit
+    * (can be negative). The result will be rounded down to the maximum number of whole units between the two
+    * temporal instances that can be counted.
+    *
+    * This requires an instance of [[CountTime]] to make sure that the given unit type is safe to count for
+    * the given temporal types. This is a safer API than working directly with Java's Time library because it
+    * forbids subtracting two different temporal types from each other, without first converting them appropriately.
+    * Java Time will just throw an exception if the types are incompatible.
+    *
+    * @param lhsExpr an expression that computes the temporal instant of when to start counting
+    * @param rhsExpr an expression that computes the temporal instant of when to stop counting
+    *                (either counting units of time in the past or future from lhsExpr)
+    * @param roundToUnitExpr the type of unit to round down to
+    */
+  def dateDiff[I, T, U](
+    lhsExpr: I ~:> W[T],
+    rhsExpr: I ~:> W[T],
+    roundToUnitExpr: I ~:> W[U],
+  )(implicit
+    countTime: CountTime[W[T], W[U], W[Long]],
+    opL: OP[W[T] :: W[T] :: W[U] :: HNil],
+    opO: OP[W[Long]],
+  ): AndThen[I, W[T] :: W[T] :: W[U] :: HNil, W[Long]] = {
+    (lhsExpr :: rhsExpr :: roundToUnitExpr).andThen {
+      Expr.CustomFunction[W[T] :: W[T] :: W[U] :: HNil, W[Long], OP]("date_diff", {
+        case lhs :: rhs :: unit :: HNil =>
+          CountTime.between(lhs, rhs, unit)
+      })
+    }
+  }
+
+  /**
+    * Returns an expression that computes the current [[LocalDate]] when it is invoke, using the system
+    * [[Clock]] with the default timezone information of host machine / JVM.
+    */
+  def today(
+    implicit
+    opC: OP[LocalDate],
+    opO: OP[W[LocalDate]],
+  ): Any ~:> W[LocalDate] =
+    today(Clock.systemDefaultZone())
+
+  /**
+    * Returns an expression that computes the current [[LocalDate]] when it is invoked, based on the given [[Clock]].
+    */
+  def today(
+    clock: Clock,
+  )(implicit
+    opC: OP[LocalDate],
+    opO: OP[W[LocalDate]],
+  ): Any ~:> W[LocalDate] = {
+    Expr.CustomFunction("today", _ => wrapConst.wrapConst(LocalDate.now(clock)))
+  }
+
+  /**
+    * Returns an expression that computes the current [[Instant]] when it is invoked, using the UTC [[Clock]].
+    */
+  def now(
+    implicit
+    opC: OP[Instant],
+    opO: OP[W[Instant]],
+  ): Any ~:> W[Instant] =
+    now(Clock.systemUTC())
+
+  /**
+    * Returns an expression that computes the current [[Instant]] when it is invoked, based on the given [[Clock]].
+    */
+  def now(
+    clock: Clock,
+  )(implicit
+    opC: OP[Instant],
+    opO: OP[W[Instant]],
+  ): Any ~:> W[Instant] =
+    Expr.CustomFunction("now", _ => wrapConst.wrapConst(Instant.now(clock)))
+
+}

--- a/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedBuildExprDsl.scala
@@ -17,6 +17,7 @@ trait UnwrappedBuildExprDsl
   with UnwrappedUsingDefinitionArityMethods
   with DefaultUnwrappedExprHListImplicits
   with DefaultUnwrappedOutputTypeImplicits
+  with UnwrappedTimeFunctions
   with UnwrappedDslTypes {
 
   override protected implicit final def boolLogic: Logic[W, Boolean, OP] = Logic.bool

--- a/core-v1/src/main/scala/dsl/UnwrappedTimeFunctions.scala
+++ b/core-v1/src/main/scala/dsl/UnwrappedTimeFunctions.scala
@@ -1,0 +1,48 @@
+package com.rallyhealth.vapors.v1
+
+package dsl
+import time.CountTime
+
+import shapeless.{::, HNil}
+
+import java.time.{Clock, Instant, LocalDate}
+
+trait UnwrappedTimeFunctions extends TimeFunctions with UnwrappedDslTypes {
+
+  override final def dateDiff[I, T, U](
+    lhsExpr: I ~:> T,
+    rhsExpr: I ~:> T,
+    roundToUnitExpr: I ~:> U,
+  )(implicit
+    countTime: CountTime[T, U, Long],
+    opL: OP[T :: T :: U :: HNil],
+    opO: OP[Long],
+  ): AndThen[I, T :: T :: U :: HNil, Long] =
+    super.dateDiff(lhsExpr, rhsExpr, roundToUnitExpr)(countTime, opL, opO)
+
+  override final def today(
+    implicit
+    opC: OP[LocalDate],
+    opO: OP[LocalDate],
+  ): Any ~:> LocalDate = super.today(opC, opO)
+
+  override final def today(
+    clock: Clock,
+  )(implicit
+    opC: OP[LocalDate],
+    opO: OP[LocalDate],
+  ): Any ~:> LocalDate = super.today(clock)(opC, opO)
+
+  override final def now(
+    implicit
+    opC: OP[Instant],
+    opO: OP[Instant],
+  ): Any ~:> Instant = super.now(opC, opO)
+
+  override final def now(
+    clock: Clock,
+  )(implicit
+    opC: OP[Instant],
+    opO: OP[Instant],
+  ): Any ~:> Instant = super.now(clock)(opC, opO)
+}

--- a/core-v1/src/main/scala/engine/SimpleCachingEngine.scala
+++ b/core-v1/src/main/scala/engine/SimpleCachingEngine.scala
@@ -7,7 +7,7 @@ import data.ExtractValue.AsBoolean
 import data._
 import debug.DebugArgs
 import debug.DebugArgs.Invoker
-import dsl.{Sortable, ZipToShortest}
+import dsl.{ConvertToHList, Sortable, ZipToShortest}
 import lens.CollectInto
 import logic.{Conjunction, Disjunction, Negation}
 
@@ -404,6 +404,15 @@ object SimpleCachingEngine {
       val unsorted: C[A] = i
       val sorted = sortable.sort(i)
       debugging(expr).invokeAndReturn(state(unsorted, cached(sorted)))
+    }
+
+    override def visitToHList[I, L <: HList : OP](
+      expr: Expr.ToHList[I, L, OP],
+    )(implicit
+      toHL: ConvertToHList[L],
+    ): I => CachedResult[L] = memoize(expr, _) { i =>
+      val fn = toHL.convertToHListWith(expr.exprHList, this)
+      debugging(expr).invokeAndReturn(state(i, fn(i)))
     }
 
     override def visitUsingDefinitions[I, O : OP](expr: Expr.UsingDefinitions[I, O, OP]): I => CachedResult[O] =

--- a/core-v1/src/main/scala/engine/SimpleEngine.scala
+++ b/core-v1/src/main/scala/engine/SimpleEngine.scala
@@ -6,7 +6,7 @@ import algebra.{EqualComparable, Expr, SizeComparable, WindowComparable}
 import data._
 import debug.DebugArgs
 import debug.DebugArgs.Invoker
-import dsl.{Sortable, ZipToShortest}
+import dsl.{ConvertToHList, ExprHCons, ExprHNil, Sortable, ZipToShortest}
 import lens.CollectInto
 import logic.{Conjunction, Disjunction, Negation}
 
@@ -255,6 +255,15 @@ object SimpleEngine {
     ): C[A] => C[A] = { i =>
       val o = sortable.sort(i)
       debugging(expr).invokeAndReturn(state(i, o))
+    }
+
+    override def visitToHList[I, L <: HList : OP](
+      expr: Expr.ToHList[I, L, OP],
+    )(implicit
+      toHL: ConvertToHList[L],
+    ): I => L = { i =>
+      val fn = toHL.convertToHListWith(expr.exprHList, this)
+      debugging(expr).invokeAndReturn(state(i, fn(i)))
     }
 
     override def visitUsingDefinitions[I, O : OP](expr: Expr.UsingDefinitions[I, O, OP]): I => O = { i =>

--- a/core-v1/src/main/scala/engine/StandardEngine.scala
+++ b/core-v1/src/main/scala/engine/StandardEngine.scala
@@ -5,7 +5,7 @@ package engine
 import algebra._
 import data.{ExprState, ExtractValue, TypedFact, Window}
 import debug.DebugArgs
-import dsl.{Sortable, ZipToShortest}
+import dsl.{ConvertToHList, Sortable, ZipToShortest}
 import lens.CollectInto
 import logic.{Conjunction, Disjunction, Negation}
 
@@ -310,6 +310,13 @@ object StandardEngine {
       debugging(expr).invokeDebugger(finalState)
       ExprResult.Sorted(expr, finalState)
     }
+
+    // TODO: This requires an Arrow over the function type, which will probably require refactoring this trait
+    override def visitToHList[I, L <: HList : OP](
+      expr: Expr.ToHList[I, L, OP],
+    )(implicit
+      toHL: ConvertToHList[L],
+    ): PO <:< I => ExprResult[PO, I, L, OP] = ???
 
     override def visitUsingDefinitions[I, O : OP](
       expr: Expr.UsingDefinitions[I, O, OP],

--- a/core-v1/src/main/scala/math/Add.scala
+++ b/core-v1/src/main/scala/math/Add.scala
@@ -2,8 +2,9 @@ package com.rallyhealth.vapors.v1
 
 package math
 
-import java.time.{Duration, Instant, LocalDate, Period}
+import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period, ZonedDateTime}
 import scala.annotation.implicitNotFound
+import scala.concurrent.duration.FiniteDuration
 
 @implicitNotFound("""${L} + ${R} is not supported.
                      
@@ -60,4 +61,24 @@ private[math] trait AddJavaTimeImplicits {
   implicit val addDurationToInstant: Add.Aux[Instant, Duration, Instant] = Add.instance(_.plus(_))
 
   implicit val addPeriodToLocalDate: Add.Aux[LocalDate, Period, LocalDate] = Add.instance(_.plus(_))
+
+  implicit val addFiniteDurationToInstant: Add.Aux[Instant, FiniteDuration, Instant] = Add.instance {
+    (temporal, duration) =>
+      temporal.plusNanos(duration.toNanos)
+  }
+
+  implicit val addFiniteDurationToLocalDate: Add.Aux[LocalDate, FiniteDuration, LocalDate] = Add.instance {
+    (temporal, duration) =>
+      temporal.plusDays(duration.toDays)
+  }
+
+  implicit val addFiniteDurationToLocalDateTime: Add.Aux[LocalDateTime, FiniteDuration, LocalDateTime] = Add.instance {
+    (temporal, duration) =>
+      temporal.plusNanos(duration.toNanos)
+  }
+
+  implicit val addFiniteDurationToZonedDateTime: Add.Aux[ZonedDateTime, FiniteDuration, ZonedDateTime] = Add.instance {
+    (temporal, duration) =>
+      temporal.plusNanos(duration.toNanos)
+  }
 }

--- a/core-v1/src/main/scala/time/CountTime.scala
+++ b/core-v1/src/main/scala/time/CountTime.scala
@@ -1,0 +1,46 @@
+package com.rallyhealth.vapors.v1
+
+package time
+
+import java.time.temporal.{ChronoUnit, Temporal, TemporalUnit}
+
+trait CountTime[-T, -U, +O] {
+
+  /**
+    * Count the whole number of complete time units between the start and end.
+    *
+    * @param start the start of the time range (inclusive)
+    * @param end the end of the time range (inclusive)
+    * @param truncateToUnit the unit to round down to
+    * @return the whole number of units between the start up to, but not including, the end
+    */
+  def between(
+    start: T,
+    end: T,
+    truncateToUnit: U,
+  ): O
+}
+
+object CountTime {
+
+  def between[T, U, O](
+    start: T,
+    end: T,
+    roundDownToUnit: U,
+  )(implicit
+    diffTime: CountTime[T, U, O],
+  ): O = diffTime.between(start, end, roundDownToUnit)
+
+  private final class OfTemporal[-T <: Temporal] extends CountTime[T, TemporalUnit, Long] {
+    override def between(
+      start: T,
+      end: T,
+      unit: TemporalUnit,
+    ): Long = start.until(end, unit)
+  }
+
+  @inline private def temporal[T <: Temporal]: CountTime[T, ChronoUnit, Long] = new OfTemporal[T]
+
+  // TODO: Restrict invalid units by type
+  implicit val ofTemporal: CountTime[Temporal, ChronoUnit, Long] = temporal
+}

--- a/core-v1/src/main/scala/time/CountTime.scala
+++ b/core-v1/src/main/scala/time/CountTime.scala
@@ -2,7 +2,8 @@ package com.rallyhealth.vapors.v1
 
 package time
 
-import java.time.temporal.{ChronoUnit, Temporal, TemporalUnit}
+import java.time.temporal.Temporal
+import java.time._
 
 trait CountTime[-T, -U, +O] {
 
@@ -36,11 +37,18 @@ object CountTime {
       start: T,
       end: T,
       unit: TemporalUnit,
-    ): Long = start.until(end, unit)
+    ): Long = start.until(end, unit.chronoUnit)
   }
 
-  @inline private def temporal[T <: Temporal]: CountTime[T, ChronoUnit, Long] = new OfTemporal[T]
+  @inline private def temporal[T <: Temporal]: CountTime[T, TemporalUnit, Long] = new OfTemporal[T]
 
-  // TODO: Restrict invalid units by type
-  implicit val ofTemporal: CountTime[Temporal, ChronoUnit, Long] = temporal
+  implicit val countInstant: CountTime[Instant, TimeUnit, Long] = temporal
+  implicit val countLocalTime: CountTime[LocalTime, TimeUnit, Long] = temporal
+  implicit val countOffsetTime: CountTime[OffsetTime, TimeUnit, Long] = temporal
+
+  implicit val countLocalDate: CountTime[LocalDate, DateUnit, Long] = temporal
+
+  implicit val countLocalDateTime: CountTime[LocalDateTime, TemporalUnit, Long] = temporal
+  implicit val countOffsetDateTime: CountTime[OffsetDateTime, TemporalUnit, Long] = temporal
+  implicit val countZonedDateTime: CountTime[ZonedDateTime, TemporalUnit, Long] = temporal
 }

--- a/core-v1/src/main/scala/time/CountTime.scala
+++ b/core-v1/src/main/scala/time/CountTime.scala
@@ -4,7 +4,9 @@ package time
 
 import java.time.temporal.Temporal
 import java.time._
+import scala.annotation.implicitNotFound
 
+@implicitNotFound("Cannot count the number of ${U} between two instances of ${T}")
 trait CountTime[-T, -U, +O] {
 
   /**
@@ -51,4 +53,7 @@ object CountTime {
   implicit val countLocalDateTime: CountTime[LocalDateTime, TemporalUnit, Long] = temporal
   implicit val countOffsetDateTime: CountTime[OffsetDateTime, TemporalUnit, Long] = temporal
   implicit val countZonedDateTime: CountTime[ZonedDateTime, TemporalUnit, Long] = temporal
+
+  implicit val countYearMonth: CountTime[YearMonth, MonthUnit, Long] = temporal
+  implicit val countYear: CountTime[Year, YearUnit, Long] = temporal
 }

--- a/core-v1/src/main/scala/time/TemporalUnit.scala
+++ b/core-v1/src/main/scala/time/TemporalUnit.scala
@@ -19,6 +19,16 @@ sealed abstract class TimeUnit(u: ChronoUnit) extends TemporalUnit(u)
   */
 sealed abstract class DateUnit(u: ChronoUnit) extends TemporalUnit(u)
 
+/**
+  * Represents a unit that is a multiple of months.
+  */
+sealed abstract class MonthUnit(u: ChronoUnit) extends DateUnit(u)
+
+/**
+  * Represents a unit that is a multiple of years.
+  */
+sealed abstract class YearUnit(u: ChronoUnit) extends MonthUnit(u)
+
 object TemporalUnit {
 
   final case object Nanos extends TimeUnit(ChronoUnit.NANOS)
@@ -31,8 +41,9 @@ object TemporalUnit {
   final case object Days extends DateUnit(ChronoUnit.DAYS)
   final case object Weeks extends DateUnit(ChronoUnit.WEEKS)
   final case object Months extends DateUnit(ChronoUnit.MONTHS)
-  final case object Years extends DateUnit(ChronoUnit.YEARS)
-  final case object Decades extends DateUnit(ChronoUnit.DECADES)
-  final case object Centuries extends DateUnit(ChronoUnit.CENTURIES)
-  final case object Millennia extends DateUnit(ChronoUnit.MILLENNIA)
+
+  final case object Years extends YearUnit(ChronoUnit.YEARS)
+  final case object Decades extends YearUnit(ChronoUnit.DECADES)
+  final case object Centuries extends YearUnit(ChronoUnit.CENTURIES)
+  final case object Millennia extends YearUnit(ChronoUnit.MILLENNIA)
 }

--- a/core-v1/src/main/scala/time/TemporalUnit.scala
+++ b/core-v1/src/main/scala/time/TemporalUnit.scala
@@ -1,0 +1,38 @@
+package com.rallyhealth.vapors.v1
+
+package time
+
+import java.time.temporal.ChronoUnit
+
+/**
+  * A hierarchically-typed version of [[ChronoUnit]] that distinguishes between [[DateUnit]]s and [[TimeUnit]]s.
+  */
+sealed abstract class TemporalUnit(val chronoUnit: ChronoUnit)
+
+/**
+  * Represents a unit of time within a day.
+  */
+sealed abstract class TimeUnit(u: ChronoUnit) extends TemporalUnit(u)
+
+/**
+  * Represents a unit that is a multiple of days.
+  */
+sealed abstract class DateUnit(u: ChronoUnit) extends TemporalUnit(u)
+
+object TemporalUnit {
+
+  final case object Nanos extends TimeUnit(ChronoUnit.NANOS)
+  final case object Micros extends TimeUnit(ChronoUnit.MICROS)
+  final case object Millis extends TimeUnit(ChronoUnit.MILLIS)
+  final case object Seconds extends TimeUnit(ChronoUnit.SECONDS)
+  final case object Minutes extends TimeUnit(ChronoUnit.MINUTES)
+  final case object Hours extends TimeUnit(ChronoUnit.HOURS)
+
+  final case object Days extends DateUnit(ChronoUnit.DAYS)
+  final case object Weeks extends DateUnit(ChronoUnit.WEEKS)
+  final case object Months extends DateUnit(ChronoUnit.MONTHS)
+  final case object Years extends DateUnit(ChronoUnit.YEARS)
+  final case object Decades extends DateUnit(ChronoUnit.DECADES)
+  final case object Centuries extends DateUnit(ChronoUnit.CENTURIES)
+  final case object Millennia extends DateUnit(ChronoUnit.MILLENNIA)
+}

--- a/core-v1/src/test/scala/SimpleJustifiedTimeFunctionSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedTimeFunctionSpec.scala
@@ -2,16 +2,18 @@ package com.rallyhealth.vapors.v1
 
 import data.Justified
 import testutil.TestClock
+import time.TemporalUnit
 
 import cats.data.NonEmptySeq
-import munit.FunSuite
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop
 import org.scalatest.Inside.inside
 
-import java.time.{Instant, LocalDate}
+import java.time._
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 
-class SimpleJustifiedTimeFunctionSpec extends FunSuite {
+class SimpleJustifiedTimeFunctionSpec extends ScalaCheckSuite {
 
   import dsl.simple.justified._
 
@@ -67,5 +69,298 @@ class SimpleJustifiedTimeFunctionSpec extends FunSuite {
         ),
       ),
     )
+  }
+
+  property("date_diff of LocalDate in positive days") {
+    Prop.forAll { (date: LocalDate) =>
+      val date3DaysBefore = date.minusDays(3)
+      val expr = dateDiff(date3DaysBefore.const, date.const, TemporalUnit.Days.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        3L,
+        NonEmptySeq.of(
+          Justified.byConst(date3DaysBefore),
+          Justified.byConst(date),
+          Justified.byConst(TemporalUnit.Days),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of LocalDate in negative days") {
+    Prop.forAll { (date: LocalDate) =>
+      val date3DaysAgo = date.minusDays(3)
+      val expr = dateDiff(date.const, date3DaysAgo.const, TemporalUnit.Days.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        -3L,
+        NonEmptySeq.of(
+          Justified.byConst(date),
+          Justified.byConst(date3DaysAgo),
+          Justified.byConst(TemporalUnit.Days),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  test("dateDiff of LocalDate in hours fails to compile") {
+    val dateToday = LocalDate.now().const
+    val message = compileErrors("dateDiff(dateToday, dateToday, TemporalUnit.Hours.const)")
+    assert(
+      message contains "Cannot count the number of com.rallyhealth.vapors.v1.time.TemporalUnit.Hours.type between two instances of java.time.LocalDate",
+    )
+  }
+
+  property("dateDiff of LocalDate in positive millennia") {
+    Prop.forAll { (date: LocalDate) =>
+      val date1000YearsAgo = date.minusYears(1000)
+      val expr = dateDiff(date1000YearsAgo.const, date.const, TemporalUnit.Millennia.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        1L,
+        NonEmptySeq.of(
+          Justified.byConst(date1000YearsAgo),
+          Justified.byConst(date),
+          Justified.byConst(TemporalUnit.Millennia),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of LocalDate in negative millennia") {
+    Prop.forAll { (date: LocalDate) =>
+      val date1000YearsAgo = date.minusYears(1000)
+      val expr = dateDiff(date.const, date1000YearsAgo.const, TemporalUnit.Millennia.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        -1L,
+        NonEmptySeq.of(
+          Justified.byConst(date),
+          Justified.byConst(date1000YearsAgo),
+          Justified.byConst(TemporalUnit.Millennia),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of LocalTime in positive nanos") {
+    Prop.forAll { (time: LocalTime) =>
+      val time3NanosAgo = time.minusNanos(3)
+      val expr = dateDiff(time3NanosAgo.const, time.const, TemporalUnit.Nanos.const)
+      // LocalTime wraps around near the start of the day, so we have to change our expectation
+      val expected = Justified.byInference(
+        "date_diff",
+        3L,
+        NonEmptySeq.of(
+          Justified.byConst(time3NanosAgo),
+          Justified.byConst(time),
+          Justified.byConst(TemporalUnit.Nanos),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of LocalTime in negative nanos") {
+    Prop.forAll { (time: LocalTime) =>
+      val time3NanosAgo = time.minusNanos(3)
+      val expr = dateDiff(time.const, time3NanosAgo.const, TemporalUnit.Nanos.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        -3L,
+        NonEmptySeq.of(
+          Justified.byConst(time),
+          Justified.byConst(time3NanosAgo),
+          Justified.byConst(TemporalUnit.Nanos),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of LocalTime in positive hours") {
+    Prop.forAll { (time: LocalTime) =>
+      val time3HoursAgo = time.minusHours(3)
+      val expr = dateDiff(time3HoursAgo.const, time.const, TemporalUnit.Hours.const)
+      // LocalTime wraps around near the start of the day, so we have to change our expectation
+      val expectedValue = if (time3HoursAgo.isAfter(time)) 3 - 24 else 3L
+      val expected = Justified.byInference(
+        "date_diff",
+        expectedValue,
+        NonEmptySeq.of(
+          Justified.byConst(time3HoursAgo),
+          Justified.byConst(time),
+          Justified.byConst(TemporalUnit.Hours),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of LocalTime in negative hours") {
+    Prop.forAll { (time: LocalTime) =>
+      val time3HoursAgo = time.minusHours(3)
+      val expr = dateDiff(time.const, time3HoursAgo.const, TemporalUnit.Hours.const)
+      // LocalTime wraps around near the end of the day, so we have to change our expectation
+      val expectedValue = if (time3HoursAgo.isAfter(time)) -3 + 24 else -3L
+      val expected = Justified.byInference(
+        "date_diff",
+        expectedValue,
+        NonEmptySeq.of(
+          Justified.byConst(time),
+          Justified.byConst(time3HoursAgo),
+          Justified.byConst(TemporalUnit.Hours),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  test("dateDiff of LocalTime in days fails to compile") {
+    val dateToday = LocalTime.now().const
+    val message = compileErrors("dateDiff(dateToday, dateToday, TemporalUnit.Days.const)")
+    assert(
+      message contains "Cannot count the number of com.rallyhealth.vapors.v1.time.TemporalUnit.Days.type between two instances of java.time.LocalTime",
+    )
+  }
+
+  property("dateDiff of LocalDateTime in positive nanos") {
+    Prop.forAll { (dateTime: LocalDateTime) =>
+      val time3NanosAgo = dateTime.minusNanos(3)
+      val expr = dateDiff(time3NanosAgo.const, dateTime.const, TemporalUnit.Nanos.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        3L,
+        NonEmptySeq.of(
+          Justified.byConst(time3NanosAgo),
+          Justified.byConst(dateTime),
+          Justified.byConst(TemporalUnit.Nanos),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of LocalDateTime in negative nanos") {
+    Prop.forAll { (dateTime: LocalDateTime) =>
+      val time3NanosAgo = dateTime.minusNanos(3)
+      val expr = dateDiff(dateTime.const, time3NanosAgo.const, TemporalUnit.Nanos.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        -3L,
+        NonEmptySeq.of(
+          Justified.byConst(dateTime),
+          Justified.byConst(time3NanosAgo),
+          Justified.byConst(TemporalUnit.Nanos),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of LocalDateTime in positive millennia") {
+    Prop.forAll { (dateTime: LocalDateTime) =>
+      val date1000YearsAgo = dateTime.minusYears(1000)
+      val expr = dateDiff(date1000YearsAgo.const, dateTime.const, TemporalUnit.Millennia.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        1L,
+        NonEmptySeq.of(
+          Justified.byConst(date1000YearsAgo),
+          Justified.byConst(dateTime),
+          Justified.byConst(TemporalUnit.Millennia),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of LocalDateTime in negative millennia") {
+    Prop.forAll { (dateTime: LocalDateTime) =>
+      val date1000YearsAgo = dateTime.minusYears(1000)
+      val expr = dateDiff(dateTime.const, date1000YearsAgo.const, TemporalUnit.Millennia.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        -1L,
+        NonEmptySeq.of(
+          Justified.byConst(dateTime),
+          Justified.byConst(date1000YearsAgo),
+          Justified.byConst(TemporalUnit.Millennia),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of ZonedDateTime in positive nanos") {
+    Prop.forAll { (dateTime: ZonedDateTime) =>
+      val time3NanosAgo = dateTime.minusNanos(3)
+      val expr = dateDiff(time3NanosAgo.const, dateTime.const, TemporalUnit.Nanos.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        3L,
+        NonEmptySeq.of(
+          Justified.byConst(time3NanosAgo),
+          Justified.byConst(dateTime),
+          Justified.byConst(TemporalUnit.Nanos),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of ZonedDateTime in negative nanos") {
+    Prop.forAll { (dateTime: ZonedDateTime) =>
+      val time3NanosAgo = dateTime.minusNanos(3)
+      val expr = dateDiff(dateTime.const, time3NanosAgo.const, TemporalUnit.Nanos.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        -3L,
+        NonEmptySeq.of(
+          Justified.byConst(dateTime),
+          Justified.byConst(time3NanosAgo),
+          Justified.byConst(TemporalUnit.Nanos),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of ZonedDateTime in positive millennia") {
+    Prop.forAll { (dateTime: ZonedDateTime) =>
+      val date1000YearsAgo = dateTime.minusYears(1000)
+      val expr = dateDiff(date1000YearsAgo.const, dateTime.const, TemporalUnit.Millennia.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        1L,
+        NonEmptySeq.of(
+          Justified.byConst(date1000YearsAgo),
+          Justified.byConst(dateTime),
+          Justified.byConst(TemporalUnit.Millennia),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of ZonedDateTime in negative millennia") {
+    Prop.forAll { (dateTime: ZonedDateTime) =>
+      val date1000YearsAgo = dateTime.minusYears(1000)
+      val expr = dateDiff(dateTime.const, date1000YearsAgo.const, TemporalUnit.Millennia.const)
+      val expected = Justified.byInference(
+        "date_diff",
+        -1L,
+        NonEmptySeq.of(
+          Justified.byConst(dateTime),
+          Justified.byConst(date1000YearsAgo),
+          Justified.byConst(TemporalUnit.Millennia),
+        ),
+      )
+      assertEquals(expr.run(), expected)
+    }
   }
 }

--- a/core-v1/src/test/scala/SimpleJustifiedTimeFunctionSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedTimeFunctionSpec.scala
@@ -1,0 +1,71 @@
+package com.rallyhealth.vapors.v1
+
+import data.Justified
+import testutil.TestClock
+
+import cats.data.NonEmptySeq
+import munit.FunSuite
+import org.scalatest.Inside.inside
+
+import java.time.{Instant, LocalDate}
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration._
+
+class SimpleJustifiedTimeFunctionSpec extends FunSuite {
+
+  import dsl.simple.justified._
+
+  test("now + 15.seconds.const produces a new Instant every time evaluated") {
+    val clock = TestClock.oneSecondPerTickFromNow()
+    val nowPlus15Sec = Instant.now(clock).plusSeconds(15)
+    val expr = now(clock) + 15.seconds.const
+    val firstTime = expr.run().value
+    assert(firstTime.isAfter(nowPlus15Sec))
+    val secondTime = expr.run()
+    inside(secondTime) {
+      case Justified.ByInference(reason, value, justified) =>
+        assertNotEquals(value, firstTime)
+        assert(value.isAfter(firstTime))
+        assertEquals(reason, "add")
+        assertEquals(
+          justified,
+          NonEmptySeq.of(
+            Justified.ByConst(value.minusNanos(15.seconds.toNanos)),
+            Justified.ByConst(15.seconds),
+          ),
+        )
+    }
+  }
+
+  test("today + 1.day.const produces a new LocalDate every time evaluated") {
+    val clock = TestClock.oneUnitPerTickFromNow(TimeUnit.DAYS)
+    // Add one to the day, because the next tick for "today" will be one day from today
+    val dateToday = LocalDate.now(clock).plusDays(1)
+    val dateTomorrow = dateToday.plusDays(1)
+    val expr = today(clock) + 1.day.const
+    val firstTime = expr.run()
+    assertEquals(
+      firstTime,
+      Justified.byInference(
+        "add",
+        dateTomorrow,
+        NonEmptySeq.of(
+          Justified.ByConst(dateToday),
+          Justified.ByConst(1.day),
+        ),
+      ),
+    )
+    val secondTime = expr.run()
+    assertEquals(
+      secondTime,
+      Justified.byInference(
+        "add",
+        dateTomorrow.plusDays(1),
+        NonEmptySeq.of(
+          Justified.ByConst(dateTomorrow),
+          Justified.ByConst(1.day),
+        ),
+      ),
+    )
+  }
+}

--- a/core-v1/src/test/scala/SimpleTimeFunctionSpec.scala
+++ b/core-v1/src/test/scala/SimpleTimeFunctionSpec.scala
@@ -1,14 +1,16 @@
 package com.rallyhealth.vapors.v1
 
 import testutil.TestClock
+import time.TemporalUnit
 
-import munit.FunSuite
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop
 
-import java.time.{Instant, LocalDate}
+import java.time._
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 
-class SimpleTimeFunctionSpec extends FunSuite {
+class SimpleTimeFunctionSpec extends ScalaCheckSuite {
 
   import dsl.simple._
 
@@ -33,5 +35,153 @@ class SimpleTimeFunctionSpec extends FunSuite {
     assertEquals(firstExpr, dateTomorrow)
     val secondTime = expr.run()
     assertEquals(secondTime, dateTomorrow.plusDays(1))
+  }
+
+  property("dateDiff of LocalDate in positive days") {
+    Prop.forAll { (date: LocalDate) =>
+      val date3DaysBefore = date.minusDays(3)
+      val expr = dateDiff(date3DaysBefore.const, date.const, TemporalUnit.Days.const)
+      assertEquals(expr.run(), 3L)
+    }
+  }
+
+  property("dateDiff of LocalDate in negative days") {
+    Prop.forAll { (date: LocalDate) =>
+      val date3DaysAgo = date.minusDays(3)
+      val expr = dateDiff(date.const, date3DaysAgo.const, TemporalUnit.Days.const)
+      assertEquals(expr.run(), -3L)
+    }
+  }
+
+  test("dateDiff of LocalDate in hours fails to compile") {
+    val dateToday = LocalDate.now().const
+    val message = compileErrors("dateDiff(dateToday, dateToday, TemporalUnit.Hours.const)")
+    assert(
+      message contains "Cannot count the number of com.rallyhealth.vapors.v1.time.TemporalUnit.Hours.type between two instances of java.time.LocalDate",
+    )
+  }
+
+  property("dateDiff of LocalDate in positive millennia") {
+    Prop.forAll { (date: LocalDate) =>
+      val date1000YearsAgo = date.minusYears(1000)
+      val expr = dateDiff(date1000YearsAgo.const, date.const, TemporalUnit.Millennia.const)
+      assertEquals(expr.run(), 1L)
+    }
+  }
+
+  property("dateDiff of LocalDate in negative millennia") {
+    Prop.forAll { (date: LocalDate) =>
+      val date1000YearsAgo = date.minusYears(1000)
+      val expr = dateDiff(date.const, date1000YearsAgo.const, TemporalUnit.Millennia.const)
+      assertEquals(expr.run(), -1L)
+    }
+  }
+
+  property("dateDiff of LocalTime in positive nanos") {
+    Prop.forAll { (time: LocalTime) =>
+      val time3NanosAgo = time.minusNanos(3)
+      val expr = dateDiff(time3NanosAgo.const, time.const, TemporalUnit.Nanos.const)
+      assertEquals(expr.run(), 3L)
+    }
+  }
+
+  property("dateDiff of LocalTime in negative nanos") {
+    Prop.forAll { (time: LocalTime) =>
+      val time3NanosAgo = time.minusNanos(3)
+      val expr = dateDiff(time.const, time3NanosAgo.const, TemporalUnit.Nanos.const)
+      assertEquals(expr.run(), -3L)
+    }
+  }
+
+  property("dateDiff of LocalTime in positive hours") {
+    Prop.forAll { (time: LocalTime) =>
+      val time3HoursAgo = time.minusHours(3)
+      val expr = dateDiff(time3HoursAgo.const, time.const, TemporalUnit.Hours.const)
+      // LocalTime wraps around near the start of the day, so we have to change our expectation
+      val expected = if (time3HoursAgo.isAfter(time)) 3 - 24 else 3L
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  property("dateDiff of LocalTime in negative hours") {
+    Prop.forAll { (time: LocalTime) =>
+      val time3HoursAgo = time.minusHours(3)
+      val expr = dateDiff(time.const, time3HoursAgo.const, TemporalUnit.Hours.const)
+      // LocalTime wraps around near the end of the day, so we have to change our expectation
+      val expected = if (time3HoursAgo.isAfter(time)) -3 + 24 else -3L
+      assertEquals(expr.run(), expected)
+    }
+  }
+
+  test("dateDiff of LocalTime in days fails to compile") {
+    val dateToday = LocalTime.now().const
+    val message = compileErrors("dateDiff(dateToday, dateToday, TemporalUnit.Days.const)")
+    assert(
+      message contains "Cannot count the number of com.rallyhealth.vapors.v1.time.TemporalUnit.Days.type between two instances of java.time.LocalTime",
+    )
+  }
+
+  property("dateDiff of LocalDateTime in positive nanos") {
+    Prop.forAll { (dateTime: LocalDateTime) =>
+      val time3NanosAgo = dateTime.minusNanos(3)
+      val expr = dateDiff(time3NanosAgo.const, dateTime.const, TemporalUnit.Nanos.const)
+      assertEquals(expr.run(), 3L)
+    }
+  }
+
+  property("dateDiff of LocalDateTime in negative nanos") {
+    Prop.forAll { (dateTime: LocalDateTime) =>
+      val time3NanosAgo = dateTime.minusNanos(3)
+      val expr = dateDiff(dateTime.const, time3NanosAgo.const, TemporalUnit.Nanos.const)
+      assertEquals(expr.run(), -3L)
+    }
+  }
+
+  property("dateDiff of LocalDateTime in positive millennia") {
+    Prop.forAll { (dateTime: LocalDateTime) =>
+      val date1000YearsAgo = dateTime.minusYears(1000)
+      val expr = dateDiff(date1000YearsAgo.const, dateTime.const, TemporalUnit.Millennia.const)
+      assertEquals(expr.run(), 1L)
+    }
+  }
+
+  property("dateDiff of LocalDateTime in negative millennia") {
+    Prop.forAll { (dateTime: LocalDateTime) =>
+      val date1000YearsAgo = dateTime.minusYears(1000)
+      val expr = dateDiff(dateTime.const, date1000YearsAgo.const, TemporalUnit.Millennia.const)
+      assertEquals(expr.run(), -1L)
+    }
+  }
+
+  property("dateDiff of ZonedDateTime in positive nanos") {
+    Prop.forAll { (dateTime: ZonedDateTime) =>
+      val time3NanosAgo = dateTime.minusNanos(3)
+      val expr = dateDiff(time3NanosAgo.const, dateTime.const, TemporalUnit.Nanos.const)
+      assertEquals(expr.run(), 3L)
+    }
+  }
+
+  property("dateDiff of ZonedDateTime in negative nanos") {
+    Prop.forAll { (dateTime: ZonedDateTime) =>
+      val time3NanosAgo = dateTime.minusNanos(3)
+      val expr = dateDiff(dateTime.const, time3NanosAgo.const, TemporalUnit.Nanos.const)
+      assertEquals(expr.run(), -3L)
+    }
+  }
+
+  property("dateDiff of ZonedDateTime in positive millennia") {
+    Prop.forAll { (dateTime: ZonedDateTime) =>
+      val date1000YearsAgo = dateTime.minusYears(1000)
+      val expr = dateDiff(date1000YearsAgo.const, dateTime.const, TemporalUnit.Millennia.const)
+      assertEquals(expr.run(), 1L)
+    }
+  }
+
+  property("dateDiff of ZonedDateTime in negative millennia") {
+    Prop.forAll { (dateTime: ZonedDateTime) =>
+      val date1000YearsAgo = dateTime.minusYears(1000)
+      val expr = dateDiff(dateTime.const, date1000YearsAgo.const, TemporalUnit.Millennia.const)
+      assertEquals(expr.run(), -1L)
+    }
   }
 }

--- a/core-v1/src/test/scala/SimpleTimeFunctionSpec.scala
+++ b/core-v1/src/test/scala/SimpleTimeFunctionSpec.scala
@@ -1,0 +1,37 @@
+package com.rallyhealth.vapors.v1
+
+import testutil.TestClock
+
+import munit.FunSuite
+
+import java.time.{Instant, LocalDate}
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration._
+
+class SimpleTimeFunctionSpec extends FunSuite {
+
+  import dsl.simple._
+
+  test("now + 15.seconds.const produces a new Instant every time evaluated") {
+    val clock = TestClock.oneSecondPerTickFromNow()
+    val nowPlus15Sec = Instant.now(clock).plusSeconds(15)
+    val expr = now(clock) + 15.seconds.const
+    val firstTime = expr.run()
+    assert(firstTime.isAfter(nowPlus15Sec))
+    val secondTime = expr.run()
+    assert(secondTime != firstTime)
+    assert(secondTime.isAfter(firstTime))
+  }
+
+  test("today + 1.day.const produces a new LocalDate every time evaluated") {
+    val clock = TestClock.oneUnitPerTickFromNow(TimeUnit.DAYS)
+    // Add one to the day, because the next tick for "today" will be one day from today
+    val dateToday = LocalDate.now(clock).plusDays(1)
+    val dateTomorrow = dateToday.plusDays(1)
+    val expr = today(clock) + 1.day.const
+    val firstExpr = expr.run()
+    assertEquals(firstExpr, dateTomorrow)
+    val secondTime = expr.run()
+    assertEquals(secondTime, dateTomorrow.plusDays(1))
+  }
+}

--- a/core-v1/src/test/scala/testutil/PositionUtils.scala
+++ b/core-v1/src/test/scala/testutil/PositionUtils.scala
@@ -1,0 +1,10 @@
+package com.rallyhealth.vapors.v1
+
+package testutil
+
+import org.scalactic.source.Position
+
+object PositionUtils {
+
+  def stringify(location: Position): String = s"${location.fileName}:${location.lineNumber}"
+}

--- a/core-v1/src/test/scala/testutil/TestClock.scala
+++ b/core-v1/src/test/scala/testutil/TestClock.scala
@@ -1,0 +1,272 @@
+package com.rallyhealth.vapors.v1
+
+package testutil
+
+import org.scalactic.source.Position
+
+import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant, ZoneId, ZoneOffset}
+import java.util.concurrent.TimeUnit
+import scala.annotation.switch
+import scala.collection.immutable.NumericRange
+import scala.concurrent.duration._
+
+/**
+  * A [[Clock]] that ticks along a pre-defined path.
+  *
+  * Every call to [[instant()]] iterates through the list of pre-defined moments and adds the [[Instant]]
+  * returned to the [[returned]] sequence. It is possible that a limited number moments have been defined,
+  * in which case, getting the next moment can throw a [[NoSuchElementException]].
+  *
+  * @note You can [[readOption()]] the next moment, but keep in mind that this will compute the moment
+  *       and fix the result to be the next moment that is returned.
+  *
+  * @param moments the finite or infinite list of moments to return
+  * @param zone the [[ZoneId]] used by any operations that use the clock for its time zone information
+  * @param definedAt where this instance of the [[TestClock]] was defined for debugging purposes
+  */
+final class TestClock private (
+  val moments: LazyList[Instant],
+  private var zone: ZoneId,
+  definedAt: Position,
+) extends Clock {
+
+  @volatile private var returnedMoments: Vector[(StackTraceElement, Instant)] = Vector()
+
+  /**
+    * The list of moments returned by [[instant()]] so far and where they was called from.
+    */
+  def returnedWithTrace: IndexedSeq[(StackTraceElement, Instant)] = returnedMoments
+
+  /**
+    * The list of moments returned by [[instant()]] so far.
+    */
+  def returned: IndexedSeq[Instant] = returnedMoments.map(_._2)
+
+  @volatile private var remainingMoments: LazyList[Instant] = moments
+
+  /**
+    * The lazy list of remaining moments to be returned when calling [[instant()]].
+    */
+  def remaining: LazyList[Instant] = remainingMoments
+
+  /**
+    * Returns a string containing all instants returned by this clock in the order in which it
+    * was invoked including the source code location where it was invoked, separated by newlines.
+    *
+    * @param fmtInstant a format function for serializing the instant (defaults to {number}ms)
+    */
+  def formatAllInvocations(
+    indent: Int = 0,
+    fmtInstant: Instant => String = m => s"${m.toEpochMilli}ms",
+  ): String = {
+    val sb = new StringBuilder
+    for ((trace, instant) <- returnedMoments)
+      sb.append(s"${" " * indent}${fmtInstant(instant)} : $trace\n")
+    sb.result()
+  }
+
+  override def getZone: ZoneId = zone
+
+  override def withZone(zone: ZoneId): Clock = {
+    this.zone = zone
+    this
+  }
+
+  /**
+    * Lazily compute the next moment to return, add it to the [[returned]] sequence, set the [[remaining]] list to
+    * the tail of the moments list, and then return the computed moment.
+    *
+    * @throws NoSuchElementException if the moments list is finite and all of them have been returned
+    * @return the next computed moment
+    */
+  @throws[NoSuchElementException]("The TestClock has a finite list of moments and all of them have been returned.")
+  override def instant(): Instant = this.synchronized {
+    val head = readOrThrow()
+    val trace = new IllegalArgumentException().getStackTrace
+    remainingMoments = remainingMoments.tail
+    returnedMoments :+= (trace(1), head)
+    head
+  }
+
+  /**
+    * Compute the next moment to be returned, but don't iterate through it.
+    *
+    * @return the next moment to be returned when calling the [[instant()]] method.
+    */
+  @throws[NoSuchElementException]("The TestClock has a finite list of moments and all of them have been returned.")
+  def readOrThrow(): Instant = remainingMoments.headOption.getOrElse {
+    throw new NoSuchElementException(
+      s"TestClock (from ${PositionUtils.stringify(definedAt)}) only defined with ${remainingMoments.size} moments.",
+    )
+  }
+
+  /**
+    * Compute the next moment to be returned, but don't iterate through it.
+    *
+    * @return the next moment to be returned when calling the [[instant()]] method or None if at the end of the list.
+    */
+  def readOption(): Option[Instant] = remainingMoments.headOption
+
+  override def toString: String = {
+    s"TestClock (defined at ${PositionUtils.stringify(definedAt)}) {\n  invocations = [\n${formatAllInvocations(4)}  ]\n}"
+  }
+}
+
+object TestClock {
+
+  /**
+    * A [[TestClock]] that computes the next moment with [[Instant.now()]].
+    *
+    * This is the same behavior as the default [[Clock]], except that the result of all [[TestClock.instant()]]
+    * calls are stored in the [[TestClock.returned]] sequence for future validation.
+    */
+  def systemUTC()(implicit pos: Position): TestClock = TestClock.continually(Instant.now())
+
+  @inline def apply(
+    moments: LazyList[Instant],
+    zone: ZoneId,
+  )(implicit
+    pos: Position,
+  ): TestClock = {
+    new TestClock(moments, zone, pos)
+  }
+
+  @inline def apply(moments: LazyList[Instant])(implicit pos: Position): TestClock = {
+    new TestClock(moments, ZoneOffset.UTC, pos)
+  }
+
+  /**
+    * A [[TestClock]] that lazily computes the next [[Instant]] to be returned.
+    */
+  def continually(compute: => Instant)(implicit pos: Position): TestClock = {
+    TestClock(LazyList.continually(compute))
+  }
+
+  /**
+    * A [[TestClock]] that always returns the given [[Instant]].
+    */
+  def fixed(moment: Instant)(implicit pos: Position): TestClock = {
+    TestClock(LazyList.continually(moment))
+  }
+
+  /**
+    * A [[TestClock]] that returns the given [[Instant]]s in the order given.
+    *
+    * After all moments have been exhausted, this clock will throw an exception.
+    */
+  def stub(moments: Instant*)(implicit pos: Position): TestClock = {
+    TestClock(LazyList.from(moments))
+  }
+
+  /**
+    * A [[TestClock]] that returns the given moments (as millis from the Epoch) in the order given.
+    *
+    * After all moments have been exhausted, this clock will throw an exception.
+    */
+  def stubMillis(moments: Long*)(implicit pos: Position): TestClock = {
+    TestClock(LazyList.from(moments).map(Instant.ofEpochMilli))
+  }
+
+  /**
+    * A [[TestClock]] that returns the given moments (as seconds from the Epoch) in the order given.
+    *
+    * After all moments have been exhausted, this clock will throw an exception.
+    */
+  def stubSeconds(moments: Long*)(implicit pos: Position): TestClock = {
+    TestClock(LazyList.from(moments).map(Instant.ofEpochSecond))
+  }
+
+  @deprecated("Replaced by stubRangeMillis", "v8.2.0")
+  def stubRange(range: NumericRange[Long])(implicit pos: Position): TestClock = {
+    TestClock(LazyList.from(range).map(Instant.ofEpochMilli))
+  }
+
+  /**
+    * A [[TestClock]] that returns a range of moments (as seconds from the Epoch) in increasing order.
+    *
+    * After all moments have been exhausted, this clock will throw an exception.
+    */
+  def stubRangeSeconds(range: NumericRange[Long])(implicit pos: Position): TestClock = {
+    TestClock(LazyList.from(range).map(Instant.ofEpochSecond))
+  }
+
+  /**
+    * A [[TestClock]] that returns a range of moments (as milliseconds from the Epoch) in increasing order.
+    *
+    * After all moments have been exhausted, this clock will throw an exception.
+    */
+  def stubRangeMillis(range: NumericRange[Long])(implicit pos: Position): TestClock = {
+    TestClock(LazyList.from(range).map(Instant.ofEpochMilli))
+  }
+
+  private def addNanosPerTickFrom(
+    start: Instant,
+    tickAmountNanos: Long,
+  )(implicit
+    pos: Position,
+  ): TestClock = {
+    var next: Instant = start
+    TestClock(LazyList.continually {
+      val current = next
+      next = next.plusNanos(tickAmountNanos)
+      current
+    })
+  }
+
+  /**
+    * A [[TestClock]] that steps forward the given [[Duration]] per call to [[TestClock.instant()]]
+    * relative to the given [[Instant]].
+    */
+  @inline def addDurationPerTickFrom(
+    start: Instant,
+    tickAmount: Duration,
+  )(implicit
+    pos: Position,
+  ): TestClock = {
+    addNanosPerTickFrom(start, tickAmount.toNanos)
+  }
+
+  /**
+    * A [[TestClock]] that steps forward the given [[Duration]] per call to [[TestClock.instant()]]
+    * relative to [[Instant.now()]] (called when this is constructed).
+    */
+  @inline def addDurationPerTickFromNow(tickAmount: Duration)(implicit pos: Position): TestClock = {
+    addNanosPerTickFrom(Instant.now(), tickAmount.toNanos)
+  }
+
+  /**
+    * A [[TestClock]] that steps forward 1 [[TimeUnit]] per call to [[TestClock.instant()]]
+    * relative to the start of the current [[TimeUnit]] when this is constructed.
+    */
+  def oneUnitPerTickFromNow(tickUnit: TimeUnit)(implicit pos: Position): TestClock = {
+    val chronoUnit = (tickUnit.ordinal(): @switch) match {
+      case 0 => ChronoUnit.NANOS
+      case 1 => ChronoUnit.MICROS
+      case 2 => ChronoUnit.MILLIS
+      case 3 => ChronoUnit.SECONDS
+      case 4 => ChronoUnit.MINUTES
+      case 5 => ChronoUnit.HOURS
+      case 6 => ChronoUnit.DAYS
+      case _ => throw new MatchError(s"Unrecognized TimeUnit: ${tickUnit}")
+    }
+    val start = Instant.now().truncatedTo(chronoUnit)
+    addNanosPerTickFrom(start, chronoUnit.getDuration.toNanos)
+  }
+
+  /**
+    * A [[TestClock]] that steps forward 1 millisecond per call to [[TestClock.instant()]]
+    * relative to the start of the current millisecond when this is constructed.
+    */
+  @inline def oneMilliPerTickFromNow()(implicit pos: Position): TestClock = {
+    oneUnitPerTickFromNow(MILLISECONDS)
+  }
+
+  /**
+    * A [[TestClock]] that steps forward 1 second per call to [[TestClock.instant()]]
+    * relative to the start of the current second when this is constructed.
+    */
+  @inline def oneSecondPerTickFromNow()(implicit pos: Position): TestClock = {
+    oneUnitPerTickFromNow(SECONDS)
+  }
+}

--- a/core/src/main/scala/vapors/data/TimeOrder.scala
+++ b/core/src/main/scala/vapors/data/TimeOrder.scala
@@ -2,45 +2,14 @@ package com.rallyhealth
 
 package vapors.data
 
-import cats.syntax.contravariant._
-import cats.Order
-
-import java.time._
-import java.time.chrono.{ChronoLocalDate, ChronoLocalDateTime, ChronoZonedDateTime}
-
-abstract class TimeOrder {
-
-  def modify[T](order: Order[T]): Order[T]
-
-  implicit val latestLocalDateFirst: Order[LocalDate] =
-    Order.reverse(Order.fromComparable[ChronoLocalDate].contramap(identity[ChronoLocalDate]))
-
-  implicit val latestLocalDateTimeFirst: Order[LocalDateTime] =
-    Order.reverse(
-      Order
-        .fromComparable[ChronoLocalDateTime[_ <: ChronoLocalDate]]
-        .contramap(identity[ChronoLocalDateTime[_ <: ChronoLocalDate]]),
-    )
-
-  implicit val latestLocalTimeFirst: Order[LocalTime] = Order.reverse(Order.fromComparable)
-
-  implicit val latestInstantFirst: Order[Instant] = Order.reverse(Order.fromComparable)
-
-  implicit val latestZonedDateTimeFirst: Order[ZonedDateTime] =
-    Order.reverse(
-      Order
-        .fromComparable[ChronoZonedDateTime[_ <: ChronoLocalDate]]
-        .contramap(identity[ChronoZonedDateTime[_ <: ChronoLocalDate]]),
-    )
-}
-
 object TimeOrder {
 
-  final object LatestFirst extends TimeOrder {
-    override def modify[T](order: Order[T]): Order[T] = Order.reverse(order)
-  }
+  @deprecated("This is confusingly named, please use com.rallyhealth.vapors.v1.data.YoungestFirst instead", "1.0.0")
+  final val LatestFirst = vapors.v1.data.TimeOrder.YoungestFirst
 
-  final object EarliestFirst extends TimeOrder {
-    override def modify[T](order: Order[T]): Order[T] = order
-  }
+  @deprecated(
+    "This was implemented incorrectly, please use com.rallyhealth.vapors.v1.data.OldestFirst for the correct behavior",
+    "1.0.0",
+  )
+  final val EarliestFirst = vapors.v1.data.TimeOrder.YoungestFirst
 }

--- a/core/src/main/scala/vapors/data/package.scala
+++ b/core/src/main/scala/vapors/data/package.scala
@@ -26,4 +26,7 @@ package object data {
     * @note not to be confused with a [[FactTypeSet]] (which is a set of [[FactType]]s, with not values)
     */
   final type TypedFactSet[T] = Set[TypedFact[T]]
+
+  @deprecated("Use com.rallyhealth.vapors.v1.data.TimeOrder instead.", "1.0.0")
+  type TimeOrder = vapors.v1.data.TimeOrder
 }


### PR DESCRIPTION
- Add `Expr.ToHList` and DSL methods to support wrapping an `ExprHList` with an `Expr` node
- Move `TimeOrder` class down to core-v1 project and fix bugs
- Add `TestClock` and `PositionUtils` to support testing time-related functions with fixed intervals
- Add TimeFunctions and support for `dateDiff`, `now`, `today`
  - Support for duration addition
  - Support for time subtraction with `dateDiff`
  - Support `now` / `today`
  - Use `TestClock` to avoid flakiness in TimeFunctionSpecs