### PR TITLE
Add repeat operation and support use case of threading it into zipToShortest

### DIFF
--- a/core-v1/src/main/scala/algebra/Expr.scala
+++ b/core-v1/src/main/scala/algebra/Expr.scala
@@ -1044,8 +1044,17 @@ object Expr {
       copy(debugging = debugging)
   }
 
+  /**
+    * Creates an [[IterableOnce]] that emits the result of the input expression forever, or up to a given limit.
+    *
+    * @param inputExpr the input expression to repeat
+    * @param recompute whether to recompute the expression on every iteration or just use the first result
+    * @param limit whether to limit the total number of elements produced by the iterable
+    */
   final case class Repeat[-I, +O, OP[_]](
     inputExpr: Expr[I, O, OP],
+    recompute: Boolean,
+    limit: Option[Int],
     override private[v1] val debugging: Debugging[Nothing, Nothing] = NoDebugging,
   )(implicit
     opO: OP[IterableOnce[O]],

--- a/core-v1/src/main/scala/debug/DebugArgs.scala
+++ b/core-v1/src/main/scala/debug/DebugArgs.scala
@@ -6,6 +6,7 @@ import algebra.{Expr, SizeComparison}
 import data._
 import lens.VariantLens
 
+import cats.Eval
 import cats.data.{NonEmptySeq, NonEmptyVector}
 import izumi.reflect.Tag
 import shapeless.HList
@@ -256,9 +257,9 @@ object DebugArgs {
       override type Out = C[B]
     }
 
-  implicit def debugRepeat[I, O, OP[_]]: Aux[Expr.Repeat[I, O, OP], OP, I, IterableOnce[O]] =
+  implicit def debugRepeat[I, O, OP[_]]: Aux[Expr.Repeat[I, O, OP], OP, (I, Eval[O], Option[Int]), IterableOnce[O]] =
     new DebugArgs[Expr.Repeat[I, O, OP], OP] {
-      override type In = I
+      override type In = (I, Eval[O], Option[Int])
       override type Out = IterableOnce[O]
     }
 

--- a/core-v1/src/main/scala/debug/DebugArgs.scala
+++ b/core-v1/src/main/scala/debug/DebugArgs.scala
@@ -256,6 +256,12 @@ object DebugArgs {
       override type Out = C[B]
     }
 
+  implicit def debugRepeat[I, O, OP[_]]: Aux[Expr.Repeat[I, O, OP], OP, I, IterableOnce[O]] =
+    new DebugArgs[Expr.Repeat[I, O, OP], OP] {
+      override type In = I
+      override type Out = IterableOnce[O]
+    }
+
   implicit def debugSelect[I, A, B, O, OP[_]]: Aux[Expr.Select[I, A, B, O, OP], OP, (I, A, VariantLens[A, B], B), O] =
     new DebugArgs[Expr.Select[I, A, B, O, OP], OP] {
       override type In = (I, A, VariantLens[A, B], B)

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -235,7 +235,8 @@ You should prefer put your declaration of dependency on definitions close to whe
     constType: ConstOutputType[W, A],
   ): ConstExprBuilder[constType.Out, OP]
 
-  final def repeat[I, O](expr: I ~:> O)(implicit opO: OP[IterableOnce[O]]): I ~:> IterableOnce[O] = Expr.Repeat(expr)
+  final def repeat[I, O](expr: I ~:> O)(implicit opO: OP[IterableOnce[O]]): I ~:> IterableOnce[O] =
+    Expr.Repeat(expr, recompute = false, limit = None)
 
   // TODO: Is this redundant syntax worth keeping around?
   implicit def inSet[I, A](inputExpr: I ~:> W[A]): InSetExprBuilder[I, A]

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -235,8 +235,35 @@ You should prefer put your declaration of dependency on definitions close to whe
     constType: ConstOutputType[W, A],
   ): ConstExprBuilder[constType.Out, OP]
 
-  final def repeat[I, O](expr: I ~:> O)(implicit opO: OP[IterableOnce[O]]): I ~:> IterableOnce[O] =
+  final def repeatConstForever[I, O](
+    expr: I ~:> O,
+  )(implicit
+    opO: OP[IterableOnce[O]],
+  ): I ~:> IterableOnce[O] =
     Expr.Repeat(expr, recompute = false, limit = None)
+
+  final def repeatConst[I, O](
+    n: Int,
+    expr: I ~:> O,
+  )(implicit
+    opO: OP[IterableOnce[O]],
+  ): I ~:> IterableOnce[O] =
+    Expr.Repeat(expr, recompute = false, limit = Some(n))
+
+  final def repeatForever[I, O](
+    expr: I ~:> O,
+  )(implicit
+    opO: OP[IterableOnce[O]],
+  ): I ~:> IterableOnce[O] =
+    Expr.Repeat(expr, recompute = true, limit = None)
+
+  final def repeat[I, O](
+    n: Int,
+    expr: I ~:> O,
+  )(implicit
+    opO: OP[IterableOnce[O]],
+  ): I ~:> IterableOnce[O] =
+    Expr.Repeat(expr, recompute = true, limit = Some(n))
 
   // TODO: Is this redundant syntax worth keeping around?
   implicit def inSet[I, A](inputExpr: I ~:> W[A]): InSetExprBuilder[I, A]

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -239,7 +239,7 @@ You should prefer put your declaration of dependency on definitions close to whe
     expr: I ~:> O,
   )(implicit
     opO: OP[IterableOnce[O]],
-  ): I ~:> IterableOnce[O] =
+  ): Expr.Repeat[I, O, OP] =
     Expr.Repeat(expr, recompute = false, limit = None)
 
   final def repeatConst[I, O](
@@ -247,14 +247,14 @@ You should prefer put your declaration of dependency on definitions close to whe
     expr: I ~:> O,
   )(implicit
     opO: OP[IterableOnce[O]],
-  ): I ~:> IterableOnce[O] =
+  ): Expr.Repeat[I, O, OP] =
     Expr.Repeat(expr, recompute = false, limit = Some(n))
 
   final def repeatForever[I, O](
     expr: I ~:> O,
   )(implicit
     opO: OP[IterableOnce[O]],
-  ): I ~:> IterableOnce[O] =
+  ): Expr.Repeat[I, O, OP] =
     Expr.Repeat(expr, recompute = true, limit = None)
 
   final def repeat[I, O](
@@ -262,7 +262,7 @@ You should prefer put your declaration of dependency on definitions close to whe
     expr: I ~:> O,
   )(implicit
     opO: OP[IterableOnce[O]],
-  ): I ~:> IterableOnce[O] =
+  ): Expr.Repeat[I, O, OP] =
     Expr.Repeat(expr, recompute = true, limit = Some(n))
 
   // TODO: Is this redundant syntax worth keeping around?

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -235,6 +235,8 @@ You should prefer put your declaration of dependency on definitions close to whe
     constType: ConstOutputType[W, A],
   ): ConstExprBuilder[constType.Out, OP]
 
+  final def repeat[I, O](expr: I ~:> O)(implicit opO: OP[IterableOnce[O]]): I ~:> IterableOnce[O] = Expr.Repeat(expr)
+
   // TODO: Is this redundant syntax worth keeping around?
   implicit def inSet[I, A](inputExpr: I ~:> W[A]): InSetExprBuilder[I, A]
 

--- a/core-v1/src/main/scala/dsl/DefaultUnwrappedExprHListImplicits.scala
+++ b/core-v1/src/main/scala/dsl/DefaultUnwrappedExprHListImplicits.scala
@@ -8,6 +8,12 @@ trait DefaultUnwrappedExprHListImplicits
   with DefaultUnwrappedLowPriorityExprHListDslImplicits
   with DefaultUnwrappedDslImplicitDefinitions {
 
+  override implicit final def hlastAlignIterableOnceMapN[H](
+    implicit
+    isCons: IsExprHCons.Aux[IterableOnce[H] :: HNil, IterableOnce[H], HNil],
+  ): ZipToShortest.Aux[Seq, IterableOnce[H] :: HNil, OP, H :: HNil] =
+    defn.hlastAlignIterableOnceMapN
+
   override implicit final def hlastAlignMapN[C[_] : Functor, H](
     implicit
     isCons: IsExprHCons.Aux[C[H] :: HNil, C[H], HNil],
@@ -17,6 +23,13 @@ trait DefaultUnwrappedExprHListImplicits
       defn.hlastAlignMapN[C, H](Functor[C], isCons)
     zts
   }
+
+  override implicit final def hconsAlignIterableOnceMapN[H, WT <: HList](
+    implicit
+    mt: ZipToShortest[Seq, WT, OP],
+    isCons: IsExprHCons.Aux[IterableOnce[H] :: WT, IterableOnce[H], WT],
+  ): ZipToShortest.Aux[Seq, IterableOnce[H] :: WT, OP, H :: mt.UL] =
+    defn.hconsAlignIterableOnceMapN(mt)
 
   override implicit final def hconsAlignMapN[C[_] : Align : FunctorFilter, H, WT <: HList](
     implicit

--- a/core-v1/src/main/scala/dsl/DslTypes.scala
+++ b/core-v1/src/main/scala/dsl/DslTypes.scala
@@ -105,7 +105,7 @@ trait DslTypes extends Any {
   /**
     * An [[ExprHList]] with a fixed [[OP]] type.
     */
-  final type XHL[-I, L <: HList] = ExprHList[I, L, OP]
+  final type XHL[-I, +L <: HList] = ExprHList[I, L, OP]
 
   /**
     * An [[ExprHNil]] with a fixed [[OP]] type.

--- a/core-v1/src/main/scala/dsl/ExprHListDslImplicits.scala
+++ b/core-v1/src/main/scala/dsl/ExprHListDslImplicits.scala
@@ -5,6 +5,8 @@ package dsl
 import cats.{Align, Functor, FunctorFilter}
 import shapeless.{::, HList, HNil}
 
+import scala.collection.Factory
+
 /**
   * A marker trait for determining which set of implicits to inherit.
   *
@@ -27,10 +29,21 @@ sealed trait ExprHListDslImplicits
 trait WrappedExprHListDslImplicits extends ExprHListDslImplicits {
   self: DslTypes with WrappedLowPriorityExprHListDslImplicits =>
 
+  implicit def hlastAlignIterableOnceMapN[H](
+    implicit
+    isCons: IsExprHCons.Aux[IterableOnce[W[H]] :: HNil, IterableOnce[W[H]], HNil],
+  ): ZipToShortest.Aux[Lambda[a => Seq[W[a]]], IterableOnce[W[H]] :: HNil, OP, H :: HNil]
+
   implicit def hlastAlignMapN[C[_] : Functor, H](
     implicit
     isCons: IsExprHCons.Aux[C[W[H]] :: HNil, C[W[H]], HNil],
   ): ZipToShortest.Aux[Lambda[a => C[W[a]]], C[W[H]] :: HNil, OP, H :: HNil]
+
+  implicit def hconsAlignIterableOnceMapN[H, WT <: HList](
+    implicit
+    isCons: IsExprHCons.Aux[IterableOnce[W[H]] :: WT, IterableOnce[W[H]], WT],
+    mt: ZipToShortest[Lambda[a => Seq[W[a]]], WT, OP],
+  ): ZipToShortest.Aux[Lambda[a => Seq[W[a]]], IterableOnce[W[H]] :: WT, OP, H :: mt.UL]
 
   implicit def hconsAlignMapN[C[_] : Align : FunctorFilter, H, WT <: HList](
     implicit
@@ -58,10 +71,21 @@ trait WrappedLowPriorityExprHListDslImplicits {
 trait UnwrappedExprHListDslImplicits extends ExprHListDslImplicits {
   self: DslTypes with UnwrappedLowPriorityExprHListDslImplicits =>
 
+  implicit def hlastAlignIterableOnceMapN[H](
+    implicit
+    isCons: IsExprHCons.Aux[IterableOnce[H] :: HNil, IterableOnce[H], HNil],
+  ): ZipToShortest.Aux[Seq, IterableOnce[H] :: HNil, OP, H :: HNil]
+
   implicit def hlastAlignMapN[C[_] : Functor, H](
     implicit
     isCons: IsExprHCons.Aux[C[H] :: HNil, C[H], HNil],
   ): ZipToShortest.Aux[C, C[H] :: HNil, OP, H :: HNil]
+
+  implicit def hconsAlignIterableOnceMapN[H, WT <: HList](
+    implicit
+    mt: ZipToShortest[Seq, WT, OP],
+    isCons: IsExprHCons.Aux[IterableOnce[H] :: WT, IterableOnce[H], WT],
+  ): ZipToShortest.Aux[Seq, IterableOnce[H] :: WT, OP, H :: mt.UL]
 
   implicit def hconsAlignMapN[C[_] : Align : FunctorFilter, H, WT <: HList](
     implicit

--- a/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
@@ -109,11 +109,24 @@ sealed trait JustifiedExprHListDslImplicits
   with JustifiedLowPriorityExprHListDslImplicits
   with DefinedJustifiedDslImplicitDefinitions {
 
+  override implicit def hlastAlignIterableOnceMapN[H](
+    implicit
+    isCons: IsExprHCons.Aux[IterableOnce[Justified[H]] :: HNil, IterableOnce[Justified[H]], HNil],
+  ): ZipToShortest.Aux[Lambda[a => Seq[Justified[a]]], IterableOnce[Justified[H]] :: HNil, OP, H :: HNil] =
+    defn.hlastAlignIterableOnceMapN
+
   override implicit def hlastAlignMapN[C[_] : Functor, H](
     implicit
     isCons: IsExprHCons.Aux[C[Justified[H]] :: HNil, C[Justified[H]], HNil],
   ): ZipToShortest.Aux[Lambda[a => C[Justified[a]]], C[Justified[H]] :: HNil, OP, H :: HNil] =
     defn.hlastAlignMapN
+
+  override implicit def hconsAlignIterableOnceMapN[H, WT <: HList](
+    implicit
+    isCons: IsExprHCons.Aux[IterableOnce[Justified[H]] :: WT, IterableOnce[Justified[H]], WT],
+    mt: ZipToShortest[Lambda[a => Seq[Justified[a]]], WT, OP],
+  ): ZipToShortest.Aux[Lambda[a => Seq[Justified[a]]], IterableOnce[Justified[H]] :: WT, OP, H :: mt.UL] =
+    defn.hconsAlignIterableOnceMapN(mt)
 
   override implicit def hconsAlignMapN[C[_] : Align : FunctorFilter, H, WT <: HList](
     implicit

--- a/core-v1/src/main/scala/dsl/ZipToShortest.scala
+++ b/core-v1/src/main/scala/dsl/ZipToShortest.scala
@@ -17,7 +17,7 @@ import shapeless.HList
   *
   *     (Any ~:> Seq[String]) :: (I ~:> Seq[Int]) => Any ~:> Seq[String :: Int :: HNil]
   */
-trait ZipToShortest[W[_], WL <: HList, OP[_]] {
+trait ZipToShortest[+W[_], WL <: HList, OP[_]] {
   type UL <: HList
 
   def zipToShortestWith[G[-_, +_] : Arrow, I](
@@ -30,5 +30,5 @@ trait ZipToShortest[W[_], WL <: HList, OP[_]] {
   * Implementations live in the subclasses of [[ExprHListDslImplicits]].
   */
 object ZipToShortest {
-  type Aux[W[_], WL <: HList, OP[_], UL0] = ZipToShortest[W, WL, OP] { type UL = UL0 }
+  type Aux[+W[_], WL <: HList, OP[_], UL0] = ZipToShortest[W, WL, OP] { type UL = UL0 }
 }

--- a/core-v1/src/main/scala/engine/ImmutableCachingEngine.scala
+++ b/core-v1/src/main/scala/engine/ImmutableCachingEngine.scala
@@ -405,6 +405,16 @@ object ImmutableCachingEngine {
       debugging(expr).invokeAndReturn(state((i, inputs), result))
     }
 
+    override def visitRepeat[I, O](
+      expr: Expr.Repeat[I, O, OP],
+    )(implicit
+      opO: OP[IterableOnce[O]],
+    ): I => CachedResult[IterableOnce[O]] = { i =>
+      val input = expr.inputExpr.visit(this)(i)
+      val forever = Iterator.continually(input.value)
+      debugging(expr).invokeAndReturn(state(i, cached(forever)))
+    }
+
     override def visitSelect[I, A, B, O : OP](expr: Expr.Select[I, A, B, O, OP]): I => CachedResult[O] =
       memoize(expr, _) { i =>
         val inputResult = expr.inputExpr.visit(this)(i)

--- a/core-v1/src/main/scala/engine/SimpleEngine.scala
+++ b/core-v1/src/main/scala/engine/SimpleEngine.scala
@@ -228,6 +228,16 @@ object SimpleEngine {
       debugging(expr).invokeAndReturn(state((i, results), finalResult))
     }
 
+    override def visitRepeat[I, O](
+      expr: Expr.Repeat[I, O, OP],
+    )(implicit
+      opO: OP[IterableOnce[O]],
+    ): I => IterableOnce[O] = { i =>
+      val const = expr.inputExpr.visit(this)(i)
+      val forever = Iterator.continually(const)
+      debugging(expr).invokeAndReturn(state(i, forever))
+    }
+
     override def visitSelect[I, A, B, O : OP](expr: Expr.Select[I, A, B, O, OP]): I => O = { i =>
       val a = expr.inputExpr.visit(this)(i)
       val b = expr.lens.get(a)

--- a/core-v1/src/main/scala/engine/SimpleEngine.scala
+++ b/core-v1/src/main/scala/engine/SimpleEngine.scala
@@ -233,14 +233,13 @@ object SimpleEngine {
     )(implicit
       opO: OP[IterableOnce[O]],
     ): I => IterableOnce[O] = { i =>
-      val forever = if (expr.recompute) Iterator.continually {
+      val always = Eval.always {
         expr.inputExpr.visit(this)(i)
-      } else {
-        val const = expr.inputExpr.visit(this)(i)
-        Iterator.continually(const)
       }
-      val iterable = expr.limit.fold(forever)(forever.take)
-      debugging(expr).invokeAndReturn(state(i, iterable))
+      val eval = if (expr.recompute) always else always.memoize
+      val unlimited = Iterator.continually(eval.value)
+      val iterable = expr.limit.fold(unlimited)(unlimited.take)
+      debugging(expr).invokeAndReturn(state((i, eval, expr.limit), iterable))
     }
 
     override def visitSelect[I, A, B, O : OP](expr: Expr.Select[I, A, B, O, OP]): I => O = { i =>

--- a/core-v1/src/main/scala/engine/StandardEngine.scala
+++ b/core-v1/src/main/scala/engine/StandardEngine.scala
@@ -265,6 +265,12 @@ object StandardEngine {
       ExprResult.Or(expr, finalState, results)
     }
 
+    override def visitRepeat[I, O](
+      expr: Expr.Repeat[I, O, OP],
+    )(implicit
+      opO: OP[IterableOnce[O]],
+    ): PO <:< I => ExprResult[PO, I, IterableOnce[O], OP] = ???
+
     override def visitSelect[I, A, B, O : OP](
       expr: Expr.Select[I, A, B, O, OP],
     ): PO <:< I => ExprResult[PO, I, O, OP] = { implicit evPOisI =>

--- a/core-v1/src/test/scala/SimpleJustifiedRepeatSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedRepeatSpec.scala
@@ -1,0 +1,163 @@
+package com.rallyhealth.vapors.v1
+
+import data.{FactTable, Justified}
+import example.FactTypes
+import lens.DataPath
+
+import cats.data.NonEmptySeq
+import munit.FunSuite
+import shapeless.{HNil, Nat}
+
+class SimpleJustifiedRepeatSpec extends FunSuite {
+
+  import dsl.uncached.justified._
+
+  test("repeat[A].take(10)") {
+    // TODO: The following use case should also be supported once .take is supported
+    // repeat(1.const).take(10)
+  }
+
+  test("wrap(repeat[A], Seq[B]).zipToShortest produces a Seq[A :: B :: HNil]") {
+    val ageFacts = valuesOfType(FactTypes.Age)
+    val scoreFacts = valuesOfType(FactTypes.Scores)
+    val expr = wrap(ageFacts, scoreFacts).zipToShortest.flatMap { hl =>
+      val age = hl.get(_.at(Nat._0))
+      val scores = hl.get(_.at(Nat._1))
+      wrap(repeat(age), scores).zipToShortest
+    }
+    val ageFact = FactTypes.Age(30)
+    val scoresFact = FactTypes.Scores(Seq(1.0, 2.0))
+    val facts = FactTable(ageFact, scoresFact)
+    val observed = expr.run(facts)
+    val expected = Vector(
+      Justified.byInference(
+        "map",
+        30 :: 1.0 :: HNil,
+        NonEmptySeq.of(
+          Justified.byInference(
+            "product",
+            (30, 1.0 :: HNil),
+            NonEmptySeq.of(
+              Justified.bySelection(
+                30,
+                DataPath.empty.atKey(0),
+                Justified.ByInference(
+                  "map",
+                  30 :: List(1.0, 2.0) :: HNil,
+                  NonEmptySeq.of(
+                    Justified.byInference(
+                      "product",
+                      (30, List(1.0, 2.0) :: HNil),
+                      NonEmptySeq.of(
+                        Justified.byFact(ageFact),
+                        Justified.byInference(
+                          "map",
+                          List(1.0, 2.0) :: HNil,
+                          NonEmptySeq.of(
+                            Justified.byFact(scoresFact),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Justified.byInference(
+                "map",
+                1.0 :: HNil,
+                NonEmptySeq.of(
+                  Justified.bySelection(
+                    1.0,
+                    DataPath.empty.atKey(1).atIndex(0),
+                    Justified.byInference(
+                      "map",
+                      30 :: List(1.0, 2.0) :: HNil,
+                      NonEmptySeq.of(
+                        Justified.byInference(
+                          "product",
+                          (30, List(1.0, 2.0) :: HNil),
+                          NonEmptySeq.of(
+                            Justified.byFact(ageFact),
+                            Justified
+                              .byInference("map", List(1.0, 2.0) :: HNil, NonEmptySeq.of(Justified.byFact(scoresFact))),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+      Justified.byInference(
+        "map",
+        30 :: 2.0 :: HNil,
+        NonEmptySeq.of(
+          Justified.byInference(
+            "product",
+            (30, 2.0 :: HNil),
+            NonEmptySeq.of(
+              Justified.bySelection(
+                30,
+                DataPath.empty.atKey(0),
+                Justified.byInference(
+                  "map",
+                  30 :: List(1.0, 2.0) :: HNil,
+                  NonEmptySeq.of(
+                    Justified.ByInference(
+                      "product",
+                      (30, List(1.0, 2.0) :: HNil),
+                      NonEmptySeq.of(
+                        Justified.byFact(ageFact),
+                        Justified.byInference(
+                          "map",
+                          List(1.0, 2.0) :: HNil,
+                          NonEmptySeq.of(
+                            Justified.byFact(scoresFact),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Justified.ByInference(
+                "map",
+                2.0 :: HNil,
+                NonEmptySeq.of(
+                  Justified.bySelection(
+                    2.0,
+                    DataPath.empty.atKey(1).atIndex(1),
+                    Justified.byInference(
+                      "map",
+                      30 :: List(1.0, 2.0) :: HNil,
+                      NonEmptySeq.of(
+                        Justified.ByInference(
+                          "product",
+                          (30, List(1.0, 2.0) :: HNil),
+                          NonEmptySeq.of(
+                            Justified.byFact(ageFact),
+                            Justified.byInference(
+                              "map",
+                              List(1.0, 2.0) :: HNil,
+                              NonEmptySeq.of(
+                                Justified.byFact(scoresFact),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+    assertEquals(observed, expected)
+  }
+}

--- a/core-v1/src/test/scala/SimpleJustifiedRepeatSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedRepeatSpec.scala
@@ -23,7 +23,7 @@ class SimpleJustifiedRepeatSpec extends FunSuite {
     val expr = wrap(ageFacts, scoreFacts).zipToShortest.flatMap { hl =>
       val age = hl.get(_.at(Nat._0))
       val scores = hl.get(_.at(Nat._1))
-      wrap(repeat(age), scores).zipToShortest
+      wrap(repeatConstForever(age), scores).zipToShortest
     }
     val ageFact = FactTypes.Age(30)
     val scoresFact = FactTypes.Scores(Seq(1.0, 2.0))

--- a/core-v1/src/test/scala/SimpleRepeatSpec.scala
+++ b/core-v1/src/test/scala/SimpleRepeatSpec.scala
@@ -21,7 +21,7 @@ class SimpleRepeatSpec extends FunSuite {
     val expr = wrap(ageFacts.headOption, scoreFacts.headOption).zipToShortest.map { hl =>
       val age = hl.get(_.at(Nat._0))
       val scores = hl.get(_.at(Nat._1))
-      wrap(repeat(age), scores).zipToShortest
+      wrap(repeatConstForever(age), scores).zipToShortest
     }
     val facts = FactTable(
       FactTypes.Age(30),

--- a/core-v1/src/test/scala/SimpleRepeatSpec.scala
+++ b/core-v1/src/test/scala/SimpleRepeatSpec.scala
@@ -1,0 +1,34 @@
+package com.rallyhealth.vapors.v1
+
+import data.FactTable
+import example.FactTypes
+
+import munit.FunSuite
+import shapeless.{HNil, Nat}
+
+class SimpleRepeatSpec extends FunSuite {
+
+  import dsl.uncached._
+
+  test("repeat[A].take(10)") {
+    // TODO: The following use case should also be supported once .take is supported
+    // repeat(1.const).take(10)
+  }
+
+  test("wrap(repeat[A], Seq[B]).zipToShortest produces a Seq[A :: B :: HNil]") {
+    val ageFacts = valuesOfType(FactTypes.Age)
+    val scoreFacts = valuesOfType(FactTypes.Scores)
+    val expr = wrap(ageFacts.headOption, scoreFacts.headOption).zipToShortest.map { hl =>
+      val age = hl.get(_.at(Nat._0))
+      val scores = hl.get(_.at(Nat._1))
+      wrap(repeat(age), scores).zipToShortest
+    }
+    val facts = FactTable(
+      FactTypes.Age(30),
+      FactTypes.Scores(Seq(1d, 2d)),
+    )
+    val observed = expr.run(facts)
+    val expected = Some(Seq(30 :: 1d :: HNil, 30 :: 2d :: HNil))
+    assertEquals(observed, expected)
+  }
+}

--- a/core-v1/src/test/scala/example/FactTypes.scala
+++ b/core-v1/src/test/scala/example/FactTypes.scala
@@ -15,6 +15,7 @@ object FactTypes extends OrderTimeImplicits {
   final val DateOfBirth = FactType[LocalDate]("date_of_birth")
   final val CombinedTags = FactType[CombinedTags]("combined_tags")
   final val GeoLocation = FactType[GeoLocation]("geolocation")
+  final val Scores = FactType[Seq[Double]]("scores")
   final val WeightLbs = FactType[Double]("weight_lbs")
   final val WeightKg = FactType[Double]("weight_kg")
 }


### PR DESCRIPTION
- Add `Expr.Repeat` to continuously produce the same value indefinitely
- Allow `IterableOnce` for `ExprHList.zipToShortest`
- Use `Seq` for return type of `ZipToShortest` for `IterableOnce`