### PR TITLE
Convert FactTable and FactTypeSet to interfaces

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,13 @@ repos:
   hooks:
   - id: sbt-scalafmt
     stages: [push]
-
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.2.0
+  hooks:
+    - id: check-yaml
+      args: ['--unsafe']
+    - id: end-of-file-fixer
+    - id: fix-byte-order-marker
+    - id: mixed-line-ending
+    - id: trailing-whitespace
+      args: [--markdown-linebreak-ext=md]

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ _(The slides are a little bit out of date, but the basic ideas are the same)_
     }
     ```
 
-5. **Run your expression with a set of facts.** 
+5. **Run your expression with a set of facts.**
 
     Assuming you have these facts:
 
@@ -341,7 +341,7 @@ assert(isOver18.run(FactTable(LocalDate.of(1990, 1, 1))))
   <td>
     Chain the output the first expression to the input of a second expression to produce the output of the second
     expression. This is the foundation for most of the DSL. Many operations only operate on a certain shape of input
-    and rely on the `andThen` operation to chain the output of a previous expression into the input. 
+    and rely on the `andThen` operation to chain the output of a previous expression into the input.
   </td>
 </tr>
 <tr>
@@ -391,7 +391,7 @@ assert(isOver18.run(FactTable(LocalDate.of(1990, 1, 1))))
   </td>
   <td>
     Adds the given definitions to the <code>FactTable</code> and makes them available to the expression provided in the
-    following block. 
+    following block.
   </td>
 </tr>
 <tr>
@@ -502,7 +502,7 @@ assert(isOver18.run(FactTable(LocalDate.of(1990, 1, 1))))
   <td><code>ident[NonEmptySeq[Int]].filter(_ > 1.const)</code></td>
   <td><code>(_: NonEmptySeq[Int]).filter(_ > 1)</code></td>
   <td>
-    Keeps elements of the given collection for which the filter expression returns true and discards the others. 
+    Keeps elements of the given collection for which the filter expression returns true and discards the others.
   </td>
 </tr>
 <tr>
@@ -600,7 +600,7 @@ assert(isOver18.run(FactTable(LocalDate.of(1990, 1, 1))))
   <td><code>(1 :: "two" :: HNil).const.as[(Int, String)]</code></td>
   <td><code>Generic[(Int, String)].from(1 :: "two" :: HNil)</code></td>
   <td>
-    Converts an <code>HList</code> to any type that can be isomorphically converted using <code>shapeless.Generic</code> 
+    Converts an <code>HList</code> to any type that can be isomorphically converted using <code>shapeless.Generic</code>
   </td>
 </tr>
 <tr>
@@ -899,7 +899,7 @@ In order to convert from an `Expr` into something useful, we must interpret the 
 The main interpreter is the engine provided by your imported DSL. If you are using an unwrapped DSL, then this is
 probably the `SimpleEngine.Visitor` which converts an `Expr[I, O, OP]` into a function `(I, FactTable) => O`.
 
-There is also a `Justified` DSL that uses the same `SimpleEngine`, but it returns a `Justified[O]` instead of just the 
+There is also a `Justified` DSL that uses the same `SimpleEngine`, but it returns a `Justified[O]` instead of just the
 `O`. This allows you to follow the chain of justification for any produced output.
 
 Lastly, there is a `StandardEngine`<sup>†</sup> which interprets the `Expr` as a function that produces an `ExprResult`,
@@ -926,14 +926,14 @@ object VisitExprAsJson {
 }
 
 class VisitExprAsJson[OP[a] <: HasEncoder[a]] extends Expr.Visitor[VisitExprAsJson.G, OP] {
-  
+
   implicit def encodeOutput[O](implicit op: OP[O]): Encoder[O] = op.encoder
-  
+
   override def visitConst[O : OP](expr: Expr.Const[O, OP]): Json = Json.obj(
     "$type" -> expr.name.asJson,
     "value" -> expr.value.asJson,
   )
-  
+
   // ... implement all other visitX methods to produce Json
 }
 ```

--- a/circe-v1/src/test/scala/circe/StandardResultAsJsonWithSourceInfoSpec.scala
+++ b/circe-v1/src/test/scala/circe/StandardResultAsJsonWithSourceInfoSpec.scala
@@ -48,7 +48,7 @@ class StandardResultAsJsonWithSourceInfoSpec extends FunSuite {
           "source": ${thisFileAt(lineOfSecondConst)},
           "expr": "const",
           "output": 2
-        }  
+        }
       }""".spaces2,
     )
   }
@@ -82,7 +82,7 @@ class StandardResultAsJsonWithSourceInfoSpec extends FunSuite {
           "source": ${thisFileAt(lineOfSecondConst)},
           "expr": "const",
           "output": 2
-        }  
+        }
       }""".spaces2,
       )
     }

--- a/core-v1/src/main/scala/dsl/BuildExprDsl.scala
+++ b/core-v1/src/main/scala/dsl/BuildExprDsl.scala
@@ -116,7 +116,7 @@ trait BuildExprDsl
 
   @deprecated(
     """You should use the using().thenReturn(...) DSL method instead.
-    
+
 You should prefer put your declaration of dependency on definitions close to where you actually use them.""",
   )
   final def usingDefinitions[I, O](

--- a/core-v1/src/main/scala/dsl/ConstOutputType.scala
+++ b/core-v1/src/main/scala/dsl/ConstOutputType.scala
@@ -17,7 +17,7 @@ import scala.annotation.implicitNotFound
   */
 @implicitNotFound(
   """Cannot find the appropriate ConstOutputType when attempting to wrap a value of type ${O}.
-     
+
 DSL wrapper type: ${W}
 
 Typically, this means that you are calling .const on an empty collection (with an element type of Nothing).

--- a/core-v1/src/main/scala/dsl/SelectOutputType.scala
+++ b/core-v1/src/main/scala/dsl/SelectOutputType.scala
@@ -20,7 +20,7 @@ import scala.annotation.implicitNotFound
   */
 @implicitNotFound(
   """Cannot find the appropriate SelectOutputType when selecting a value of type ${A} from ${I}.
-     
+
 DSL wrapper type: ${W}
 
 Typically, this means that you are calling .select() and creating a lens to an empty collection (with an element type of Nothing) or a non-Traverse higher-kinded type.

--- a/core-v1/src/main/scala/math/Add.scala
+++ b/core-v1/src/main/scala/math/Add.scala
@@ -7,9 +7,9 @@ import scala.annotation.implicitNotFound
 import scala.concurrent.duration.FiniteDuration
 
 @implicitNotFound("""${L} + ${R} is not supported.
-                     
+
 If these are non-numeric types, try swapping the order of arguments to ${R} + ${L}.
-                     
+
 If you think this operation should be allowed, you can define an implicit Add[${L}, ${R}].""")
 trait Add[L, R] {
   type Out

--- a/core-v1/src/main/scala/math/Divide.scala
+++ b/core-v1/src/main/scala/math/Divide.scala
@@ -5,7 +5,7 @@ package math
 import scala.annotation.implicitNotFound
 
 @implicitNotFound("""${N} / ${D} is not supported.
-                     
+
 If these are non-numeric types, you can try swapping the order of arguments to ${D} / ${N}.
 
 If you think this operation should be allowed, you can define an implicit Divide[${N}, ${D}].""")

--- a/core-v1/src/main/scala/math/Multiply.scala
+++ b/core-v1/src/main/scala/math/Multiply.scala
@@ -5,9 +5,9 @@ package math
 import scala.annotation.implicitNotFound
 
 @implicitNotFound("""${L} * ${R} is not supported.
-                     
+
 If these are non-numeric types, try swapping the order of arguments to ${R} * ${L}.
-                     
+
 If you think this operation should be allowed, you can define an implicit Multiply[${L}, ${R}].""")
 trait Multiply[L, R] {
   type Out

--- a/core-v1/src/main/scala/math/Power.scala
+++ b/core-v1/src/main/scala/math/Power.scala
@@ -5,7 +5,7 @@ package math
 import scala.annotation.implicitNotFound
 
 @implicitNotFound("""${B} ^ ${E} is not supported (aka pow(${B}, ${E})).
-                     
+
 If these are non-numeric types, you can try swapping the order of arguments to ${E} ^ ${B}.
 
 If you think this operation should be allowed, you can define an implicit Power[${B}, ${E}].""")

--- a/core-v1/src/main/scala/math/Subtract.scala
+++ b/core-v1/src/main/scala/math/Subtract.scala
@@ -6,7 +6,7 @@ import java.time.{Duration, Instant, LocalDate, Period}
 import scala.annotation.implicitNotFound
 
 @implicitNotFound("""${L} - ${R} is not supported.
-                     
+
 If these are non-numeric types, try swapping the order of arguments to ${R} - ${L}.
 
 If you think this operation should be allowed, you can define an implicit Subtract[${L}, ${R}].""")


### PR DESCRIPTION
- Add more pre-commit-hooks and run on all files
  - Add EOF check
  - Remove trailing whitespace
- Convert `FactTable` to a universal trait
  - Add `SimpleFactTable` as a simple implementation
- Convert `FactTypeSet` to a universal trait
  - Add `SimpleFactTypeSet` as a simple implementation