### PR TITLE
Add Expr.RegexMatches, DSL methods, and unit tests

### DIFF
--- a/core-v1/src/main/scala/data/Justified.scala
+++ b/core-v1/src/main/scala/data/Justified.scala
@@ -3,7 +3,7 @@ package com.rallyhealth.vapors.v1
 package data
 
 import algebra.{EqualComparable, SizeComparable, SizeComparison}
-import dsl.{WrapConst, WrapContained, WrapFact, WrapQuantifier, WrapSelected}
+import dsl.{WrapConst, WrapContained, WrapFact, WrapQuantifier, WrapRegexMatches, WrapSelected}
 import lens.{DataPath, VariantLens}
 import logic.Logic
 import math._
@@ -15,6 +15,7 @@ import cats.{Applicative, Eq, Eval, Foldable, Functor, Order, Semigroupal, Trave
 
 import scala.annotation.nowarn
 import scala.collection.Factory
+import scala.util.matching.Regex
 
 /**
   * Represents a result that contains a tree of justified inputs and operations, as well as the value
@@ -304,6 +305,27 @@ object Justified extends LowPriorityJustifiedImplicits {
     ): Justified[O] = {
       container.withView((_: Any) => VariantLens(path, (_: Any) => element))
     }
+  }
+
+  implicit def wrapRegexMatches[OP[_]]: WrapRegexMatches[Justified, OP] =
+    WrapRegexMatchesJustified.asInstanceOf[WrapRegexMatches[Justified, OP]]
+
+  private final object WrapRegexMatchesJustified extends WrapRegexMatches[Justified, Any] {
+
+    override def wrapMatched[O](
+      in: Justified[String],
+      out: O,
+      pattern: Regex,
+      matches: LazyList[RegexMatch],
+    ): Justified[O] =
+      Justified.byInference(
+        "regex_matches",
+        out,
+        NonEmptySeq.of(
+          in,
+          Justified.byConst(pattern),
+        ),
+      )
   }
 
   implicit def wrapSelected[OP[_]]: WrapSelected[Justified, OP] =

--- a/core-v1/src/main/scala/data/RegexMatch.scala
+++ b/core-v1/src/main/scala/data/RegexMatch.scala
@@ -1,0 +1,35 @@
+package com.rallyhealth.vapors.v1
+
+package data
+
+import scala.util.matching.Regex
+
+/**
+  * Represents the data provided from a regular expression matched within some input string.
+  *
+  * @see [[Regex.Match]]
+  *
+  * @param matched the string that was matched in the original input
+  * @param slice the slice range of the matched string
+  * @param groups a map of group names AND group indexes to their matched strings
+  */
+final case class RegexMatch(
+  matched: String,
+  slice: SliceRange.Absolute,
+  groups: Map[String, String],
+)
+
+object RegexMatch {
+
+  def unapply(m: RegexMatch): Some[(String, Map[String, String])] = Some((m.matched, m.groups))
+  def unapply(m: Regex.Match): Some[(String, Map[String, String])] = unapply(from(m))
+
+  def from(m: Regex.Match): RegexMatch =
+    RegexMatch(
+      m.matched,
+      SliceRange.Absolute(m.start, m.end),
+      (1 to m.groupCount).map(_.toString).zip(m.subgroups).toMap.withDefault { k =>
+        Option(m.group(k)).getOrElse("")
+      },
+    )
+}

--- a/core-v1/src/main/scala/data/SliceRange.scala
+++ b/core-v1/src/main/scala/data/SliceRange.scala
@@ -32,7 +32,7 @@ object SliceRange {
         relativeStart => if (relativeStart < 0) size + relativeStart else relativeStart,
         relativeEnd => if (relativeEnd < 0) size + relativeEnd else relativeEnd,
       )
-      Absolute(this, relative.left.getOrElse(0), relative.right.getOrElse(size) - 1)
+      Absolute(relative.left.getOrElse(0), relative.right.getOrElse(size) - 1, this)
     }
   }
 
@@ -54,14 +54,27 @@ object SliceRange {
     * This could contain the total size as well, but I didn't see a need for it yet.
     */
   final case class Absolute private[SliceRange] (
-    relative: Relative,
     start: Int,
     end: Int,
+    relative: Relative,
   ) {
+
+    def this(
+      start: Int,
+      end: Int,
+    ) = this(start, end, Relative(Ior.Both(start, end)))
 
     val toRange: Range = Range.inclusive(start, end)
 
     def contains(index: Int): Boolean = toRange.contains(index)
+  }
+
+  object Absolute {
+
+    def apply(
+      start: Int,
+      end: Int,
+    ): Absolute = new Absolute(start, end)
   }
 
   final class Syntax(private val num: Int) extends AnyVal {

--- a/core-v1/src/main/scala/debug/DebugArgs.scala
+++ b/core-v1/src/main/scala/debug/DebugArgs.scala
@@ -8,11 +8,11 @@ import lens.VariantLens
 
 import cats.Eval
 import cats.data.{NonEmptySeq, NonEmptyVector}
-import com.rallyhealth.vapors.v1.algebra.Expr.MatchCase
 import izumi.reflect.Tag
-import shapeless.{unexpected, HList}
+import shapeless.HList
 
 import scala.reflect.ClassTag
+import scala.util.matching.Regex
 
 /**
   * A type-level programming trick that enlists the compiler to prove that the [[Debugging]] hook function
@@ -310,6 +310,17 @@ object DebugArgs {
     new DebugArgs[Expr.Match[I, S, B, O, OP], OP] {
       override type In = (I, Option[Int])
       override type Out = Option[O]
+    }
+
+  implicit def debugRegexMatches[
+    I,
+    S,
+    O,
+    OP[_],
+  ]: Aux[Expr.RegexMatches[I, S, O, OP], OP, (I, S, Regex, LazyList[RegexMatch]), O] =
+    new DebugArgs[Expr.RegexMatches[I, S, O, OP], OP] {
+      override type In = (I, S, Regex, LazyList[RegexMatch])
+      override type Out = O
     }
 
   implicit def debugWhen[I, B, O, OP[_]]: Aux[Expr.When[I, B, O, OP], OP, (I, Int), O] =

--- a/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/JustifiedBuildExprDsl.scala
@@ -36,6 +36,8 @@ trait JustifiedBuildExprDsl
 
   override protected implicit final def wrapFact: WrapFact[Justified, OP] = Justified.wrapFact
 
+  override protected implicit final def wrapRegexMatches: WrapRegexMatches[Justified, OP] = Justified.wrapRegexMatches
+
   override protected implicit final def wrapSelected: WrapSelected[Justified, OP] = Justified.wrapSelected
 
   override protected implicit final def wrapQuantifier: WrapQuantifier[Justified, OP] = Justified.wrapQuantifier

--- a/core-v1/src/main/scala/dsl/WrapRegexMatches.scala
+++ b/core-v1/src/main/scala/dsl/WrapRegexMatches.scala
@@ -1,0 +1,33 @@
+package com.rallyhealth.vapors.v1
+
+package dsl
+
+import data.RegexMatch
+
+import shapeless.Id
+
+import scala.util.matching.Regex
+
+trait WrapRegexMatches[W[+_], OP[_]] {
+
+  def wrapMatched[O](
+    in: W[String],
+    out: O,
+    pattern: Regex,
+    matches: LazyList[RegexMatch],
+  ): W[O]
+}
+
+object WrapRegexMatches {
+
+  @inline final def unwrapped[OP[_]]: WrapRegexMatches[Id, OP] = Unwrapped.asInstanceOf[WrapRegexMatches[Id, OP]]
+
+  private final object Unwrapped extends WrapRegexMatches[Id, Any] {
+    override def wrapMatched[O](
+      in: String,
+      out: O,
+      pattern: Regex,
+      matches: LazyList[RegexMatch],
+    ): O = out
+  }
+}

--- a/core-v1/src/main/scala/dsl/WrappedBuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/WrappedBuildExprDsl.scala
@@ -12,6 +12,8 @@ import cats.{FlatMap, Foldable, Functor, Id, Order, Reducible, Traverse}
 import izumi.reflect.Tag
 import shapeless.{Generic, HList, Nat, Typeable}
 
+import scala.util.matching.Regex
+
 trait WrappedBuildExprDsl extends BuildExprDsl {
   self: DslTypes with WrappedExprHListDslImplicits with OutputTypeImplicits =>
 
@@ -22,6 +24,8 @@ trait WrappedBuildExprDsl extends BuildExprDsl {
   protected implicit def wrapQuantifier: WrapQuantifier[W, OP]
 
   protected implicit def wrapFact: WrapFact[W, OP]
+
+  protected implicit def wrapRegexMatches: WrapRegexMatches[W, OP]
 
   protected implicit def wrapSelected: WrapSelected[W, OP]
 
@@ -35,6 +39,10 @@ trait WrappedBuildExprDsl extends BuildExprDsl {
     pow: Power[W[L], W[R]],
   ): CombineHolder[I, W[L], W[L], W[R], W[R], pow.Out, OP] =
     (leftExpr ^ rightExpr)(opR, pow)
+
+  override implicit def str[I](expr: I ~:> W[String]): WrappedStringExprOps[I] = new WrappedStringExprOps(expr)
+
+  class WrappedStringExprOps[-I](inputExpr: I ~:> W[String]) extends StringExprOps(inputExpr)
 
   override def when[I](condExpr: I ~:> W[Boolean]): WrappedWhenBuilder[I] = new WrappedWhenBuilder(condExpr)
 

--- a/core-v1/src/main/scala/engine/ImmutableCachingEngine.scala
+++ b/core-v1/src/main/scala/engine/ImmutableCachingEngine.scala
@@ -440,6 +440,8 @@ object ImmutableCachingEngine {
       debugging(expr).invokeAndReturn(state((i, inputs), result))
     }
 
+    override def visitRegexMatches[I, S, O : OP](expr: Expr.RegexMatches[I, S, O, OP]): I => CachedResult[O] = ???
+
     override def visitRepeat[I, O](
       expr: Expr.Repeat[I, O, OP],
     )(implicit

--- a/core-v1/src/main/scala/engine/StandardEngine.scala
+++ b/core-v1/src/main/scala/engine/StandardEngine.scala
@@ -271,6 +271,10 @@ object StandardEngine {
       ExprResult.Or(expr, finalState, results)
     }
 
+    override def visitRegexMatches[I, S, O : OP](
+      expr: Expr.RegexMatches[I, S, O, OP],
+    ): PO <:< I => ExprResult[PO, I, O, OP] = ???
+
     override def visitRepeat[I, O](
       expr: Expr.Repeat[I, O, OP],
     )(implicit

--- a/core-v1/src/test/scala/SimpleJustifiedRegexMatchesSpec.scala
+++ b/core-v1/src/test/scala/SimpleJustifiedRegexMatchesSpec.scala
@@ -1,0 +1,147 @@
+package com.rallyhealth.vapors.v1
+
+import data.{Justified, RegexMatch, SliceRange}
+import lens.DataPath
+
+import cats.data.NonEmptySeq
+import munit.FunSuite
+
+class SimpleJustifiedRegexMatchesSpec extends FunSuite {
+
+  import dsl.uncached.justified._
+
+  test("matchesRegex returns true with an exact string match") {
+    val exact = "exact"
+    val re = exact.r
+    val expr = exact.const.matchesRegex(re)
+    val obtained = expr.run()
+    val expected = Justified.byInference(
+      "regex_matches",
+      true,
+      NonEmptySeq.of(Justified.byConst(exact), Justified.byConst(re)),
+    )
+    assertEquals(obtained, expected)
+  }
+
+  test("matchesRegex returns false") {
+    val input = "correct"
+    val re = "wrong".r
+    val expr = input.const.matchesRegex(re)
+    val obtained = expr.run()
+    val expected = Justified.byInference(
+      "regex_matches",
+      false,
+      NonEmptySeq.of(Justified.byConst(input), Justified.byConst(re)),
+    )
+    assertEquals(obtained, expected)
+  }
+
+  test("matchesRegex returns true for multiple substrings") {
+    val input = "one match, two match, three match, more"
+    val re = "match".r
+    val expr = input.const.matchesRegex(re)
+    val obtained = expr.run()
+    val expected = Justified.byInference(
+      "regex_matches",
+      true,
+      NonEmptySeq.of(Justified.byConst(input), Justified.byConst(re)),
+    )
+    assertEquals(obtained, expected)
+  }
+
+  test("findFirstMatch returns some exact match") {
+    val exact = "exact"
+    val re = exact.r
+    val expr = exact.const.findFirstMatch(re)
+    val obtained = expr.run()
+    val firstMatch = RegexMatch(exact, SliceRange.Absolute(0, exact.length), Map())
+    val expected = Justified.bySelection(
+      firstMatch,
+      DataPath.empty.atIndex(0),
+      Justified.byInference(
+        "regex_matches",
+        LazyList(firstMatch),
+        NonEmptySeq.of(Justified.byConst(exact), Justified.byConst(re)),
+      ),
+    )
+    assertEquals(obtained, Some(expected))
+  }
+
+  test("findFirstMatch returns multiple matches") {
+    val input = "one match, two match, three match, more"
+    val exact = "match"
+    val re = exact.r
+    val expr = input.const.findFirstMatch(re)
+    val obtained = expr.run()
+    def matchAfter(prefix: String): RegexMatch =
+      RegexMatch(exact, SliceRange.Absolute(prefix.length, prefix.length + exact.length), Map())
+
+    val firstMatch = matchAfter("one ")
+    val expected = Justified.BySelection(
+      firstMatch,
+      DataPath.empty.atIndex(0),
+      Justified.byInference(
+        "regex_matches",
+        LazyList(
+          firstMatch,
+          matchAfter("one match, two "),
+          matchAfter("one match, two match, three "),
+        ),
+        NonEmptySeq.of(Justified.byConst(input), Justified.byConst(re)),
+      ),
+    )
+    assertEquals(obtained, Some(expected))
+  }
+
+  test("findFirstMatch returns none") {
+    val expr = "correct".const.findFirstMatch("wrong".r)
+    val obtained = expr.run()
+    assertEquals(obtained, None)
+  }
+
+  test("findAllMatches returns one exact match") {
+    val exact = "exact"
+    val re = exact.r
+    val expr = exact.const.findAllMatches(re)
+    val obtained = expr.run()
+    val firstMatch = RegexMatch(exact, SliceRange.Absolute(0, exact.length), Map())
+    val expected = Justified.elements(
+      Justified.byInference(
+        "regex_matches",
+        LazyList(firstMatch),
+        NonEmptySeq.of(Justified.byConst(exact), Justified.byConst(re)),
+      ),
+    )
+    assertEquals(obtained, expected)
+  }
+
+  test("findAllMatches returns multiple matches") {
+    val input = "one match, two match, three match, more"
+    val exact = "match"
+    val re = exact.r
+    val expr = input.const.findAllMatches(re)
+    val obtained = expr.run()
+    def matchAfter(prefix: String): RegexMatch =
+      RegexMatch(exact, SliceRange.Absolute(prefix.length, prefix.length + exact.length), Map())
+
+    val firstMatch = matchAfter("one ")
+    val expected = Justified.elements(
+      Justified.byInference(
+        "regex_matches",
+        LazyList(
+          firstMatch,
+          matchAfter("one match, two "),
+          matchAfter("one match, two match, three "),
+        ),
+        NonEmptySeq.of(Justified.byConst(input), Justified.byConst(re)),
+      ),
+    )
+    assertEquals(obtained, expected)
+  }
+
+  test("findAllMatches returns none") {
+    val expr = "correct".const.findAllMatches("wrong".r)
+    val obtained = expr.run()
+    assertEquals(obtained, LazyList())
+  }
+}

--- a/core-v1/src/test/scala/SimpleRegexMatchesSpec.scala
+++ b/core-v1/src/test/scala/SimpleRegexMatchesSpec.scala
@@ -1,0 +1,85 @@
+package com.rallyhealth.vapors.v1
+
+import data.{RegexMatch, SliceRange}
+
+import munit.FunSuite
+
+class SimpleRegexMatchesSpec extends FunSuite {
+
+  import dsl.uncached._
+
+  test("matchesRegex returns true with an exact string match") {
+    val input = "exact"
+    val expr = input.const.matchesRegex(input.r)
+    val obtained = expr.run()
+    assertEquals(obtained, true)
+  }
+
+  test("matchesRegex returns false") {
+    val expr = "correct".const.matchesRegex("wrong".r)
+    val obtained = expr.run()
+    assertEquals(obtained, false)
+  }
+
+  test("matchesRegex returns true for multiple substrings") {
+    val expr = "one match, two match, three match, more".const.matchesRegex("match".r)
+    val obtained = expr.run()
+    assertEquals(obtained, true)
+  }
+
+  test("findFirstMatch returns some exact match") {
+    val exact = "exact"
+    val re = exact.r
+    val expr = exact.const.findFirstMatch(re)
+    val obtained = expr.run()
+    assertEquals(obtained, Some(RegexMatch(exact, SliceRange.Absolute(0, exact.length), Map())))
+  }
+
+  test("findFirstMatch returns multiple matches") {
+    val input = "one match, two match, three match, more"
+    val exact = "match"
+    val re = exact.r
+    val expr = input.const.findFirstMatch(re)
+    val obtained = expr.run()
+    val firstIdx = "one ".length
+    assertEquals(obtained, Some(RegexMatch(exact, SliceRange.Absolute(firstIdx, firstIdx + exact.length), Map())))
+  }
+
+  test("findFirstMatch returns none") {
+    val expr = "correct".const.findFirstMatch("wrong".r)
+    val obtained = expr.run()
+    assertEquals(obtained, None)
+  }
+
+  test("findAllMatches returns some exact match") {
+    val exact = "exact"
+    val re = exact.r
+    val expr = exact.const.findAllMatches(re)
+    val obtained = expr.run()
+    assertEquals(obtained, LazyList(RegexMatch(exact, SliceRange.Absolute(0, exact.length), Map())))
+  }
+
+  test("findAllMatches returns multiple matches") {
+    val input = "one match, two match, three match, more"
+    val exact = "match"
+    val re = exact.r
+    val expr = input.const.findAllMatches(re)
+    val obtained = expr.run()
+    def matchAfter(prefix: String): RegexMatch =
+      RegexMatch(exact, SliceRange.Absolute(prefix.length, prefix.length + exact.length), Map())
+
+    val expected = LazyList(
+      matchAfter("one "),
+      matchAfter("one match, two "),
+      matchAfter("one match, two match, three "),
+    )
+    assertEquals(obtained, expected)
+  }
+
+  test("findAllMatches returns empty") {
+    val expr = "correct".const.findAllMatches("wrong".r)
+    val obtained = expr.run()
+    assertEquals(obtained, LazyList())
+  }
+
+}


### PR DESCRIPTION
- Add Expr.RegexMatches, DSL method, and unit tests
- Add support for .matchesRegex, .findFirstMatch, and .findAllMatches
- Add unit tests for one, multiple, and zero RegexMatches
- Add documentation