### PR TITLE
🐛  Fix MatchError bug with sealed trait -> open trait refactor

### DIFF
--- a/core-v1/src/main/scala/data/Fact.scala
+++ b/core-v1/src/main/scala/data/Fact.scala
@@ -91,10 +91,7 @@ object TypedFact {
     evidence: Evidence,
   ): TypedFact[A] with DerivedFact = DerivedFactOfType(typeInfo, value, evidence)
 
-  def unapply[A](fact: TypedFact[A]): Some[(FactType[A], A)] = fact match {
-    case SourceFactOfType(typeInfo, value) => Some((typeInfo, value))
-    case DerivedFactOfType(typeInfo, value, _) => Some((typeInfo, value))
-  }
+  def unapply[A](fact: TypedFact[A]): Some[(FactType[A], A)] = Some((fact.typeInfo, fact.value))
 
   def orderTypedFactByValue[T]: Order[TypedFact[T]] = { (x, y) =>
     x.typeInfo.order.compare(x.value, y.value)
@@ -113,7 +110,7 @@ object TypedFact {
   *
   * The [[Evidence]] is tracked from the original set of [[Fact]]s based on the expression.
   */
-sealed trait DerivedFact extends Fact {
+trait DerivedFact extends Fact {
   def evidence: Evidence
 }
 
@@ -126,11 +123,8 @@ object DerivedFact {
   ): DerivedFact =
     DerivedFactOfType(typeInfo, value, evidence)
 
-  def unapply(fact: Fact): Option[(FactType[fact.Value], fact.Value, Evidence)] = fact match {
-    case DerivedFactOfType(_, _, evidence) =>
-      Some((fact.typeInfo, fact.value, evidence))
-    case _ => None
-  }
+  def unapply(fact: DerivedFact): Some[(FactType[fact.Value], fact.Value, Evidence)] =
+    Some((fact.typeInfo, fact.value, fact.evidence))
 }
 
 /**

--- a/core-v1/src/test/scala/data/FactSpec.scala
+++ b/core-v1/src/test/scala/data/FactSpec.scala
@@ -1,0 +1,43 @@
+package com.rallyhealth.vapors.v1
+
+package data
+
+import munit.FunSuite
+import example.FactTypes
+
+import java.time.LocalDate
+
+class FactSpec extends FunSuite {
+
+  test("Fact extractor matches CustomFact") {
+    val f = CustomFact(FactTypes.Age, 23)
+    f match {
+      case Fact(tpe, value) =>
+        assert(tpe == f.typeInfo && value == f.value)
+    }
+  }
+
+  test("DerivedFact extractor matches CustomDerivedFact") {
+    val yearsAgo23 = FactTypes.DateOfBirth(LocalDate.now().minusYears(23).withDayOfYear(1))
+    val f = CustomDerivedFact(FactTypes.Age, 23, Evidence(yearsAgo23))
+    f match {
+      case DerivedFact(tpe, value, evidence) =>
+        assert(tpe == f.typeInfo && value == f.value && evidence == f.evidence)
+    }
+  }
+}
+
+final case class CustomFact[T](
+  typeInfo: FactType[T],
+  value: T,
+) extends Fact {
+  override type Value = T
+}
+
+final case class CustomDerivedFact[T](
+  typeInfo: FactType[T],
+  value: T,
+  evidence: Evidence,
+) extends DerivedFact {
+  override type Value = T
+}


### PR DESCRIPTION
## Description

Fixes a bug with a `MatchError` being thrown when using the `Fact` or `DerivedFact` extractors on custom `Fact` subclasses.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
