### PR TITLE
FactTable label suggestion.

### DIFF
--- a/core-v1/src/main/scala/data/FactTable.scala
+++ b/core-v1/src/main/scala/data/FactTable.scala
@@ -14,7 +14,7 @@ import scala.collection.immutable.SortedMap
   *
   * @note some expressions can update the fact table for sub-expressions.
   */
-final case class FactTable(factsByName: SortedMap[String, FactSet]) extends AnyVal {
+final case class FactTable(factsByName: SortedMap[String, FactSet], label: String = "{no debug label}") {
 
   def add(fact: Fact): FactTable = addAll(FactSet(fact))
 


### PR DESCRIPTION
It would be nice to support a debug label for FactTable, for use in testing output.

For example:

    [info]   systolic
    [info]   - tests systolic_lt_120 is false with FactTable(name=BloodPressureSystolic,unit=mmHg,value=120.0)
    [info]   - tests systolic_lt_120 is true with FactTable(name=BloodPressureSystolic,unit=mmHg,value=110.0)
    [info]   - tests systolic_lt_120 is false with FactTable({empty})
    [info]   - tests systolic_ge_120 is false with FactTable(name=BloodPressureSystolic,unit=mmHg,value=110.0)
    [info]   - tests systolic_ge_120 is true with FactTable(name=BloodPressureSystolic,unit=mmHg,value=120.0)
    [info]   - tests systolic_ge_120 is false with FactTable({empty})

By having a debug label, test output can have more salient details for testing without interfering with the toString() output.

This did change the value class semantics, so I don't know whether there is a hidden performance hit.