### PR TITLE
Remove redundent sbt ci-release run after tagging in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,3 @@ jobs:
         run: |
           git tag -am "${{ steps.validate.outputs.version }}" ${{ steps.validate.outputs.version }}
           git push origin ${{ steps.validate.outputs.version }}
-      - uses: olafurpg/setup-scala@v13
-      - run: sbt ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}


### PR DESCRIPTION
## Description

When a tag is pushed to github, it will [automatically run the `sbt ci-release`](https://github.com/jeffmay/vapors/blob/v1/.github/workflows/ci.yml#L119) task to publish the artifacts. Currently, the [`release.yml`](.github/workflows/release.yml) workflow will push a tagged version AND run the `sbt ci-release` task, which then creates a race condition where both jobs are attempting to publish the tagged version.

Fix:
- Remove redundent sbt ci-release run after tagging in release.yml

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
