### PR TITLE
Add .asCase to VariantLens

### DIFF
--- a/core-v1/src/main/scala/lens/VariantLens.scala
+++ b/core-v1/src/main/scala/lens/VariantLens.scala
@@ -9,7 +9,7 @@ import cats.data.NonEmptySet
 import cats.kernel.Semigroup
 import cats.{Eval, Foldable, Reducible}
 import shapeless.ops.hlist
-import shapeless.{Generic, HList}
+import shapeless.{Generic, HList, Typeable}
 
 import scala.annotation.nowarn
 import scala.collection.{Factory, View}
@@ -146,6 +146,15 @@ object VariantLens extends VariantLensLowPriorityImplicits {
         path = lens.path,
         get = lens.get.andThen(tupler.apply),
       )
+  }
+
+  implicit final class AsSumTypeBuilder[A, B](private val lens: VariantLens[A, B]) extends AnyVal {
+
+    /**
+      * Attempt to cast the value of super-type [[B]] as sub-type [[V]] (if possible), otherwise None.
+      */
+    def asCase[V <: B : Typeable]: VariantLens[A, Option[V]] =
+      lens.copy(get = lens.get.andThen(Typeable[V].cast))
   }
 }
 

--- a/core-v1/src/test/scala/lens/VariantLensSpec.scala
+++ b/core-v1/src/test/scala/lens/VariantLensSpec.scala
@@ -26,4 +26,36 @@ class VariantLensSpec extends FunSuite {
   test("VariantLens.asFoldable[NonEmptyVector].to[Vector]") {
     val expected: VariantLens[NonEmptyVector[Int], Vector[Int]] = VariantLens.id[NonEmptyVector[Int]].to[Vector]
   }
+
+  test("VariantLens[Person].asCase[Employee] returns Some[Employee] for an Employee") {
+    val lens = VariantLens.id[Person].asCase[Employee]
+    val expected = new Employee
+    assertEquals(lens.get(expected), Some(expected))
+  }
+
+  test("VariantLens[Person].asCase[Employee] returns None for a Spouse") {
+    val lens = VariantLens.id[Person].asCase[Employee]
+    val expected = new Spouse
+    assertEquals(lens.get(expected), None)
+  }
+
+  test("VariantLens[Person].asCase[Employee] doesn't compile") {
+    compileErrors("VariantLens.id[Person].asCase[Employee]")
+  }
+
+  test("VariantLens[Seq[Person]].asCase[List[Employee]] returns Some[List[Employee]] for a List[Employee]") {
+    val lens = VariantLens.id[Seq[Person]].asCase[List[Employee]]
+    val expected = List(new Employee, new Employee)
+    assertEquals(lens.get(expected), Some(expected))
+  }
+
+  test("VariantLens[Seq[Person]].asCase[List[Employee]] returns None for a List[Person]") {
+    val lens = VariantLens.id[Seq[Person]].asCase[List[Employee]]
+    val expected = List(new Employee, new Spouse)
+    assertEquals(lens.get(expected), None)
+  }
 }
+
+class Person
+class Employee extends Person
+class Spouse extends Person


### PR DESCRIPTION
- Add `.asCase` to `VariantLens` using `shapeless.Typeable`